### PR TITLE
feat: add verify-lock-file toggle for lock file verification

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -41,6 +41,9 @@ on:
             - add-pr-comment
                 bool, whether to add validation summary as comment on PR, see the workflow input 'add-pr-comment'.
                 note: this is a per environment setting, use the workflow input for a global setting that applies to all environments.
+            - verify-lock-file
+                bool, whether to verify lock file platform coverage on PRs, see the workflow input 'verify-lock-file'.
+                note: this is a per environment setting, use the workflow input for a global setting that applies to all environments.
             - allow-failing-terraform-operations
                 bool, defaults to false, if true: the workflow will not terminate with failure even if job steps fails.
                 This parameter allows for ignoring failing results of terraform operations for select environments.
@@ -183,6 +186,16 @@ on:
         description: |
           The default is to add validation summary as comment on PR if the workflow triggered by a pull request event.
           Set this to false to avoid a comment being added.
+        required: false
+        default: true
+      verify-lock-file:
+        type: boolean
+        description: |
+          Whether to verify that the committed '.terraform.lock.hcl' contains h1: hashes for all required platforms.
+          The check runs after 'terraform init' on pull_request events; push/dispatch/schedule runs on the default branch
+          skip it since verification has already happened at PR time.
+
+          Set this to 'false' to disable lock file verification. For per environment control specify this directly in the environment specification.
         required: false
         default: true
       pr-auto-merge-enabled:
@@ -382,11 +395,13 @@ jobs:
       # Verify the committed .terraform.lock.hcl covers all required platforms.
       # Only runs on PR events — once merged to the default branch the
       # verification has already happened at PR-time, so push/dispatch/schedule
-      # runs skip this step.
+      # runs skip this step. Can be disabled globally or per-env via the
+      # 'verify-lock-file' workflow input / env setting.
       - name: "🔒 Verify lock file platform coverage"
         id: verify-lock
         if: |
-          steps.init.outcome == 'success'
+          matrix.vars.verify-lock-file == 'true'
+          && steps.init.outcome == 'success'
           && github.event_name == 'pull_request'
           && github.event.action != 'closed'
           && github.event.action != 'converted_to_draft'
@@ -487,9 +502,11 @@ jobs:
         # do not terminate if configured to ignore, fromJSON ensures bool
         continue-on-error: ${{ fromJSON(matrix.vars.allow-failing-terraform-operations) }}
       - name: "🧐 Validation outcome: 🔒 Lock file"
-        # Only checked when verify-lock actually ran (PR events with successful init).
+        # Only checked when verify-lock actually ran (lock file verification
+        # enabled, PR event, init succeeded).
         if: |
-          steps.init.outcome == 'success'
+          matrix.vars.verify-lock-file == 'true'
+          && steps.init.outcome == 'success'
           && github.event_name == 'pull_request'
           && github.event.action != 'closed'
           && github.event.action != 'converted_to_draft'

--- a/create-tf-vars-matrix/action.yml
+++ b/create-tf-vars-matrix/action.yml
@@ -236,6 +236,7 @@ runs:
           terraform-version
           tflint-version
           url
+          verify-lock-file
         )
 
         NOT_EMPTY_FIELDS=(
@@ -255,6 +256,7 @@ runs:
           project-dir
           terraform-version
           tflint-version
+          verify-lock-file
         )
 
         # Check that environment vars is of type array

--- a/create-tf-vars-matrix/test_data/test_input_fail_yml_spec_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_fail_yml_spec_inputs-json.json
@@ -5,5 +5,6 @@
   "extra-envs-yml": "{}",
   "terraform-version": "latest",
   "tflint-version": "latest",
-  "add-pr-comment": "true"
+  "add-pr-comment": "true",
+  "verify-lock-file": "true"
 }

