### PR TITLE
fix: fmt and lint should not process modules in `.terraform` directory

### DIFF
--- a/lint-with-tflint/action.yml
+++ b/lint-with-tflint/action.yml
@@ -82,7 +82,7 @@ runs:
         log-info "looking for terraform modules file at '$(ws-path ${MODULES_FILE})'"
         if [ -f "${MODULES_FILE}" ]; then
           log-info "found it, parsing directories to lint"
-          TFLINT_DIRS=$(jq -cr --arg pwd "$(pwd)/" '[ .Modules[].Dir ] | unique | sort | $pwd + .[]' "${MODULES_FILE}")
+          TFLINT_DIRS=$(jq -cr --arg pwd "$(pwd)/" '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' "${MODULES_FILE}")
         else
           log-info "no modules file found, linting will only be performed in '$(ws-path $(pwd))'"
           TFLINT_DIRS="$(pwd)"

--- a/terraform-fmt/action.yml
+++ b/terraform-fmt/action.yml
@@ -45,7 +45,7 @@ runs:
           TF_FMT_DIRS="${GITHUB_WORKSPACE}"
         elif [ -f "${MODULES_FILE}" ]; then
           log-info "check will run in directories from terraform modules file '$(ws-path ${MODULES_FILE})'"
-          TF_FMT_DIRS=$(jq -cr --arg pwd "$(pwd)/" '[ .Modules[].Dir ] | unique | sort | $pwd + .[]' "${MODULES_FILE}")
+          TF_FMT_DIRS=$(jq -cr --arg pwd "$(pwd)/" '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' "${MODULES_FILE}")
         else
           log-info "check will run in 'project-dir' '$(pwd)'"
           TF_FMT_DIRS="$(pwd)"


### PR DESCRIPTION
# fixes
- fix(terraform-fmt): skip modules in `.terraform` directory
- fix(lint-with-tflint): skip modules in `.terraform` directory