### PR TITLE
Caching and rate limiting

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -240,7 +240,6 @@ jobs:
         with:
           path: ${{ steps.setup-terraform-cache.outputs.plugin-cache-directory }}
           key: "terraform-provider-plugin-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/.terraform.lock.hcl', matrix.vars.project-dir)) }}"
-          restore-keys: "terraform-provider-plugin-cache-${{ runner.os }}-${{ runner.arch }}"
 
       - name: ⚙️ Terraform Init
         id: init

--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -233,6 +233,7 @@ jobs:
         uses: dsb-norge/github-actions-terraform/setup-tflint@v0
         with:
           tflint-version: ${{ matrix.vars.tflint-version }}
+          working-directory: ${{ matrix.vars.project-dir }}
 
       - name: "🚀 Cache Terraform provider plugins"
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'init')

--- a/lint-with-tflint/action.yml
+++ b/lint-with-tflint/action.yml
@@ -12,6 +12,12 @@ inputs:
       If not specified, the action will attempt to locate a config file to use.
     required: false
     default: ""
+  github-token:
+    description: |
+      GitHub token to use for downloading tflint plugins from GitHub during init.
+      See https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+    required: false
+    default: ${{ github.token }}
 runs:
   using: "composite"
   steps:
@@ -69,6 +75,8 @@ runs:
     - id: lint
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         # determine directories to lint in and go
 

--- a/setup-tflint/action.yml
+++ b/setup-tflint/action.yml
@@ -9,12 +9,21 @@ inputs:
       See https://github.com/terraform-linters/tflint/releases
     required: false
     default: latest
+  config-file-path:
+    description: |
+      The path to a TFLint config file to use.
+      If not specified, the action will attempt to locate a config file to use.
+    required: false
+    default: ""
   github-token:
     description: |
       GitHub token to use for downloading tflint plugins from GitHub during init.
       See https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
     required: false
     default: ${{ github.token }}
+  working-directory:
+    description: From what directory to run TFLint, this path is used to locate a TFLint config file.
+    required: true
 outputs:
   installed-version:
     description: Actual version that was installed. can be interesting when using 'latest' as input.
@@ -106,6 +115,42 @@ runs:
         set-output 'install-dir' "${INSTALL_DIR}"
         set-output 'install-bin-path' "${INSTALL_DIR}/tflint"
         set-output 'cache-key' "tflint-binary-${TAG_NAME}-${{ runner.os }}-${{ runner.arch }}"
+    - id: get-config
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        # attempt to locate TFLint config file
+
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+
+        configured_path='${{ inputs.config-file-path }}'
+        possible_paths=(
+          "$(pwd)/.tflint.hcl"
+          "${GITHUB_WORKSPACE}/.tflint.hcl"
+        )
+
+        # allow output to be empty, worst case output of hashfiles in cache key further down will be empty
+        path_to_use=""
+        if [ ! -z "${configured_path}" ]; then
+          log-info "using configured TFLint config file path"
+          if [ -f "${configured_path}" ]; then
+            path_to_use="${configured_path}"
+          elif [ -f "$(pwd)/${configured_path}" ]; then
+            path_to_use="$(pwd)/${configured_path}"
+          else
+            log-warn "the configured path '${configured_path}' does not exist, unable to conform to configuration!"
+          fi
+        else
+          log-info "TFLint config file path was not configured, attempting to locate one ..."
+          for path_to_use in ${possible_paths[*]}; do
+            [ -f "${path_to_use}" ] && break || :
+          done
+          if [ ! -f "${path_to_use}" ]; then
+            log-warn "could not find a TFLint config file to use, unable to conform to configuration!"
+          fi
+        fi
+        log-info "using TFLint config file path '${path_to_use}'"
+        set-output 'config-file' "${path_to_use}"
     # attempt to retrieve tflint binary from GitHub cache
     # note: this will also save the binary to GitHub cache in cases where the binary must be downloaded and installed
     - id: cache-tflint
@@ -113,6 +158,13 @@ runs:
       with:
         path: ${{ steps.get-meta.outputs.install-dir }}
         key: ${{ steps.get-meta.outputs.cache-key }}
+    # attempt to retrieve tflint plugins from GitHub cache
+    # note: this will also save the plugins to GitHub cache in cases where the plugins must be downloaded and installed
+    - id: cache-tflint-plugins
+      uses: actions/cache@v4
+      with:
+        path: "~/.tflint.d/plugins"
+        key: "tflint-plugins-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(steps.get-config.outputs.config-file) }}"
     - id: exists-check
       shell: bash
       env:

--- a/setup-tflint/action.yml
+++ b/setup-tflint/action.yml
@@ -9,6 +9,12 @@ inputs:
       See https://github.com/terraform-linters/tflint/releases
     required: false
     default: latest
+  github-token:
+    description: |
+      GitHub token to use for downloading tflint plugins from GitHub during init.
+      See https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+    required: false
+    default: ${{ github.token }}
 outputs:
   installed-version:
     description: Actual version that was installed. can be interesting when using 'latest' as input.
@@ -32,7 +38,8 @@ runs:
           RELEASE_JSON=$(
             curl -s --request GET \
             --url "${RELEASE_URL}" \
-            --header "Accept: application/json"
+            --header "Accept: application/json" \
+            --header 'authorization: Bearer ${{ inputs.github-token }}'
           )
           #log-json "release json" "${RELEASE_JSON}"
         else
@@ -41,7 +48,8 @@ runs:
           ALL_RELEASES_JSON=$(
             curl -s --request GET \
             --url "${RELEASE_URL}" \
-            --header "Accept: application/json"
+            --header "Accept: application/json" \
+            --header 'authorization: Bearer ${{ inputs.github-token }}'
           )
           # log-multiline "all release json" "${ALL_RELEASES_JSON}"
           RELEASE_JSON=$(echo "$ALL_RELEASES_JSON" | jq 'first(.[] | select(.tag_name == "${{ inputs.tflint-version }}" ) )') || (

--- a/terraform-plan/action.yml
+++ b/terraform-plan/action.yml
@@ -107,7 +107,7 @@ runs:
       continue-on-error: true # allow action to continue, execution status is returned by the last step
     - id: plan-upload
       if: steps.plan.outcome != 'cancelled' && steps.plan.outcome != 'skipped'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.environment-name }}-terraform-plan-console-output
         path: ${{ steps.plan.outputs.tf-plan-console-output-file }}


### PR DESCRIPTION
# changes

- feat: setup-tflint - make github api calls authenticated to prevent rate limiting
- feat: setup-tflint - cache plugins to prevent rate limiting
- fix: workflow: prevent tf provider cache from growing infinitely
- chore: terraform-plan - bump actions/upload-artifact action to node20 - compatible version `v4`