### PR TITLE
Feat/terraform docs

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -187,8 +187,7 @@ jobs:
         uses: actions/checkout@v4
       - name: "🎰 Create env matrix"
         id: create-matrix
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/create-tf-vars-matrix@tf-docs
+        uses: dsb-norge/github-actions-terraform/create-tf-vars-matrix@v0
         with:
           inputs-json: ${{ toJSON(inputs) }}
 
@@ -211,8 +210,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "🎰 Export environment variables and secrets"
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/export-env-vars@tf-docs
+        uses: dsb-norge/github-actions-terraform/export-env-vars@v0
         with:
           extra-envs: ${{ toJSON(matrix.vars.extra-envs) }}
           extra-envs-from-secrets: ${{ toJSON(matrix.vars.extra-envs-from-secrets) }}
@@ -227,14 +225,12 @@ jobs:
 
       - name: "🗄️ Setup Terraform provider plugin cache"
         id: setup-terraform-cache
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@tf-docs
+        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@v0
 
       - name: "📥 Setup TFLint"
         id: setup-tflint
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'lint')
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/setup-tflint@tf-docs
+        uses: dsb-norge/github-actions-terraform/setup-tflint@v0
         with:
           tflint-version: ${{ matrix.vars.tflint-version }}
           working-directory: ${{ matrix.vars.project-dir }}
@@ -249,8 +245,7 @@ jobs:
       - name: ⚙️ Terraform Init
         id: init
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'init')
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-init@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-init@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           additional-dirs-json: ${{ toJSON(matrix.vars.terraform-init-additional-dirs) }}
@@ -260,8 +255,7 @@ jobs:
       - name: 🖌 Terraform Format
         id: fmt
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'format')
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-fmt@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-fmt@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           format-check-in-root-dir: ${{ matrix.vars.format-check-in-root-dir }}
@@ -270,8 +264,7 @@ jobs:
       - name: ✔ Terraform Validate
         id: validate
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'validate')
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-validate@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-validate@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -279,8 +272,7 @@ jobs:
       - name: 🧹 Lint with TFLint
         id: lint
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'lint')
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/lint-with-tflint@tf-docs
+        uses: dsb-norge/github-actions-terraform/lint-with-tflint@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -288,8 +280,7 @@ jobs:
       - name: 📖 Terraform Plan
         id: plan
         if: steps.init.outcome == 'success' && ( contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'plan') )
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-plan@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-plan@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: ${{ matrix.vars.github-environment }}
@@ -298,8 +289,7 @@ jobs:
       - name: 📝 Create validation summary
         id: create-validation-summary
         if: github.event_name == 'pull_request' && matrix.vars.add-pr-comment == 'true'
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/create-validation-summary@tf-docs
+        uses: dsb-norge/github-actions-terraform/create-validation-summary@v0
         with:
           environment-name: ${{ matrix.vars.github-environment }}
           plan-txt-output-file: ${{ steps.plan.outputs.txt-output-file }}
@@ -387,8 +377,7 @@ jobs:
               && github.event_name == 'pull_request'
               && github.base_ref == matrix.vars.caller-repo-default-branch
           ) )
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-apply@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-apply@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.plan.outputs.terraform-plan-file }}
@@ -400,8 +389,7 @@ jobs:
         if: |
           steps.init.outcome == 'success'
           && contains(matrix.vars.goals, 'destroy-plan')
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-plan@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-plan@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: "${{ matrix.vars.github-environment }}-destroy"
@@ -428,8 +416,7 @@ jobs:
               && github.event_name == 'pull_request'
               && github.base_ref == matrix.vars.caller-repo-default-branch
           ) )
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-apply@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-apply@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.destroy-plan.outputs.terraform-plan-file }}

--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -187,7 +187,8 @@ jobs:
         uses: actions/checkout@v4
       - name: "🎰 Create env matrix"
         id: create-matrix
-        uses: dsb-norge/github-actions-terraform/create-tf-vars-matrix@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-tf-vars-matrix@tf-docs
         with:
           inputs-json: ${{ toJSON(inputs) }}
 