--- a/create-tf-vars-matrix/test_data/test_input_happy_day_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_happy_day_inputs-json.json
@@ -7,5 +7,6 @@
   "tflint-version": "v0.46.1",
   "terraform-init-additional-dirs-yml": "- \"./main\"\n- \"./module/1\"\n- \"./module/2\"\n",
   "format-check-in-root-dir": "true",
-  "add-pr-comment": "true"
+  "add-pr-comment": "true",
+  "verify-lock-file": "true"
 }

--- a/create-tf-vars-matrix/test_data/test_input_minimal_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_minimal_inputs-json.json
@@ -5,5 +5,6 @@
   "extra-envs-yml": "{}",
   "terraform-version": "latest",
   "tflint-version": "latest",
-  "add-pr-comment": "true"
+  "add-pr-comment": "true",
+  "verify-lock-file": "true"
 }


### PR DESCRIPTION
## Background

PR #34 introduced the 🔒 **verify lock file platform coverage** step, which runs after `terraform init` on PR events. The check is on for every caller by default — there was no way to disable it.

This PR adds a clean opt-out mechanism for environments where the check isn't wanted (intentionally single-platform locks, vendored providers, or other edge cases). Disable can be set globally or per environment.

## Why a flag rather than a goal

Two natural options were considered:

1. A new **goal** `verify-lock-file` slotted alongside `init`, `format`, `validate`, etc.
2. A new **boolean flag** `verify-lock-file` (default true), like `add-pr-comment` and `format-check-in-root-dir`.

The flag won because:

- **Semantics fit better.** Goals are workflow *stages* a caller composes (`init`, `plan`, `apply`, …). Lock verification is a behavior modifier on the existing init+PR flow, not a stage you reach for instead of `plan`.
- **Default-on works for everyone.** With goals, callers who already use an explicit subset (e.g. `goals-yml: [init, format, validate, lint, plan]` to skip `apply`) would silently lose verification on upgrade. With a flag, every caller gains the safety net automatically and opts out only if needed.
- **Per-env override is free.** `create-tf-vars-matrix/action.yml` already has a generic input-forwarding loop (lines 93-99) that propagates any top-level input into each env, with per-env override. Adding a goal would require new wiring; adding a flag does not.
- **One-line disable.** Globally: `verify-lock-file: false`. Per env: same line inside the env spec.

## What changed

**Workflow** (`terraform-ci-cd-default.yml`)
- New `verify-lock-file` input (`boolean`, `required: false`, `default: true`) with docstring describing global + per-env semantics.
- `environments-yml` docstring extended to list the new optional per-env field, mirroring how `add-pr-comment` is described.
- The 🔒 verify-lock step now gates on `matrix.vars.verify-lock-file == 'true'` in addition to the existing init-success + PR-event gates.
- The 🧐 *Validation outcome: 🔒 Lock file* step gates on the same flag, so when verification is disabled, neither the run nor the outcome check fires.

**Matrix builder** (`create-tf-vars-matrix/action.yml`)
- `verify-lock-file` registered in both `REQ_FIELDS` and `NOT_EMPTY_FIELDS` so the post-build validator catches missing/empty values consistently with the other top-level booleans.

**Test fixtures** (`create-tf-vars-matrix/test_data/*.json`)
- All three input fixtures get `"verify-lock-file": "true"` added, mirroring what the workflow will pass at runtime so the validator passes.

## Behavior when disabled

When `verify-lock-file: false` is set (globally or for a specific env):

- The 🔒 verify step's `if` evaluates false → step is `skipped`.
- The 🧐 outcome check is `skipped` for the same reason — no spurious job failures.
- The PR comment table's 🔒 row renders `<kbd>skipped</kbd>`, matching how the existing pipeline renders other disabled stages (e.g. when a goal is omitted). No changes needed in `create-validation-summary` — the existing `format-status` helper handles all outcome strings uniformly.

## Backwards compatibility

Default value is `true`, so callers on the default `@v0` (post-merge of #34) get verification enabled automatically. The only behavioral change for existing callers is that `verify-lock-file` becomes available to disable verification if they need to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)