### PR TITLE
fix: handle output-only changes in plan parser

### DIFF
--- a/parse-terraform-plan/run_all_tests.sh
+++ b/parse-terraform-plan/run_all_tests.sh
@@ -136,13 +136,19 @@ export input_plan_console_file="${_this_script_dir}/test-data/plan_1_change.log"
 run_test "0 add, 1 change, 0 destroy" \
   "0" "0" "1" "0" "0" "0"
 
-# Test 5: Empty input (no file specified)
+# Test 5: Output-only changes (no resource changes)
+export input_plan_console_file="${_this_script_dir}/test-data/plan_output_only_changes.log"
+#                   imports adds changes destroys moves removes
+run_test "Output-only changes (no resource changes)" \
+  "0" "0" "0" "0" "0" "0"
+
+# Test 6: Empty input (no file specified)
 export input_plan_console_file=""
 #                   imports adds changes destroys moves removes
 run_test "Empty input file path yields fallback values" \
   "?" "?" "?" "?" "?" "?"
 
-# Test 6: Non-existent file (empty file = file exists but is empty)
+# Test 7: Non-existent file (empty file = file exists but is empty)
 _empty_file=$(mktemp)
 export input_plan_console_file="${_empty_file}"
 #                   imports adds changes destroys moves removes

--- a/parse-terraform-plan/step_parse_plan_output.sh
+++ b/parse-terraform-plan/step_parse_plan_output.sh
@@ -35,8 +35,16 @@ function main {
 
     if [ -s "${input_plan_console_file}" ]; then
 
-      # Parse the Plan: line or detect "No changes."
+      # Parse the Plan: line or detect "No changes." / output-only changes
       if grep -q "No changes." "${input_plan_console_file}"; then
+        imports=0
+        adds=0
+        changes=0
+        destroys=0
+      elif grep -q "without changing any real infrastructure" "${input_plan_console_file}"; then
+        # Output-only changes: Terraform reports changes to outputs but no resource changes.
+        # There is no "Plan:" summary line in this case.
+        log-info "detected output-only changes (no resource changes)"
         imports=0
         adds=0
         changes=0

--- a/parse-terraform-plan/test-data/plan_output_only_changes.log
+++ b/parse-terraform-plan/test-data/plan_output_only_changes.log
@@ -1,0 +1,12 @@
+data.github_repositories.all: Reading...
+data.github_repositories.all: Read complete after 1s
+
+Changes to Outputs:
+  ~ repos_not_in_iac = [
+        # (4 unchanged elements hidden)
+        "some-existing-repo",
+      + "some-new-repo",
+    ]
+
+You can apply this plan to save these new output values to the Terraform
+state, without changing any real infrastructure.


### PR DESCRIPTION
## Problem

When a Terraform plan contains only output value changes (no resource additions, modifications, or deletions), the `parse-terraform-plan` action fails with exit code 1. This causes the "Plan Details" row (showing add/change/destroy counts) to be missing from the PR validation summary comment.

## Root Cause

The plan parser has two detection branches:
1. Look for `"No changes."` — not present when outputs change
2. Look for `"Plan: "` — Terraform doesn't emit this summary line when only outputs change

In the output-only case, neither branch matches. The unguarded `grep "Plan: "` returns exit code 1, which under `set -e` crashes the step. Since the workflow gates the Plan Details row on `steps.parse-plan.outcome == 'success'`, the row is silently omitted.

Terraform's console output for this case looks like:

```
Changes to Outputs:
  ~ some_output = [...]

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.
```

## Fix

Added a third detection branch that matches the phrase `"without changing any real infrastructure"`, which Terraform consistently uses for output-only change plans. When detected, all resource counts are correctly set to 0.

## Changes

- **`parse-terraform-plan/step_parse_plan_output.sh`** — Added `elif` branch to detect output-only changes
- **`parse-terraform-plan/test-data/plan_output_only_changes.log`** — New test data file for this scenario
- **`parse-terraform-plan/run_all_tests.sh`** — Added test case (Test 5), renumbered existing tests 5-6 → 6-7