@@ -210,7 +211,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "🎰 Export environment variables and secrets"
-        uses: dsb-norge/github-actions-terraform/export-env-vars@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/export-env-vars@tf-docs
         with:
           extra-envs: ${{ toJSON(matrix.vars.extra-envs) }}
           extra-envs-from-secrets: ${{ toJSON(matrix.vars.extra-envs-from-secrets) }}
@@ -225,12 +227,14 @@ jobs:
 
       - name: "🗄️ Setup Terraform provider plugin cache"
         id: setup-terraform-cache
-        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@tf-docs
 
       - name: "📥 Setup TFLint"
         id: setup-tflint
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'lint')
-        uses: dsb-norge/github-actions-terraform/setup-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-tflint@tf-docs
         with:
           tflint-version: ${{ matrix.vars.tflint-version }}
           working-directory: ${{ matrix.vars.project-dir }}
@@ -245,7 +249,8 @@ jobs:
       - name: ⚙️ Terraform Init
         id: init
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'init')
-        uses: dsb-norge/github-actions-terraform/terraform-init@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-init@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           additional-dirs-json: ${{ toJSON(matrix.vars.terraform-init-additional-dirs) }}
@@ -255,7 +260,8 @@ jobs:
       - name: 🖌 Terraform Format
         id: fmt
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'format')
-        uses: dsb-norge/github-actions-terraform/terraform-fmt@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-fmt@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           format-check-in-root-dir: ${{ matrix.vars.format-check-in-root-dir }}
@@ -264,7 +270,8 @@ jobs:
       - name: ✔ Terraform Validate
         id: validate
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'validate')
-        uses: dsb-norge/github-actions-terraform/terraform-validate@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-validate@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -272,7 +279,8 @@ jobs:
       - name: 🧹 Lint with TFLint
         id: lint
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'lint')
-        uses: dsb-norge/github-actions-terraform/lint-with-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/lint-with-tflint@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -280,7 +288,8 @@ jobs:
       - name: 📖 Terraform Plan
         id: plan
         if: steps.init.outcome == 'success' && ( contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'plan') )
-        uses: dsb-norge/github-actions-terraform/terraform-plan@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-plan@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: ${{ matrix.vars.github-environment }}
@@ -289,7 +298,8 @@ jobs:
       - name: 📝 Create validation summary
         id: create-validation-summary
         if: github.event_name == 'pull_request' && matrix.vars.add-pr-comment == 'true'
-        uses: dsb-norge/github-actions-terraform/create-validation-summary@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-validation-summary@tf-docs
         with:
           environment-name: ${{ matrix.vars.github-environment }}
           plan-txt-output-file: ${{ steps.plan.outputs.txt-output-file }}
@@ -377,7 +387,8 @@ jobs:
               && github.event_name == 'pull_request'
               && github.base_ref == matrix.vars.caller-repo-default-branch
           ) )
-        uses: dsb-norge/github-actions-terraform/terraform-apply@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-apply@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.plan.outputs.terraform-plan-file }}
@@ -389,7 +400,8 @@ jobs:
         if: |
           steps.init.outcome == 'success'
           && contains(matrix.vars.goals, 'destroy-plan')
-        uses: dsb-norge/github-actions-terraform/terraform-plan@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-plan@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: "${{ matrix.vars.github-environment }}-destroy"
@@ -416,7 +428,8 @@ jobs:
               && github.event_name == 'pull_request'
               && github.base_ref == matrix.vars.caller-repo-default-branch
           ) )
-        uses: dsb-norge/github-actions-terraform/terraform-apply@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-apply@tf-docs
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.destroy-plan.outputs.terraform-plan-file }}

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -262,17 +262,26 @@ jobs:
   generate-docs:
     name: Update README.md
     needs: terraform-module-ci
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, dsb-terraformer, linux, x64]
     if: github.job.terraform-module-ci.result == 'success'
     steps:
       - name: "📥 Checkout"
         uses: actions/checkout@v4
 
       - name: "📝 Validate and update README.md"
+        id: update-readme
         uses: dsb-norge/github-actions-terraform/terraform-docs@v0
         with:
           readme-file-path: ${{ inputs.readme-file-path }}
         continue-on-error: true
+
+      - name: "🧐 Validation outcome: 📝 Update docs"
+        run: |
+          if [ ! "${{ steps.update-readme.outcome }}" == 'success' ]; then
+            echo "::error title=Update README.md failed::Outcome of update README.md step was '${{ steps.update-readme.outcome }}'!"
+            exit 1
+          fi
+        continue-on-error: false
 
 
     # create a global result indicating if workflow steps succeeded or not,

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -262,7 +262,7 @@ jobs:
   generate-docs:
     name: Update README.md
     needs: terraform-module-ci
-    runs-on: [self-hosted, dsb-terraformer, linux, x64]
+    runs-on: ubuntu-latest
     if: github.job.terraform-module-ci.result == 'success'
     steps:
       - name: "📥 Checkout"

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -34,7 +34,7 @@ on:
         description: |
           "README.md file path to inject terraform docs into. Default is the root of the repository."
         type : string
-        default: "${{ github.workspace }}"
+        default: ${{ github.workspace }}
 
 env:
   ARM_TENANT_ID: ${{ secrets.REPO_AZURE_DSB_TENANT_ID }}

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -34,7 +34,7 @@ on:
         description: |
           "README.md file path to inject terraform docs into. Default is the root of the repository."
         type : string
-        default: ${{ github.workspace }}
+        default: "."
 
 env:
   ARM_TENANT_ID: ${{ secrets.REPO_AZURE_DSB_TENANT_ID }}
@@ -277,6 +277,8 @@ jobs:
     steps:
       - name: "📥 Checkout"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: "📝 Validate and update README.md"
         id: update-readme

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -64,8 +64,7 @@ jobs:
 
       - name: "🎰 Create env matrix"
         id: create-matrix
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/create-tftest-matrix@tf-docs
+        uses: dsb-norge/github-actions-terraform/create-tftest-matrix@v0
 
       - name: "📥 Setup Terraform"
         uses: hashicorp/setup-terraform@v3
@@ -76,13 +75,11 @@ jobs:
 
       - name: "🗄️ Setup Terraform provider plugin cache"
         id: setup-terraform-cache
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@tf-docs
+        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@v0
 
       - name: "📥 Setup TFLint"
         id: setup-tflint
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/setup-tflint@tf-docs
+        uses: dsb-norge/github-actions-terraform/setup-tflint@v0
         with:
           tflint-version: ${{ inputs.tflint-version }}
           working-directory: ${{ github.workspace }}
@@ -95,8 +92,7 @@ jobs:
 
       - name: ⚙️ Terraform Init
         id: init
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-init@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-init@v0
         with:
           working-directory: ${{ github.workspace }}
           additional-dirs-json: null
@@ -105,8 +101,7 @@ jobs:
 
       - name: 🖌 Terraform Format
         id: fmt
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-fmt@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-fmt@v0
         with:
           working-directory: ${{ github.workspace }}
           format-check-in-root-dir: true
@@ -114,16 +109,14 @@ jobs:
     
       - name: ✔ Terraform Validate
         id: validate
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-validate@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-validate@v0
         with:
           working-directory: ${{ github.workspace }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: 🧹 Lint with TFLint
         id: lint
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/lint-with-tflint@tf-docs
+        uses: dsb-norge/github-actions-terraform/lint-with-tflint@v0
         with:
           working-directory: ${{ github.workspace }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -131,8 +124,7 @@ jobs:
       - name: 📝 Create validation summary
         id: create-validation-summary
         if: github.event_name == 'pull_request'
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/create-validation-summary@tf-docs
+        uses: dsb-norge/github-actions-terraform/create-validation-summary@v0
         with:
           environment-name: "module"
           plan-txt-output-file: ""
@@ -211,8 +203,7 @@ jobs:
     
       - name: ⚙️ Terraform Init
         id: init
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-init@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-init@v0
         with:
           working-directory: ${{ github.workspace }}
           additional-dirs-json: null
@@ -221,8 +212,7 @@ jobs:
 
       - name: 🧪 Terraform Test
         id: test
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-test@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-test@v0
         with:
           test-file: ${{ matrix.test-file }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -230,8 +220,7 @@ jobs:
       - name: 📝 Create test report
         id: create-test-report
         if: github.event_name == 'pull_request'
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/create-test-report@tf-docs
+        uses: dsb-norge/github-actions-terraform/create-test-report@v0
         with:
           test-out-file: ${{ steps.test.outputs.json }}
           status-init: ${{ steps.init.outcome }}
@@ -282,8 +271,7 @@ jobs:
 
       - name: "📝 Validate and update README.md"
         id: update-readme
-        # TODO revert to @v0
-        uses: dsb-norge/github-actions-terraform/terraform-docs@tf-docs
+        uses: dsb-norge/github-actions-terraform/terraform-docs@v0
         with:
           readme-file-path: ${{ inputs.readme-file-path }}
         continue-on-error: true

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -65,7 +65,8 @@ jobs:
 
       - name: "🎰 Create env matrix"
         id: create-matrix
-        uses: dsb-norge/github-actions-terraform/create-tftest-matrix@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-tftest-matrix@tf-docs
 
       - name: "📥 Setup Terraform"
         uses: hashicorp/setup-terraform@v3
@@ -76,11 +77,13 @@ jobs:
 
       - name: "🗄️ Setup Terraform provider plugin cache"
         id: setup-terraform-cache
-        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@tf-docs
 
       - name: "📥 Setup TFLint"
         id: setup-tflint
-        uses: dsb-norge/github-actions-terraform/setup-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-tflint@tf-docs
         with:
           tflint-version: ${{ inputs.tflint-version }}
           working-directory: ${{ github.workspace }}
@@ -93,7 +96,8 @@ jobs:
 
       - name: ⚙️ Terraform Init
         id: init
-        uses: dsb-norge/github-actions-terraform/terraform-init@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-init@tf-docs
         with:
           working-directory: ${{ github.workspace }}
           additional-dirs-json: null
@@ -102,7 +106,8 @@ jobs:
 
       - name: 🖌 Terraform Format
         id: fmt
-        uses: dsb-norge/github-actions-terraform/terraform-fmt@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-fmt@tf-docs
         with:
           working-directory: ${{ github.workspace }}
           format-check-in-root-dir: true
@@ -110,14 +115,16 @@ jobs:
     
       - name: ✔ Terraform Validate
         id: validate
-        uses: dsb-norge/github-actions-terraform/terraform-validate@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-validate@tf-docs
         with:
           working-directory: ${{ github.workspace }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: 🧹 Lint with TFLint
         id: lint
-        uses: dsb-norge/github-actions-terraform/lint-with-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/lint-with-tflint@tf-docs
         with:
           working-directory: ${{ github.workspace }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -125,7 +132,8 @@ jobs:
       - name: 📝 Create validation summary
         id: create-validation-summary
         if: github.event_name == 'pull_request'
-        uses: dsb-norge/github-actions-terraform/create-validation-summary@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-validation-summary@tf-docs
         with:
           environment-name: "module"
           plan-txt-output-file: ""
@@ -204,7 +212,8 @@ jobs:
     
       - name: ⚙️ Terraform Init
         id: init
-        uses: dsb-norge/github-actions-terraform/terraform-init@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-init@tf-docs
         with:
           working-directory: ${{ github.workspace }}
           additional-dirs-json: null
@@ -213,7 +222,8 @@ jobs:
 
       - name: 🧪 Terraform Test
         id: test
-        uses: dsb-norge/github-actions-terraform/terraform-test@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-test@tf-docs
         with:
           test-file: ${{ matrix.test-file }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -221,7 +231,8 @@ jobs:
       - name: 📝 Create test report
         id: create-test-report
         if: github.event_name == 'pull_request'
-        uses: dsb-norge/github-actions-terraform/create-test-report@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-test-report@tf-docs
         with:
           test-out-file: ${{ steps.test.outputs.json }}
           status-init: ${{ steps.init.outcome }}
@@ -270,7 +281,8 @@ jobs:
 
       - name: "📝 Validate and update README.md"
         id: update-readme
-        uses: dsb-norge/github-actions-terraform/terraform-docs@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-docs@tf-docs
         with:
           readme-file-path: ${{ inputs.readme-file-path }}
         continue-on-error: true

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -33,7 +33,6 @@ on:
       readme-file-path:
         description: |
           "README.md file path to inject terraform docs into. Default is the root of the repository."
-        required: true
         type : string
         default: "${{ github.workspace }}"
 

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -273,7 +273,7 @@ jobs:
     name: Update README.md
     needs: terraform-module-ci
     runs-on: ubuntu-latest
-    if: github.job.terraform-module-ci.result == 'success'
+    if: needs.terraform-module-ci.result == 'success'
     steps:
       - name: "📥 Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -30,6 +30,12 @@ on:
         description: "TFLint version to use for the tests."
         required: true
         type : string
+      readme-file-path:
+        description: |
+          "README.md file path to inject terraform docs into. Default is the root of the repository."
+        required: true
+        type : string
+        default: "${{ github.workspace }}"
 
 env:
   ARM_TENANT_ID: ${{ secrets.REPO_AZURE_DSB_TENANT_ID }}
@@ -167,7 +173,6 @@ jobs:
             exit 1
           fi
         continue-on-error: false
-      
 
   terraform-module-ci:
     name: "Terraform Test"
@@ -254,12 +259,28 @@ jobs:
           fi
         continue-on-error: false
 
+  generate-docs:
+    name: Update README.md
+    needs: terraform-module-ci
+    runs-on: ubuntu-latest
+    if: github.job.terraform-module-ci.result == 'success'
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v4
+
+      - name: "📝 Validate and update README.md"
+        uses: dsb-norge/github-actions-terraform/terraform-docs@v0
+        with:
+          readme-file-path: ${{ inputs.readme-file-path }}
+        continue-on-error: true
+
+
     # create a global result indicating if workflow steps succeeded or not,
     # handy for branch protection rules
   conclusion:
     if: always()
     name: "Terraform conclusion"
-    needs: [create-matrix, terraform-module-ci]
+    needs: [create-matrix, terraform-module-ci, generate-docs]
     runs-on: ubuntu-latest # no need to schedule this on our own runners
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ on:
 
 jobs:
   tf:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout
@@ -130,7 +131,8 @@ Example of how to add terraform CI/CD with default operations to a github repo c
 # snip, 'name:' and 'on:' fields removed
 jobs:
   tf:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout
@@ -153,7 +155,8 @@ jobs:
 
   # you can achieve passwordless auth to Azure
   tf-1:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       id-token: write # required for Azure password-less auth
@@ -180,7 +183,8 @@ jobs:
 
   # hardcoded versions and modify what steps are executed
   tf-2:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ on:
 
 jobs:
   tf:
-    # TODO revert to @v0
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout
@@ -131,8 +130,7 @@ Example of how to add terraform CI/CD with default operations to a github repo c
 # snip, 'name:' and 'on:' fields removed
 jobs:
   tf:
-    # TODO revert to @v0
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout
@@ -155,8 +153,7 @@ jobs:
 
   # you can achieve passwordless auth to Azure
   tf-1:
-    # TODO revert to @v0
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       id-token: write # required for Azure password-less auth
@@ -183,8 +180,7 @@ jobs:
 
   # hardcoded versions and modify what steps are executed
   tf-2:
-    # TODO revert to @v0
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ on:
 
 jobs:
   tf:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout
@@ -130,7 +131,8 @@ Example of how to add terraform CI/CD with default operations to a github repo c
 # snip, 'name:' and 'on:' fields removed
 jobs:
   tf:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout
@@ -153,7 +155,8 @@ jobs:
 
   # you can achieve passwordless auth to Azure
   tf-1:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       id-token: write # required for Azure password-less auth
@@ -180,7 +183,8 @@ jobs:
 
   # hardcoded versions and modify what steps are executed
   tf-2:
-    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@v0
+    # TODO revert to @v0
+    uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@tf-docs
     secrets: inherit # pass all secrets, ok since we trust our own workflow
     permissions:
       contents: read # required for actions/checkout
@@ -208,7 +212,7 @@ jobs:
 ```text
    permissions:
      id-token: write       # Required for Azure password-less authentication
-     contents: read        # Required for actions/checkout
+     contents: write        # Required for actions/checkout and to update readme by PR.
      pull-requests: write  # Required for commenting on PRs
 ```
 
@@ -216,6 +220,7 @@ jobs:
 
 - terraform-version: The version of Terraform to use for the tests (required).
 - tflint-version: The version of tflint (required)
+- readme-file-path: path to README.md file. By default repo root used.
 
 #### Secrets
 
@@ -259,7 +264,13 @@ Jobs:
       - Add validation summary as pull request comment
       - Validate outcomes of init and test
 
- 3. conclusion:
+ 3. generate-docs:
+    - Steps:
+      - Checkout working branch
+      - Terraform-docs
+      - Validate outcome of terraform-docs
+
+ 4. conclusion:
     - Steps:
       - Exit with status 1 if any of the previous jobs failed or were cancelled
 
@@ -289,6 +300,7 @@ jobs:
     with:
       terraform-version: "1.9.x"
       tflint-version: "v0.53.0"
+      readme-file-path: '.'
 ```
 
 ## Maintenance

--- a/terraform-docs/action.yaml
+++ b/terraform-docs/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: |
       "README.md file path to inject terraform docs into. Default is the root of the repository.
       Path consider default name of README.md.
-      If README.md is in repo root then use ```${{ github-workspace }}``` as path."
+      If README.md is in repo root then use github-workspace as path."
 
 runs:
   using: "composite"

--- a/terraform-docs/action.yaml
+++ b/terraform-docs/action.yaml
@@ -1,0 +1,60 @@
+name: "Run terraform docs"
+description: "Inject terraform docs for modules into README.md"
+author: "Artjoms Laivins"
+
+inputs:
+  readme-file-path:
+    description: |
+      "README.md file path to inject terraform docs into. Default is the root of the repository.
+      Path consider default name of README.md.
+      If README.md is in repo root then use ```${{ github-workspace }}``` as path."
+
+runs:
+  using: "composite"
+  steps:
+    - id: validate-readme
+      shell: bash
+      run: |
+        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
+        # enable debug
+        # set -x
+
+        README_FILE="${{ inputs.readme-file-path }}/README.md"
+
+        if [ -f "${README_FILE}" ]; then
+            log-info "Checking if delimiters exist in ${README_FILE}"
+            if grep -q '<!-- BEGIN_TF_DOCS -->' "${README_FILE}" && grep -q '<!-- END_TF_DOCS -->' "${README_FILE}" ; then
+                log-info "Delimiters exist in ${README_FILE}"
+                log-info "Checking if delimiters are in the correct order"
+                START_LINE=$(grep -n '<!-- BEGIN_TF_DOCS -->' "${README_FILE}" | cut -d: -f1)
+                log-info "BEGIN_TF_DOCS found on line: $START_LINE"
+                END_LINE=$(grep -n '<!-- END_TF_DOCS -->' "${README_FILE}" | cut -d: -f1)
+                log-info "END_TF_DOCS found on line: $END_LINE"
+                if [ "$START_LINE" -lt "$END_LINE" ]; then
+                    log-info "Delimiters are in the correct order"
+                else
+                    log-error "Delimiters are not in the correct order, verify ${README_FILE}"
+                fi
+            else
+                log-info "Delimiters do not exist in ${README_FILE}"
+                log-info "Adding delimiters to ${README_FILE}"
+                printf "\nBelow is a placeholder for Terraform-docs generated documentation. Do not edit between the delimiters." >> "${README_FILE}"
+                {
+                    echo "<!-- BEGIN_TF_DOCS -->"
+                    echo " "
+                    echo "<!-- END_TF_DOCS -->"
+                } >> "${README_FILE}"
+                log-info "Delimiters added to ${README_FILE}"
+            fi
+
+        else
+            log-info "File ${README_FILE} does not exist. Terraform-docs will create new README.md file."
+        fi
+      continue-on-error: true
+    - id: run-terraform-docs
+      uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25
+      with:
+        working-dir: ${{ inputs.readme-file-path }}
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/terraform-docs/action.yaml
+++ b/terraform-docs/action.yaml
@@ -34,6 +34,7 @@ runs:
                     log-info "Delimiters are in the correct order"
                 else
                     log-error "Delimiters are not in the correct order, verify ${README_FILE}"
+                    exit 1
                 fi
             else
                 log-info "Delimiters do not exist in ${README_FILE}"
@@ -52,9 +53,15 @@ runs:
         fi
       continue-on-error: true
     - id: run-terraform-docs
+      if: steps.validate-readme.outcome == 'success'
       uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25
       with:
         working-dir: ${{ inputs.readme-file-path }}
         output-file: README.md
         output-method: inject
         git-push: "true"
+
+    - id: tf-docs-status
+      if: ( steps.validate-readme.outcome == 'failure' || steps.validate-readme.outcome == 'cancelled' )
+      shell: bash
+      run: exit 1

--- a/terraform-docs/action.yaml
+++ b/terraform-docs/action.yaml
@@ -16,8 +16,6 @@ runs:
       shell: bash
       run: |
         set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-        # enable debug
-        # set -x
 
         README_FILE="${{ inputs.readme-file-path }}/README.md"
 
@@ -39,7 +37,7 @@ runs:
             else
                 log-info "Delimiters do not exist in ${README_FILE}"
                 log-info "Adding delimiters to ${README_FILE}"
-                printf "\nBelow is a placeholder for Terraform-docs generated documentation. Do not edit between the delimiters." >> "${README_FILE}"
+                printf "\nBelow is a placeholder for Terraform-docs generated documentation. Do not edit between the delimiters.\n" >> "${README_FILE}"
                 {
                     echo "<!-- BEGIN_TF_DOCS -->"
                     echo " "

--- a/terraform-docs/helpers.sh
+++ b/terraform-docs/helpers.sh
@@ -1,0 +1,40 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name="$(basename "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)")"
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+function set-output { echo "${1}=${2}" >>$GITHUB_OUTPUT; }
+function set-multiline-output {
+  local outputName outputValue delimiter
+  outputName="${1}"
+  outputValue="${2}"
+  delimiter=$(echo $RANDOM | md5sum | head -c 20)
+  echo "${outputName}<<\"${delimiter}\"" >>$GITHUB_OUTPUT
+  echo "${outputValue}" >>$GITHUB_OUTPUT
+  echo "\"${delimiter}\"" >>$GITHUB_OUTPUT
+}
+function ws-path {
+  local inPath
+  inPath="${1}"
+  realpath --relative-to="${GITHUB_WORKSPACE}" "${inPath}"
+}
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."
+
+if [ -f "${GITHUB_ACTION_PATH}/helpers_additional.sh" ]; then
+  source "${GITHUB_ACTION_PATH}/helpers_additional.sh"
+fi


### PR DESCRIPTION
feat: terraform doc gen action based on terraform docs, with pinned hard version.  Action does following steps: 
* Checks if README.md exists. 
* If it does - action validate if delimiters are added and placed correctly  ( BEGIN should go before END).  
* If delimiters found but placed in wrong order action will fail. 
* If no delimiters found in existing README - they will be added at the end of file with info comment. 
* If no README.md found - doc action will generate new one and commit to PR. 

Action runs on Github own runner  so we don't need run 3rd part pinned version on own hosted runners ( Kind of security measure )  