### PR TITLE
feat: PR comment grouping via per-env pr-comment-group field

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -44,6 +44,13 @@ on:
             - verify-lock-file
                 bool, whether to verify lock file platform coverage on PRs, see the workflow input 'verify-lock-file'.
                 note: this is a per environment setting, use the workflow input for a global setting that applies to all environments.
+            - pr-comment-group
+                string, name of a group this environment belongs to for PR-comment aggregation, see the workflow input 'pr-comment-group'.
+                Environments with the same non-empty group value share a single grouped validation-summary PR comment (one column per environment).
+                Their per-environment comments drop the validation table and keep only the plan extract.
+                Default behavior (empty string) is unchanged from prior versions — each environment gets its own table+plan comment.
+                See docs/Workflow-pr-comments.md for full details.
+                note: this is a per environment setting, use the workflow input for a global default that applies to all environments.
             - allow-failing-terraform-operations
                 bool, defaults to false, if true: the workflow will not terminate with failure even if job steps fails.
                 This parameter allows for ignoring failing results of terraform operations for select environments.
@@ -198,6 +205,18 @@ on:
           Set this to 'false' to disable lock file verification. For per environment control specify this directly in the environment specification.
         required: false
         default: true
+      pr-comment-group:
+        type: string
+        description: |
+          Optional global default for the per-environment 'pr-comment-group' field. Rarely useful as a global value — you almost always want to set this per environment in 'environments-yml'.
+
+          When an environment's effective value is non-empty, the workflow:
+            - Removes the validation table from that environment's per-environment PR comment (keeping plan extract and footer only).
+            - Adds the environment as a column to a per-group PR comment shared with all other environments using the same group name.
+
+          See docs/Workflow-pr-comments.md for the full grouped-comment spec.
+        required: false
+        default: ""
       pr-auto-merge-enabled:
         type: boolean
         description: |

--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -489,6 +489,9 @@ jobs:
           status-validate: ${{ steps.validate.outcome }}
           status-lint: ${{ steps.lint.outcome }}
           status-plan: ${{ steps.plan.outcome }}
+          # When non-empty, omits the validation table from the per-env comment
+          # body (it appears in the per-group comment instead). See docs/Workflow-pr-comments.md §3.2.
+          pr-comment-group: ${{ matrix.vars.pr-comment-group }}
           # include details when parse step actually returned data
           include-plan-details: ${{ steps.parse-plan.outcome == 'success' }}
           plan-count-add: ${{ steps.parse-plan.outputs.count-add }}
@@ -654,6 +657,41 @@ jobs:
           github-context-json: ${{ toJSON(github) }}
           steps-context-json: ${{ toJSON(steps) }}
         continue-on-error: true # never fail the job due to metadata capture
+
+  # Reconciles per-group PR comments according to the desired set computed from
+  # matrix-job-meta-*.json artifacts. Runs unconditionally on PR events (not gated
+  # on whether any env declares a pr-comment-group) so that toggling grouping off
+  # for an env reliably cleans up its stale group comment on the very next run.
+  # See docs/Workflow-pr-comments.md §4.6 for the reconcile algorithm and the
+  # cost discussion behind the unconditional gate.
+  pr-comment-aggregator:
+    if: |
+      always()
+      && github.event_name == 'pull_request'
+      && github.event.action != 'closed'
+      && github.event.action != 'converted_to_draft'
+    name: "PR comment aggregator"
+    needs: [create-matrix, terraform-ci-cd]
+    runs-on: ${{ inputs.runs-on }} # global setting
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: "📥 Download matrix job metadata"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: matrix-job-meta-*
+          merge-multiple: true
+        # An empty artifact set is a valid input (sweep-only mode still
+        # needs to run to clean up any orphan group comments).
+        continue-on-error: true
+      - name: "🧮 Reconcile per-group PR comments"
+        uses: dsb-norge/github-actions-terraform/aggregate-validation-summaries@v0
+        with:
+          metadata-files-pattern: "matrix-job-meta-*.json"
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ github.token }}
+        continue-on-error: true # never fail the workflow over PR comment rendering
 
   # create a global result indicating if workflow steps succeeded or not,
   # handy for branch protection rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository overview
+
+A collection of composite GitHub Actions and reusable workflows for terraform projects used by other DSB repositories. The two main consumption points are:
+
+- **`.github/workflows/terraform-ci-cd-default.yml`** — the reusable CI/CD workflow that orchestrates init → fmt → validate → lint → plan → apply with a `📊` PR comment summary and optional `🔒` lock file verification and PR auto-merge.
+- **Composite actions** in top-level directories (e.g. `terraform-init/`, `terraform-plan/`, `verify-terraform-lock/`, `create-validation-summary/`, …).
+
+Calling repos pin against either the rolling major tag (`@v0`) or a specific minor (`@v0.21`). The major tag is force-moved on every minor release, so changes shipped on `@v0` are immediately picked up by all calling repos — be mindful when touching anything in here.
+
+## Architecture
+
+### The matrix builder is the center of gravity
+
+`create-tf-vars-matrix/action.yml` is the spine of the default workflow. It takes the workflow's full `inputs` JSON plus the user's `environments-yml` and produces a job matrix where each row is one fully-resolved environment configuration.
+
+Two patterns to know:
+
+- **Generic input-forwarding loop** (around `create-tf-vars-matrix/action.yml:93-99`): every top-level workflow input is automatically propagated into each env's `matrix.vars`, with per-env override available for free if the user sets the same key inside `environments-yml`. **Adding a new boolean/string workflow input does NOT require matrix-builder changes** — just add it to the `REQ_FIELDS` and `NOT_EMPTY_FIELDS` validators near the end of the action and to the JSON test fixtures.
+- **YAML fields** (`extra-envs-yml`, `goals-yml`, `terraform-init-additional-dirs-yml`, `pr-auto-merge-*-yml`) get explicit handling — some default to global, others merge global with per-env.
+
+Boolean inputs end up as strings in the matrix (e.g. `matrix.vars.add-pr-comment == 'true'`). The exception is `allow-failing-terraform-operations`, which is explicitly normalized to a JSON boolean so the workflow can `fromJSON()` it. Follow this pattern only if the value needs `fromJSON()`; otherwise plain string comparison is fine.
+
+### Validation-step + outcome-step pattern
+
+Validation steps (init, fmt, validate, lint, plan, verify-lock) all use the same pattern in the workflow:
+
+1. The step itself runs with `continue-on-error: true` so the job continues regardless.
+2. Its outcome is forwarded to `create-validation-summary` which posts a 📊 PR comment row.
+3. A separate `🧐 Validation outcome: <step>` step later in the job hard-fails on non-success, respecting `matrix.vars.allow-failing-terraform-operations` via `continue-on-error: ${{ fromJSON(...) }}`.
+
+When adding a new validation step, follow all three pieces. The validation-summary action's status inputs are all `required: true` — add a new one alongside `status-init`, `status-fmt`, etc.
+
+### Two flavors of action layout
+
+Modern actions follow `docs/Action-implementation-guide.md` strictly — see `verify-terraform-lock/`, `create-validation-summary/`, `capture-matrix-job-meta/`, `parse-terraform-plan/` as reference implementations. Layout:
+
+```
+my-action/
+├── action.yml                  # thin shim: env: input_* + `set -o allexport; source step_<name>.sh`
+├── helpers.sh                  # identical across all actions; auto-loads helpers_additional.sh
+├── helpers_additional.sh       # optional, action-specific helpers used by step_*.sh
+├── step_<name>.sh              # all logic; sources helpers.sh; main(); exits with main's code
+├── run_local_step_<name>.sh    # simulates GitHub Actions env for manual testing
+└── run_all_tests.sh            # automated tests using subshells + GITHUB_OUTPUT capture
+```
+
+Legacy actions (e.g. `terraform-validate/`, `terraform-init/`, `setup-tflint/`) still embed bash in `action.yml`. **When touching one of these for non-trivial work, convert it to the modern layout** following the guide. Cherry-pick `helpers.sh` from a reference action without modifying it.
+
+For step scripts: end with `main; _main_exit_code=$?; exit ${_main_exit_code}` — never `return`. GitHub Actions sources the script in a `bash -eo pipefail` shell, so `exit` terminates the sourced process cleanly and the runner fails the step on non-zero. Tests run the script in a `( subshell )`, so `exit` terminates only the subshell.
+
+For JSON inputs in `action.yml` shims, use heredocs:
+```yaml
+run: |
+  input_json_data=$(cat <<'EOF'
+  ${{ inputs.json-data }}
+  EOF
+  )
+  export input_json_data
+  set -o allexport
+  source "${{ github.action_path }}/step_<name>.sh"
+```
+
+## Common commands
+
+```bash
+# Run an action's full test suite
+bash <action-name>/run_all_tests.sh
+
+# Manually run an action's main step against simulated GitHub env
+bash <action-name>/run_local_step_<name>.sh
+
+# Validate workflow / action YAML parses
+python3 -c "import yaml; yaml.safe_load(open('<path-to>.yml'))"
+
+# Validate a test-data JSON fixture parses
+python3 -c "import json; json.load(open('<path-to>.json'))"
+```
+
+The matrix-builder test harness (`create-tf-vars-matrix/test_action_source.sh`) is a known-flaky direct-invocation harness that requires a real tty and may fail on pristine main; rely on the modern per-action `run_all_tests.sh` suites where they exist.
+
+## Development workflow (see `docs/Development-and-release.md` for full procedure)
+
+To test changes from a calling repo, the documented "dev-tag swap" flow is mandatory:
+
+1. **Rewrite `@v0` refs** in all `dsb-norge/github-actions-terraform/...@v0` lines in this repo to `@<your-feature-tag>`, with a `# TODO revert to @v0` marker above each — there's a documented vscode regex pattern for both the swap and the revert.
+2. **Commit on a feature branch**, push, then `git tag -f -a '<tag>' && git push -f origin 'refs/tags/<tag>'`. Re-tag and force-push each time you push more commits.
+3. **Calling repo** uses `uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@<tag>`.
+4. **Before merge**: delete the dev tag locally and on origin, and revert all `@<tag>` refs back to `@v0` using the second documented regex.
+
+Branch + tag may share a name. To disambiguate locally, use `refs/heads/<name>` and `refs/tags/<name>` explicitly with `git push`.
+
+## Release process (see `docs/Development-and-release.md`)
+
+Minor and major releases both use annotated tags. Critical points beyond the doc:
+
+- **The `v0` major tag's annotation is an append-only changelog.** Every prior `v0.X:` block must be preserved when force-recreating `v0`. The doc shows interactive `git tag -f -a 'v0'` which prompts for fresh annotation — that overwrites. To **amend** properly:
+  ```bash
+  old=$(git for-each-ref --format='%(contents)' refs/tags/v0)
+  new_block="v0.X:
+    - <commit subject>
+    - <commit subject>"
+  combined="${old}
+  ${new_block}"
+  git tag -a v0.X -m "${new_block}"
+  git tag -f -a v0 -m "${combined}"
+  git push origin refs/tags/v0.X
+  git push -f origin refs/tags/v0
+  ```
+- The new minor's annotation block follows the format `vX.Y:\n  - <commit subject>\n  ...`. Mirror commit subjects since `vX.(Y-1)`, lightly rephrasing if a literal subject would be confusing as a release note.
+- Force-pushing `v0` is intentional and is the supported mechanism — every calling repo on `@v0` moves to the new commit immediately.
+
+## Conventions
+
+- **Commit messages:** lowercase semantic prefix (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`), subject ≤70 chars, body separated by blank line, body lines not wrapped.
+- **PR descriptions:** focus on motivation/context and a summary of changes. Don't include QA checklists or testing instructions.
+- **Comments in step scripts:** explain *why* (non-obvious constraints, intentional side-effects, references to past incidents); never *what* a well-named identifier already says. Don't reference current PR/task numbers since those rot.

--- a/aggregate-validation-summaries/action.yml
+++ b/aggregate-validation-summaries/action.yml
@@ -1,0 +1,70 @@
+name: "Aggregate validation summaries into per-group PR comments"
+description: |
+  Reconciles the set of per-group "validation summary" PR comments on a pull request
+  according to the desired set computed from matrix-job-meta-*.json artifacts.
+
+  See docs/Workflow-pr-comments.md for the full spec — this action implements §4
+  (the per-group comment shape and the reconcile algorithm).
+
+  Behavior:
+    - Reads every matrix-job-meta-*.json in the current directory.
+    - Partitions envs by their matrix_context.vars["pr-comment-group"] value.
+    - Lists all PR comments via the GitHub API; finds existing group comments by
+      family-prefix match.
+    - Deletes existing group comments whose specific prefix is no longer desired
+      (orphans from removed/renamed groups), plus existing group comments that
+      ARE desired (will be reposted with fresh body).
+    - Posts one fresh per-group comment per distinct non-empty group.
+
+  Failure isolation:
+    - Empty desired set + empty existing set -> no-op.
+    - Empty desired set + non-empty existing set -> sweep mode (clean orphans only).
+    - GitHub API outage -> degraded mode: skip delete pass, still post fresh bodies.
+    - Malformed individual metadata file -> log warning, skip the file.
+
+author: "Peder Schmedling"
+
+inputs:
+  metadata-files-pattern:
+    description: |
+      Glob pattern matched against files in the working directory. Each match must
+      be a JSON file with the structure produced by capture-matrix-job-meta.
+    required: false
+    default: "matrix-job-meta-*.json"
+  pr-number:
+    description: |
+      The pull request number to reconcile group comments against.
+    required: true
+  github-token:
+    description: |
+      Token used by the `gh` CLI to call the GitHub API. Needs `pull-requests: write`.
+
+      No default is provided: the `github` context is not available inside a
+      composite action's `inputs.<name>.default`, so the caller must pass the
+      token explicitly. From a reusable workflow, the canonical value to pass
+      is the `github.token` context (or the `secrets.GITHUB_TOKEN` secret).
+    required: true
+
+outputs:
+  groups-processed-json:
+    description: |
+      JSON array of objects describing each action taken. Each object has shape:
+        {group: <string>, "comment-id": <string>, action: posted|repost|orphan-deleted|post-failed}
+      Used for logs/tests; not normally consumed by callers.
+    value: ${{ steps.aggregate.outputs.groups-processed-json }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: aggregate
+      shell: bash
+      env:
+        input_metadata_files_pattern: ${{ inputs.metadata-files-pattern }}
+        input_pr_number: ${{ inputs.pr-number }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -o allexport
+        source "${{ github.action_path }}/step_aggregate.sh"
+        exit_code=$?
+        set +o allexport
+        exit ${exit_code}

--- a/aggregate-validation-summaries/helpers.sh
+++ b/aggregate-validation-summaries/helpers.sh
@@ -1,0 +1,40 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name="$(basename "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)")"
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+function set-output { echo "${1}=${2}" >>$GITHUB_OUTPUT; }
+function set-multiline-output {
+  local outputName outputValue delimiter
+  outputName="${1}"
+  outputValue="${2}"
+  delimiter=$(echo $RANDOM | md5sum | head -c 20)
+  echo "${outputName}<<\"${delimiter}\"" >>$GITHUB_OUTPUT
+  echo "${outputValue}" >>$GITHUB_OUTPUT
+  echo "\"${delimiter}\"" >>$GITHUB_OUTPUT
+}
+function ws-path {
+  local inPath
+  inPath="${1}"
+  realpath --relative-to="${GITHUB_WORKSPACE}" "${inPath}"
+}
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."
+
+if [ -f "${GITHUB_ACTION_PATH}/helpers_additional.sh" ]; then
+  source "${GITHUB_ACTION_PATH}/helpers_additional.sh"
+fi

--- a/aggregate-validation-summaries/helpers_additional.sh
+++ b/aggregate-validation-summaries/helpers_additional.sh
@@ -1,0 +1,174 @@
+#!/bin/env bash
+#
+# Action-specific helpers for aggregate-validation-summaries.
+#
+# Production-only helpers (no test-only code). Sourced automatically
+# by helpers.sh.
+#
+
+# Family prefix shared by every per-group comment this action manages.
+# Used both for delete-by-prefix reconciliation and to identify orphans
+# whose specific group name is no longer in the desired set.
+# See docs/Workflow-pr-comments.md §2.
+declare -gr GROUP_COMMENT_FAMILY_PREFIX='### Terraform validation summary for group: '
+
+# Per-env comment prefix template (uses backtick-delimited env name so
+# partial matches can't collide).
+# See docs/Workflow-pr-comments.md §2.
+function _per_env_prefix {
+  local env_name="${1}"
+  echo "### Terraform validation summary for environment: \`${env_name}\`"
+}
+
+# Specific group comment prefix for one group name.
+function _group_prefix {
+  local group_name="${1}"
+  echo "${GROUP_COMMENT_FAMILY_PREFIX}\`${group_name}\`"
+}
+
+# Map a GitHub Actions step outcome string to the (emoji, title) pair used
+# in the grouped table's status cells.
+# Outcomes: success | failure | cancelled | skipped | '' (missing)
+# Output written to stdout: "<emoji>|<title>" — split on '|' by caller.
+# See docs/Workflow-pr-comments.md §4.3.
+function _status_emoji_and_title {
+  local outcome="${1}"
+  case "${outcome}" in
+    success)   echo "✅|success" ;;
+    failure)   echo "❌|failure" ;;
+    cancelled) echo "🚫|cancelled" ;;
+    skipped)   echo "⏭️|skipped" ;;
+    *)         echo "—|not applicable" ;;
+  esac
+}
+
+# Render a status cell for the grouped table (column-2 emoji wrapped in
+# <span title="..."> so desktop browsers surface a hover tooltip).
+function _render_status_cell {
+  local outcome="${1}"
+  local pair emoji title
+  pair=$(_status_emoji_and_title "${outcome}")
+  emoji="${pair%%|*}"
+  title="${pair##*|}"
+  echo "<span title=\"${title}\">${emoji}</span>"
+}
+
+# Render the column-1 step-icon cell with a tooltip (label is the step name).
+function _render_step_icon_cell {
+  local emoji="${1}"
+  local label="${2}"
+  echo "<span title=\"${label}\">${emoji}</span>"
+}
+
+# Row definitions for the grouped table.
+# Format: "<step-id-in-matrix-meta>|<emoji>|<label>".
+# The step-id matches the keys under `steps:` in a matrix-job-meta-*.json
+# file (set by capture-matrix-job-meta from GitHub's steps context).
+# See .github/workflows/terraform-ci-cd-default.yml: id: init, verify-lock,
+# fmt, validate, lint, plan.
+declare -gar GROUPED_TABLE_STEP_ROWS=(
+  "init|⚙️|Initialization"
+  "verify-lock|🔒|Lock file"
+  "fmt|🖌|Format and Style"
+  "validate|✔|Validate"
+  "lint|🧹|TFLint"
+  "plan|📖|Plan"
+)
+
+# Render the Plan Details cell for a single env in the grouped table.
+# Cell content is wrapped in <div align="left">...</div> so the badge stack
+# anchors to the left edge of the otherwise center-aligned column (see
+# docs/Workflow-pr-comments.md §4.4).
+# Echos "N/A" when no parse-plan data is available for the env.
+function _render_plan_details_cell {
+  local count_add="${1}"
+  local count_change="${2}"
+  local count_destroy="${3}"
+  local count_import="${4}"
+  local count_move="${5}"
+  local count_remove="${6}"
+
+  # All-empty means parse-plan didn't run for this env -> N/A
+  if [ -z "${count_add}" ] && [ -z "${count_change}" ] && [ -z "${count_destroy}" ]; then
+    echo "N/A"
+    return 0
+  fi
+
+  local cell="<div align=\"left\">"
+  cell+="<span title=\"Resources to be added\">\`💫 ${count_add:-0}\` add</span>"
+  cell+="<br><span title=\"Resources to be changed\">\`🛠️ ${count_change:-0}\` change</span>"
+  cell+="<br><span title=\"Resources to be destroyed\">\`💥 ${count_destroy:-0}\` destroy</span>"
+
+  if [ -n "${count_move}" ] && [ "${count_move}" != "0" ]; then
+    cell+="<br><span title=\"Resources to be moved\">\`🔀 ${count_move}\` move</span>"
+  fi
+  if [ -n "${count_import}" ] && [ "${count_import}" != "0" ]; then
+    cell+="<br><span title=\"Resources to be imported\">\`📥 ${count_import}\` import</span>"
+  fi
+  if [ -n "${count_remove}" ] && [ "${count_remove}" != "0" ]; then
+    cell+="<br><span title=\"Resources to be removed\">\`⛓️‍💥 ${count_remove}\` remove</span>"
+  fi
+
+  cell+="</div>"
+  echo "${cell}"
+}
+
+# Render the Links cell for a single env (0-2 lines, <br>-separated).
+# Each argument may be empty — the corresponding line is omitted. Both empty
+# yields an empty cell rather than a row of stray pipes.
+# See docs/Workflow-pr-comments.md §4.5.
+function _render_links_cell {
+  local log_extract_anchor="${1}"
+  local job_log_url="${2}"
+
+  local -a lines=()
+  if [ -n "${log_extract_anchor}" ]; then
+    lines+=("[log extract](${log_extract_anchor})")
+  fi
+  if [ -n "${job_log_url}" ]; then
+    lines+=("[job log](${job_log_url})")
+  fi
+
+  if [ ${#lines[@]} -eq 0 ]; then
+    echo ""
+    return
+  fi
+
+  local out="${lines[0]}"
+  local i
+  for ((i = 1; i < ${#lines[@]}; i++)); do
+    out+="<br>${lines[$i]}"
+  done
+  echo "${out}"
+}
+
+# gh-api wrappers. Production code calls these; tests can shadow them by
+# putting a fake `gh` script earlier on PATH. Keeping the wrappers thin
+# means the test surface is just the `gh` invocations.
+
+function _gh_list_pr_comments {
+  local repo="${1}" pr="${2}"
+  # --paginate to get all comments regardless of page count
+  gh api --paginate "repos/${repo}/issues/${pr}/comments"
+}
+
+# Lists jobs for a workflow run. Each page is an object {total_count, jobs: [...]}.
+# We extract just the jobs array per page so the caller can combine them via
+# jq -s 'add'.
+function _gh_list_run_jobs {
+  local repo="${1}" run_id="${2}"
+  gh api --paginate "repos/${repo}/actions/runs/${run_id}/jobs" --jq '.jobs'
+}
+
+function _gh_delete_comment {
+  local repo="${1}" comment_id="${2}"
+  gh api -X DELETE "repos/${repo}/issues/comments/${comment_id}"
+}
+
+# Posts a comment, returns the new comment ID on stdout.
+# Body is passed via a temp file (-F body=@file) so multi-line content
+# is preserved and not subject to shell quoting.
+function _gh_post_comment {
+  local repo="${1}" pr="${2}" body_file="${3}"
+  gh api -X POST "repos/${repo}/issues/${pr}/comments" -F "body=@${body_file}" --jq '.id'
+}

--- a/aggregate-validation-summaries/run_all_tests.sh
+++ b/aggregate-validation-summaries/run_all_tests.sh
@@ -1,0 +1,807 @@
+#!/bin/env bash
+#
+# Test runner for step_aggregate.sh
+#
+# Strategy:
+#   - Each test creates a temp dir with fixture matrix-job-meta-*.json files
+#   - A fake `gh` script is placed on PATH ahead of the real one; it records
+#     every call to ${GH_FAKE_CALL_LOG} and returns canned responses driven
+#     by ${GH_FAKE_LIST_RESPONSE_FILE} (for `--paginate ... /comments`)
+#   - The step is sourced in a subshell so its side-effects don't leak
+#   - Assertions inspect stdout, GITHUB_OUTPUT, and the recorded gh calls
+#
+
+set -u
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+# Setup a fresh sandbox for one test
+setup() {
+  TEST_DIR=$(mktemp -d)
+
+  # Fake gh. Behaviour driven by env vars + response files in TEST_DIR.
+  mkdir -p "${TEST_DIR}/bin"
+  cat > "${TEST_DIR}/bin/gh" <<'FAKE_GH'
+#!/bin/bash
+LOG="${GH_FAKE_CALL_LOG:-/dev/null}"
+echo "gh $*" >> "${LOG}"
+# Order matters: more specific patterns first.
+case "$*" in
+  *"--paginate"*"/actions/runs/"*"/jobs"*)
+    # Jobs-API call. Returns a flat JSON array (because production code uses
+    # --jq '.jobs', which strips the envelope and concatenates pages).
+    if [ -n "${GH_FAKE_JOBS_RESPONSE_FILE:-}" ] && [ -f "${GH_FAKE_JOBS_RESPONSE_FILE}" ]; then
+      cat "${GH_FAKE_JOBS_RESPONSE_FILE}"
+    else
+      echo "[]"
+    fi
+    if [ "${GH_FAKE_JOBS_EXIT:-0}" != "0" ]; then
+      exit "${GH_FAKE_JOBS_EXIT}"
+    fi
+    ;;
+  *"--paginate"*"/comments"*)
+    if [ -n "${GH_FAKE_LIST_RESPONSE_FILE:-}" ] && [ -f "${GH_FAKE_LIST_RESPONSE_FILE}" ]; then
+      cat "${GH_FAKE_LIST_RESPONSE_FILE}"
+    else
+      echo "[]"
+    fi
+    if [ "${GH_FAKE_LIST_EXIT:-0}" != "0" ]; then
+      exit "${GH_FAKE_LIST_EXIT}"
+    fi
+    ;;
+  *"-X DELETE"*)
+    if [ "${GH_FAKE_DELETE_EXIT:-0}" != "0" ]; then
+      exit "${GH_FAKE_DELETE_EXIT}"
+    fi
+    echo '{"deleted": true}'
+    ;;
+  *"-X POST"*)
+    if [ "${GH_FAKE_POST_EXIT:-0}" != "0" ]; then
+      exit "${GH_FAKE_POST_EXIT}"
+    fi
+    # Each post returns a different fake id from a counter so tests can
+    # distinguish per-group posts.
+    POST_COUNTER_FILE="${TEST_DIR:-/tmp}/.post-counter"
+    COUNTER=$(cat "${POST_COUNTER_FILE}" 2>/dev/null || echo 9000)
+    COUNTER=$((COUNTER + 1))
+    echo "${COUNTER}" > "${POST_COUNTER_FILE}"
+    echo "${COUNTER}"
+    ;;
+esac
+FAKE_GH
+  chmod +x "${TEST_DIR}/bin/gh"
+
+  export GH_FAKE_CALL_LOG="${TEST_DIR}/gh-calls.log"
+  export GH_FAKE_LIST_RESPONSE_FILE="${TEST_DIR}/list-response.json"
+  export GH_FAKE_JOBS_RESPONSE_FILE="${TEST_DIR}/jobs-response.json"
+  unset GH_FAKE_LIST_EXIT GH_FAKE_DELETE_EXIT GH_FAKE_POST_EXIT GH_FAKE_JOBS_EXIT
+  echo "[]" > "${GH_FAKE_LIST_RESPONSE_FILE}"
+  echo "[]" > "${GH_FAKE_JOBS_RESPONSE_FILE}"
+  : > "${GH_FAKE_CALL_LOG}"
+
+  export PATH="${TEST_DIR}/bin:${PATH}"
+
+  # GH Actions plumbing
+  export GITHUB_OUTPUT=$(mktemp)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${TEST_DIR}"
+  export GITHUB_REPOSITORY="dsb-norge/test-repo"
+  export GITHUB_SERVER_URL="https://github.com"
+  export GITHUB_RUN_ID="999"
+  export GITHUB_WORKFLOW="Terraform CI"
+  export GITHUB_ACTOR="test-user"
+  export GITHUB_EVENT_NAME="pull_request"
+  export GH_TOKEN="fake"
+
+  export input_metadata_files_pattern="matrix-job-meta-*.json"
+  export input_pr_number="123"
+
+  cd "${TEST_DIR}"
+}
+
+teardown() {
+  rm -rf "${TEST_DIR}" 2>/dev/null || true
+  unset TEST_DIR
+}
+
+# Create a metadata file in TEST_DIR.
+# Usage: write_meta <env> [group] [fmt_outcome] [extra-counts-json]
+write_meta() {
+  local env="${1}" group="${2:-}" fmt_outcome="${3:-success}" counts="${4:-}"
+  local counts_default='{"count-add":"0","count-change":"0","count-destroy":"0","count-import":"0","count-move":"0","count-remove":"0"}'
+  local counts_use="${counts:-${counts_default}}"
+  cat > "${TEST_DIR}/matrix-job-meta-${env}.json" <<JSON
+{
+  "metadata": {"environment": "${env}", "captured_at": "2026-01-30T12:00:00Z", "schema_version": "2.0.0"},
+  "workflow": {"run_id": "999", "run_number": "1", "run_attempt": "1",
+               "workflow_name": "Terraform CI", "job_name": "terraform-ci-cd",
+               "actor": "test-user", "event_name": "pull_request",
+               "ref": "refs/pull/123/merge", "sha": "abc"},
+  "matrix_context": {"environment": "${env}", "vars": {"environment": "${env}", "pr-comment-group": "${group}"}},
+  "github_context": {"actor": "test-user"},
+  "steps": {
+    "init":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "verify-lock": {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "fmt":         {"outcome": "${fmt_outcome}", "conclusion": "${fmt_outcome}", "outputs": {}},
+    "validate":    {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "lint":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "plan":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "parse-plan":  {"outcome": "success", "conclusion": "success", "outputs": ${counts_use}}
+  }
+}
+JSON
+}
+
+# Set up the fake Jobs API response so per-env job URL resolution succeeds.
+# Each env arg gets a synthetic html_url. The job name format mirrors what
+# GitHub actually renders when this reusable workflow is called from another
+# workflow: "<caller-job-name> / Terraform (<env>)". The default caller name
+# is "tf" (matches the real-world calling repo) — override via the first
+# argument prefixed with "caller=" if a test needs a different one. Use
+# "caller=" (empty) to test the bare "Terraform (<env>)" format.
+# Usage:
+#   with_jobs_for env1 env2 ...
+#   with_jobs_for caller=ci-cd env1 env2 ...
+#   with_jobs_for caller= env1 env2 ...
+with_jobs_for() {
+  local caller="tf / "
+  if [[ "${1:-}" == caller=* ]]; then
+    local val="${1#caller=}"
+    if [ -z "${val}" ]; then
+      caller=""
+    else
+      caller="${val} / "
+    fi
+    shift
+  fi
+  local out='['
+  local first=true
+  local env
+  for env in "${@}"; do
+    if [ "${first}" = "true" ]; then first=false; else out+=','; fi
+    out+="{\"id\": $((RANDOM + 1000)), \"name\": \"${caller}Terraform (${env})\", \"html_url\": \"https://github.com/dsb-norge/test-repo/actions/runs/999/job/${env}\"}"
+  done
+  out+=']'
+  echo "${out}" > "${GH_FAKE_JOBS_RESPONSE_FILE}"
+}
+
+# Run the step. Captures stdout to ${TEST_DIR}/step.log; reads GITHUB_OUTPUT
+# for assertions.
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_aggregate.sh"
+  ) > "${TEST_DIR}/step.log" 2>&1
+  STEP_EXIT_CODE=$?
+}
+
+# Read groups-processed-json output (multi-line)
+get_processed_json() {
+  local content="" delim="" in_block=false
+  while IFS= read -r line; do
+    if [[ "${in_block}" == true ]]; then
+      if [[ "${line}" == "${delim}" ]]; then break; fi
+      if [[ -n "${content}" ]]; then content="${content}"$'\n'"${line}"; else content="${line}"; fi
+    elif [[ "${line}" =~ ^groups-processed-json\<\<(.*)$ ]]; then
+      delim="${BASH_REMATCH[1]}"
+      in_block=true
+    fi
+  done < "${GITHUB_OUTPUT}"
+  echo "${content}"
+}
+
+# Generic test runner
+run_test() {
+  local name="${1}"
+  local fn="${2}"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  setup
+  local err
+  err=$("${fn}" 2>&1)
+  local exit_code=$?
+  if [[ ${exit_code} -eq 0 ]]; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo -e "${err}"
+    echo "--- step output ---"
+    cat "${TEST_DIR}/step.log" 2>/dev/null
+    echo "--- gh calls ---"
+    cat "${GH_FAKE_CALL_LOG}" 2>/dev/null
+    echo "--- GITHUB_OUTPUT ---"
+    cat "${GITHUB_OUTPUT}" 2>/dev/null
+    echo "--- end ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# ============================================================================
+# Test cases
+# ============================================================================
+
+test_empty_desired_empty_existing_is_noop() {
+  # No metadata files; empty PR comment list.
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Must have called list (once) but no DELETE and no POST
+  if ! grep -q 'gh api --paginate' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected gh list call"; return 1
+  fi
+  if grep -q 'DELETE' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect DELETE in empty/empty scenario"; return 1
+  fi
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST in empty/empty scenario"; return 1
+  fi
+  return 0
+}
+
+test_sweep_only_orphans() {
+  # No desired groups, but PR has an existing group comment from a prior run
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 5001, "body": "### Terraform validation summary for group: `stale-group`\nold body"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/5001' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected DELETE of orphan comment 5001"; return 1
+  fi
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST when desired set is empty"; return 1
+  fi
+  return 0
+}
+
+test_post_when_no_existing() {
+  # Two envs in one group, no existing comments
+  write_meta "alpha-dev" "dev"
+  write_meta "beta-dev" "dev"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if grep -q 'DELETE' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect DELETE when no existing"; return 1
+  fi
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
+    echo "expected exactly 1 POST"; return 1
+  fi
+  # Verify body content was generated (peek at the body file path used)
+  local body_file
+  body_file=$(grep -o 'body=@/tmp/[^ ]*' "${GH_FAKE_CALL_LOG}" | head -n1 | cut -d@ -f2)
+  if [ -z "${body_file}" ] || [ ! -f "${body_file}" ]; then
+    # File was cleaned up - that's fine. Check the step log instead.
+    if ! grep -q 'Terraform validation summary for group: `dev`' "${TEST_DIR}/step.log"; then
+      echo "expected rendered body to contain group prefix"; return 1
+    fi
+  fi
+  return 0
+}
+
+test_mixed_reconcile() {
+  # One desired group, one orphan, one matching-prefix-existing
+  write_meta "alpha-dev" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[
+  {"id": 7001, "body": "### Terraform validation summary for group: `dev`\nold matching body"},
+  {"id": 7002, "body": "### Terraform validation summary for group: `obsolete-group`\norphan body"}
+]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Both existing must be deleted (one as repost, one as orphan)
+  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7001' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected DELETE of matching-prefix existing 7001"; return 1
+  fi
+  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7002' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected DELETE of orphan 7002"; return 1
+  fi
+  # And we should have posted the fresh body for 'dev'
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
+    echo "expected 1 POST for desired 'dev'"; return 1
+  fi
+  return 0
+}
+
+test_alphabetical_column_order() {
+  # Three envs added in non-alpha order; expect alpha column order in output
+  write_meta "charlie" "dev"
+  write_meta "alpha" "dev"
+  write_meta "bravo" "dev"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Header line should list envs alphabetically
+  if ! grep -q '|  | Step | alpha | bravo | charlie |' "${TEST_DIR}/step.log"; then
+    echo "expected alphabetical header '|  | Step | alpha | bravo | charlie |'"
+    grep '|  | Step |' "${TEST_DIR}/step.log" || true
+    return 1
+  fi
+  return 0
+}
+
+test_per_env_anchor_resolved() {
+  write_meta "myenv" "g"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 4242, "body": "### Terraform validation summary for environment: `myenv`\nbody"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q '\[log extract\](#issuecomment-4242)' "${TEST_DIR}/step.log"; then
+    echo "expected resolved log-extract anchor #issuecomment-4242"
+    return 1
+  fi
+  return 0
+}
+
+test_per_env_anchor_missing_but_job_url_resolved_shows_only_job_log() {
+  write_meta "lonely" "g"
+  with_jobs_for "lonely"
+  # No per-env comment in the PR
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local links_row
+  links_row=$(grep -E '^\| <span title="Links"' "${TEST_DIR}/step.log" | head -n1)
+  if [ -z "${links_row}" ]; then
+    echo "no Links row found"; return 1
+  fi
+  if echo "${links_row}" | grep -q 'log extract'; then
+    echo "Links row must NOT contain 'log extract' when no per-env comment exists"
+    echo "row: ${links_row}"
+    return 1
+  fi
+  if ! echo "${links_row}" | grep -q '\[job log\](https://github.com/dsb-norge/test-repo/actions/runs/999/job/lonely#logs)'; then
+    echo "expected resolved per-env job URL in Links row"
+    echo "row: ${links_row}"
+    return 1
+  fi
+  return 0
+}
+
+test_neither_anchor_nor_job_url_yields_empty_cell() {
+  write_meta "ghost" "g"
+  # No PR comment match AND no jobs API match (jobs response is empty array)
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local links_row
+  links_row=$(grep -E '^\| <span title="Links"' "${TEST_DIR}/step.log" | head -n1)
+  if [ -z "${links_row}" ]; then echo "no Links row found"; return 1; fi
+  # Cell for 'ghost' (the only env in the group) must be empty: `... | Links |  |`
+  if ! echo "${links_row}" | grep -qE '\| Links \|  \|'; then
+    echo "expected empty Links cell when neither anchor nor job URL resolved"
+    echo "row: ${links_row}"
+    return 1
+  fi
+  return 0
+}
+
+test_both_anchor_and_job_url_resolved_shows_both_with_br() {
+  write_meta "envX" "g"
+  with_jobs_for "envX"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 7777, "body": "### Terraform validation summary for environment: `envX`\n"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local links_row
+  links_row=$(grep -E '^\| <span title="Links"' "${TEST_DIR}/step.log" | head -n1)
+  if [ -z "${links_row}" ]; then echo "no Links row found"; return 1; fi
+  if ! echo "${links_row}" | grep -q '\[log extract\](#issuecomment-7777)<br>\[job log\](https://github.com/dsb-norge/test-repo/actions/runs/999/job/envX#logs)'; then
+    echo "expected both links separated by <br>"
+    echo "row: ${links_row}"
+    return 1
+  fi
+  return 0
+}
+
+test_jobs_api_failure_omits_job_log_for_all_envs() {
+  write_meta "envA" "g"
+  export GH_FAKE_JOBS_EXIT=1
+  echo "boom" > "${GH_FAKE_JOBS_RESPONSE_FILE}"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Specifically: no markdown `[job log](...)` link in any rendered Links row.
+  # (Use literal-bracket match to avoid catching the WARN log line's prose.)
+  local links_row
+  links_row=$(grep -E '^\| <span title="Links"' "${TEST_DIR}/step.log" | head -n1)
+  if echo "${links_row}" | grep -q '\[job log\]'; then
+    echo "Links row must not contain a [job log] link when Jobs API fails"
+    echo "row: ${links_row}"
+    return 1
+  fi
+  # And we should have logged a warn about it
+  if ! grep -q 'Failed to list run jobs' "${TEST_DIR}/step.log"; then
+    echo "expected warning 'Failed to list run jobs'"
+    return 1
+  fi
+  return 0
+}
+
+test_job_url_resolution_handles_caller_prefixed_name() {
+  # Real-world: when this reusable workflow is called from another workflow,
+  # GitHub renders matrix job names with the caller's job name prepended,
+  # e.g. "tf / Terraform (dsb-norge)". This is the default form of
+  # with_jobs_for. Verify the regex picks it up.
+  write_meta "myenv" "g"
+  with_jobs_for "myenv"  # produces name "tf / Terraform (myenv)"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q "Resolved 1 per-env job URL" "${TEST_DIR}/step.log"; then
+    echo "expected exactly 1 resolved job URL"
+    grep "Resolved" "${TEST_DIR}/step.log" || true
+    return 1
+  fi
+  local links_row
+  links_row=$(grep -E '^\| <span title="Links"' "${TEST_DIR}/step.log" | head -n1)
+  if ! echo "${links_row}" | grep -q '\[job log\](https://github.com/dsb-norge/test-repo/actions/runs/999/job/myenv#logs)'; then
+    echo "expected resolved per-env job URL despite 'tf / ' prefix"
+    echo "row: ${links_row}"
+    return 1
+  fi
+  return 0
+}
+
+test_job_url_resolution_handles_bare_name() {
+  # Backwards: if a caller invokes the reusable workflow at the top level
+  # (no parent job), names lack the "caller / " prefix.
+  write_meta "myenv" "g"
+  with_jobs_for caller= "myenv"  # produces bare "Terraform (myenv)"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q "Resolved 1 per-env job URL" "${TEST_DIR}/step.log"; then
+    echo "expected 1 resolved URL even with bare name"
+    return 1
+  fi
+  return 0
+}
+
+test_job_url_resolution_skips_non_matrix_jobs() {
+  # Real workflow includes 'tf / PR comment aggregator' and 'tf / Create job
+  # matrix' jobs alongside the matrix. They must not match the regex.
+  write_meta "myenv" "g"
+  cat > "${GH_FAKE_JOBS_RESPONSE_FILE}" <<'JSON'
+[
+  {"id": 1, "name": "tf / Create job matrix", "html_url": "https://example/1"},
+  {"id": 2, "name": "tf / Terraform (myenv)", "html_url": "https://example/2"},
+  {"id": 3, "name": "tf / Terraform conclusion", "html_url": "https://example/3"},
+  {"id": 4, "name": "tf / PR comment aggregator", "html_url": "https://example/4"},
+  {"id": 5, "name": "tf / PR auto merger", "html_url": "https://example/5"}
+]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q "Resolved 1 per-env job URL" "${TEST_DIR}/step.log"; then
+    echo "expected exactly 1 match (Terraform conclusion, PR comment aggregator, etc. must be filtered out)"
+    grep "Resolved\|Resolving" "${TEST_DIR}/step.log" || true
+    return 1
+  fi
+  return 0
+}
+
+test_post_pass_does_not_nest_log_groups() {
+  # GitHub Actions does not support nested log groups. Verify that no
+  # ::group:: line appears before a matching ::endgroup:: while another
+  # ::group:: is already open.
+  write_meta "envA" "dev"
+  write_meta "envB" "prod"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Walk the log; track nesting depth. If depth ever exceeds 1, fail.
+  local depth=0
+  local max_depth=0
+  while IFS= read -r line; do
+    if [[ "${line}" == "::group::"* ]]; then
+      depth=$((depth + 1))
+      if [[ ${depth} -gt ${max_depth} ]]; then max_depth=${depth}; fi
+    elif [[ "${line}" == "::endgroup::"* ]]; then
+      depth=$((depth - 1))
+    fi
+  done < "${TEST_DIR}/step.log"
+  if [[ ${max_depth} -gt 1 ]]; then
+    echo "log groups nested: max depth=${max_depth}, expected 1"
+    grep -E '^::(group|endgroup)' "${TEST_DIR}/step.log" | head -40
+    return 1
+  fi
+  return 0
+}
+
+test_per_env_anchor_picks_newest_when_duplicates() {
+  write_meta "dup" "g"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[
+  {"id": 100, "body": "### Terraform validation summary for environment: `dup`\nold"},
+  {"id": 999, "body": "### Terraform validation summary for environment: `dup`\nnewer"},
+  {"id": 500, "body": "### Terraform validation summary for environment: `dup`\nmid"}
+]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q '#issuecomment-999' "${TEST_DIR}/step.log"; then
+    echo "expected anchor to point at newest id 999"
+    return 1
+  fi
+  if ! grep -q 'duplicates' "${TEST_DIR}/step.log"; then
+    echo "expected warning about duplicates"
+    return 1
+  fi
+  return 0
+}
+
+test_status_emoji_map() {
+  # Build envs with different fmt outcomes to exercise the status map
+  write_meta "envS" "g" "success"
+  write_meta "envF" "g" "failure"
+  write_meta "envC" "g" "cancelled"
+  write_meta "envK" "g" "skipped"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  # All four emoji+title pairs must appear at least once in the Format row
+  local fmt_row
+  fmt_row=$(grep -E '^\| <span title="Format and Style"' "${log}")
+  for pair in \
+    '<span title="success">✅</span>' \
+    '<span title="failure">❌</span>' \
+    '<span title="cancelled">🚫</span>' \
+    '<span title="skipped">⏭️</span>'; do
+    if ! echo "${fmt_row}" | grep -qF "${pair}"; then
+      echo "expected '${pair}' in Format row: ${fmt_row}"
+      return 1
+    fi
+  done
+  return 0
+}
+
+test_plan_details_optional_categories() {
+  # Set non-zero move and remove for one env
+  local counts='{"count-add":"3","count-change":"2","count-destroy":"1","count-import":"0","count-move":"4","count-remove":"5"}'
+  write_meta "myenv" "g" "success" "${counts}"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  # add/change/destroy always present
+  grep -q '`💫 3` add' "${log}" || { echo "missing add badge"; return 1; }
+  grep -q '`🛠️ 2` change' "${log}" || { echo "missing change badge"; return 1; }
+  grep -q '`💥 1` destroy' "${log}" || { echo "missing destroy badge"; return 1; }
+  # move and remove non-zero -> present
+  grep -q '`🔀 4` move' "${log}" || { echo "missing move badge"; return 1; }
+  grep -q '`⛓️‍💥 5` remove' "${log}" || { echo "missing remove badge"; return 1; }
+  # import was zero -> must NOT appear
+  if grep -q '`📥 0` import' "${log}"; then
+    echo "import (count=0) must not appear"
+    return 1
+  fi
+  return 0
+}
+
+test_plan_details_left_align_div() {
+  write_meta "envA" "g"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q '<div align="left">' "${TEST_DIR}/step.log"; then
+    echo "expected Plan Details cell to wrap in <div align=\"left\">"
+    return 1
+  fi
+  return 0
+}
+
+test_group_prefix_byte_exact() {
+  write_meta "envA" "dev"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # The first line of the rendered body must be the byte-exact group prefix
+  if ! grep -q '^### Terraform validation summary for group: `dev`$' "${TEST_DIR}/step.log"; then
+    echo "expected byte-exact group prefix line"
+    return 1
+  fi
+  return 0
+}
+
+test_degraded_mode_when_list_fails() {
+  write_meta "envA" "g"
+  # Make gh list call fail
+  export GH_FAKE_LIST_EXIT=1
+  echo "boom" > "${GH_FAKE_LIST_RESPONSE_FILE}"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE} (degraded mode should still succeed overall)"; return 1; }
+  if ! grep -q 'degraded mode' "${TEST_DIR}/step.log"; then
+    echo "expected 'degraded mode' log line"
+    return 1
+  fi
+  # Delete pass must be skipped
+  if grep -q 'DELETE' "${GH_FAKE_CALL_LOG}"; then
+    echo "DELETE must NOT be called in degraded mode"
+    return 1
+  fi
+  # POST must still happen so the table renders
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
+    echo "expected 1 POST even in degraded mode"
+    return 1
+  fi
+  return 0
+}
+
+test_malformed_metadata_is_skipped() {
+  write_meta "good" "g"
+  echo "not valid json" > "${TEST_DIR}/matrix-job-meta-broken.json"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q 'Skipping malformed metadata file' "${TEST_DIR}/step.log"; then
+    echo "expected 'Skipping malformed' warning"
+    return 1
+  fi
+  # Good file should still be processed
+  if ! grep -q "Env 'good' belongs to group 'g'" "${TEST_DIR}/step.log"; then
+    echo "valid file should still be processed"
+    return 1
+  fi
+  return 0
+}
+
+test_envs_without_group_are_ignored() {
+  write_meta "in-group" "dev"
+  write_meta "no-group" ""
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Header should only have the in-group env
+  if ! grep -q '|  | Step | in-group |$' "${TEST_DIR}/step.log"; then
+    echo "header should contain only 'in-group' env"
+    grep '|  | Step |' "${TEST_DIR}/step.log"
+    return 1
+  fi
+  return 0
+}
+
+test_multiple_groups_sorted_alphabetically() {
+  write_meta "zenv" "zebra"
+  write_meta "aenv" "alpha"
+  write_meta "menv" "mike"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Three POSTs in alphabetical group order
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 3 ]]; then
+    echo "expected 3 POSTs (one per group)"
+    return 1
+  fi
+  # Per-group log group names appear in alpha order
+  local order
+  order=$(grep -oE "Step 5: Posting group '[^']+'" "${TEST_DIR}/step.log" | head -3 | tr '\n' ' ')
+  local expected="Step 5: Posting group 'alpha' Step 5: Posting group 'mike' Step 5: Posting group 'zebra' "
+  if [[ "${order}" != "${expected}" ]]; then
+    echo "groups not in alphabetical order"
+    echo "got:      ${order}"
+    echo "expected: ${expected}"
+    return 1
+  fi
+  return 0
+}
+
+test_groups_processed_json_output() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 8001, "body": "### Terraform validation summary for group: `obsolete`\n"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local processed
+  processed=$(get_processed_json)
+  # Must include both orphan-deleted and posted entries
+  if ! echo "${processed}" | jq -e '.[] | select(.action == "orphan-deleted" and .group == "obsolete")' >/dev/null; then
+    echo "expected orphan-deleted entry for 'obsolete'"
+    echo "got: ${processed}"
+    return 1
+  fi
+  if ! echo "${processed}" | jq -e '.[] | select(.action == "posted" and .group == "dev")' >/dev/null; then
+    echo "expected posted entry for 'dev'"
+    echo "got: ${processed}"
+    return 1
+  fi
+  return 0
+}
+
+test_step_row_order_byte_exact() {
+  write_meta "envA" "g"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  # Extract just the table body rows in order
+  local lines
+  lines=$(grep -oE '^\| <span title="[^"]+">' "${log}" | head -8)
+  local expected='| <span title="Initialization">
+| <span title="Lock file">
+| <span title="Format and Style">
+| <span title="Validate">
+| <span title="TFLint">
+| <span title="Plan">
+| <span title="Plan details">
+| <span title="Links">'
+  if [[ "${lines}" != "${expected}" ]]; then
+    echo "step row order mismatch"
+    echo "got:"
+    echo "${lines}"
+    echo "expected:"
+    echo "${expected}"
+    return 1
+  fi
+  return 0
+}
+
+test_missing_pr_number_fails_fast() {
+  write_meta "envA" "g"
+  unset input_pr_number
+  run_step
+  if [[ ${STEP_EXIT_CODE} -eq 0 ]]; then
+    echo "expected non-zero exit when input_pr_number missing"
+    return 1
+  fi
+  if ! grep -q 'input_pr_number is required' "${TEST_DIR}/step.log"; then
+    echo "expected 'input_pr_number is required' error"
+    return 1
+  fi
+  return 0
+}
+
+test_post_failure_recorded_without_aborting() {
+  write_meta "envA" "g"
+  export GH_FAKE_POST_EXIT=22
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE} — should not abort on post failure"; return 1; }
+  local processed
+  processed=$(get_processed_json)
+  if ! echo "${processed}" | jq -e '.[] | select(.action == "post-failed")' >/dev/null; then
+    echo "expected post-failed entry in groups-processed-json"
+    echo "got: ${processed}"
+    return 1
+  fi
+  return 0
+}
+
+# ============================================================================
+# Run tests
+# ============================================================================
+
+run_test "empty desired + empty existing is a no-op"                       test_empty_desired_empty_existing_is_noop
+run_test "sweep mode: empty desired + orphan existing → delete only"       test_sweep_only_orphans
+run_test "post mode: desired + no existing → post only"                    test_post_when_no_existing
+run_test "mixed reconcile: orphan deleted + matching reposted"             test_mixed_reconcile
+run_test "envs render in alphabetical column order"                        test_alphabetical_column_order
+run_test "per-env anchor resolved → log-extract link rendered"             test_per_env_anchor_resolved
+run_test "anchor missing + job URL resolved → Links shows only job log"    test_per_env_anchor_missing_but_job_url_resolved_shows_only_job_log
+run_test "neither anchor nor job URL → Links cell is empty"                test_neither_anchor_nor_job_url_yields_empty_cell
+run_test "both anchor + job URL resolved → both lines, <br>-joined"        test_both_anchor_and_job_url_resolved_shows_both_with_br
+run_test "Jobs API failure → 'job log' line omitted for all envs"          test_jobs_api_failure_omits_job_log_for_all_envs
+run_test "job URL resolution handles 'caller / Terraform (env)' prefix"   test_job_url_resolution_handles_caller_prefixed_name
+run_test "job URL resolution handles bare 'Terraform (env)' too"          test_job_url_resolution_handles_bare_name
+run_test "job URL resolution skips non-matrix jobs"                       test_job_url_resolution_skips_non_matrix_jobs
+run_test "post pass does NOT nest log groups"                              test_post_pass_does_not_nest_log_groups
+run_test "per-env anchor picks newest comment id when duplicates exist"    test_per_env_anchor_picks_newest_when_duplicates
+run_test "status emoji map covers success/failure/cancelled/skipped"       test_status_emoji_map
+run_test "Plan Details: optional categories appear only when non-zero"     test_plan_details_optional_categories
+run_test "Plan Details cell wraps in <div align='left'>"                   test_plan_details_left_align_div
+run_test "group prefix line is byte-exact"                                 test_group_prefix_byte_exact
+run_test "degraded mode: gh list fails → skip delete, still post"          test_degraded_mode_when_list_fails
+run_test "malformed metadata file is skipped with warning"                 test_malformed_metadata_is_skipped
+run_test "envs without pr-comment-group are ignored"                       test_envs_without_group_are_ignored
+run_test "multiple groups are posted in alphabetical order"                test_multiple_groups_sorted_alphabetically
+run_test "groups-processed-json output records every action"               test_groups_processed_json_output
+run_test "table step rows appear in spec order"                            test_step_row_order_byte_exact
+run_test "missing input_pr_number fails the step"                          test_missing_pr_number_fails_fast
+run_test "post failure does not abort, recorded in output"                 test_post_failure_recorded_without_aborting
+
+# ============================================================================
+echo ""
+echo "========================================"
+echo "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo "========================================"
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/aggregate-validation-summaries/run_local_step_aggregate.sh
+++ b/aggregate-validation-summaries/run_local_step_aggregate.sh
@@ -1,0 +1,155 @@
+#!/bin/env bash
+#
+# Local runner for step_aggregate.sh.
+# Sets up a simulated GitHub Actions environment with two fixture matrix-job-meta
+# files (one group with two envs) and a fake `gh` that records and returns canned
+# API responses. Useful for manual end-to-end smoke testing without a real PR.
+#
+
+set -e
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+TEST_DIR=$(mktemp -d)
+echo "Using test dir: ${TEST_DIR}"
+cd "${TEST_DIR}"
+
+# Fake gh binary that records calls and serves a canned list-comments
+# response. Production code uses _gh_list_pr_comments / _gh_delete_comment /
+# _gh_post_comment which thinly wrap the `gh` CLI; replacing `gh` on PATH is
+# enough to exercise the full code path.
+mkdir -p "${TEST_DIR}/bin"
+cat > "${TEST_DIR}/bin/gh" <<'FAKE_GH'
+#!/bin/bash
+LOG="${GH_FAKE_CALL_LOG:-/dev/null}"
+echo "gh $*" >> "${LOG}"
+case "$*" in
+  *"--paginate"*"/actions/runs/"*"/jobs"*)
+    # Jobs API: production code uses --jq '.jobs', so we return a flat array.
+    # Names mirror the real-world "<caller-job> / <reusable-job> (<env>)"
+    # rendering that GitHub does when this workflow is called as reusable.
+    cat <<'JOBS'
+[
+  {"id": 5001, "name": "tf / Terraform (sub-a-dev)", "html_url": "https://github.com/dsb-norge/test-repo/actions/runs/21494130907/job/5001"},
+  {"id": 5002, "name": "tf / Terraform (sub-b-dev)", "html_url": "https://github.com/dsb-norge/test-repo/actions/runs/21494130907/job/5002"},
+  {"id": 5003, "name": "tf / PR comment aggregator", "html_url": "https://github.com/dsb-norge/test-repo/actions/runs/21494130907/job/5003"}
+]
+JOBS
+    ;;
+  *"--paginate"*"/comments")
+    cat <<'COMMENTS'
+[
+  {"id": 100, "body": "### Terraform validation summary for group: `legacy-group`\nold body\n"},
+  {"id": 200, "body": "### Terraform validation summary for environment: `sub-a-dev`\nplan content\n"},
+  {"id": 201, "body": "### Terraform validation summary for environment: `sub-b-dev`\nplan content\n"}
+]
+COMMENTS
+    ;;
+  *"-X DELETE"*)
+    echo '{"deleted": true}'
+    ;;
+  *"-X POST"*)
+    echo "9999"
+    ;;
+esac
+FAKE_GH
+chmod +x "${TEST_DIR}/bin/gh"
+export PATH="${TEST_DIR}/bin:${PATH}"
+export GH_FAKE_CALL_LOG="${TEST_DIR}/gh-calls.log"
+: > "${GH_FAKE_CALL_LOG}"
+
+# Two matrix-job-meta fixture files, both in the same group 'dev'.
+cat > matrix-job-meta-sub-a-dev.json <<'JSON'
+{
+  "metadata": {"environment": "sub-a-dev", "captured_at": "2026-01-30T12:28:54Z", "schema_version": "2.0.0"},
+  "workflow": {
+    "run_id": "21494130907", "run_number": "102", "run_attempt": "1",
+    "workflow_name": "Terraform CI", "job_name": "terraform-ci-cd",
+    "actor": "peder", "event_name": "pull_request",
+    "ref": "refs/pull/295/merge", "sha": "abc123"
+  },
+  "matrix_context": {
+    "environment": "sub-a-dev",
+    "vars": {"environment": "sub-a-dev", "pr-comment-group": "dev"}
+  },
+  "github_context": {"actor": "peder"},
+  "steps": {
+    "init":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "verify-lock": {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "fmt":         {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "validate":    {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "lint":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "plan":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "parse-plan":  {"outcome": "success", "conclusion": "success",
+                    "outputs": {"count-add": "0", "count-change": "0", "count-destroy": "0",
+                                "count-import": "0", "count-move": "0", "count-remove": "0"}}
+  }
+}
+JSON
+
+cat > matrix-job-meta-sub-b-dev.json <<'JSON'
+{
+  "metadata": {"environment": "sub-b-dev", "captured_at": "2026-01-30T12:28:54Z", "schema_version": "2.0.0"},
+  "workflow": {
+    "run_id": "21494130907", "run_number": "102", "run_attempt": "1",
+    "workflow_name": "Terraform CI", "job_name": "terraform-ci-cd",
+    "actor": "peder", "event_name": "pull_request",
+    "ref": "refs/pull/295/merge", "sha": "abc123"
+  },
+  "matrix_context": {
+    "environment": "sub-b-dev",
+    "vars": {"environment": "sub-b-dev", "pr-comment-group": "dev"}
+  },
+  "github_context": {"actor": "peder"},
+  "steps": {
+    "init":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "verify-lock": {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "fmt":         {"outcome": "failure", "conclusion": "failure", "outputs": {}},
+    "validate":    {"outcome": "skipped", "conclusion": "skipped", "outputs": {}},
+    "lint":        {"outcome": "skipped", "conclusion": "skipped", "outputs": {}},
+    "plan":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "parse-plan":  {"outcome": "success", "conclusion": "success",
+                    "outputs": {"count-add": "1", "count-change": "0", "count-destroy": "0",
+                                "count-import": "2", "count-move": "0", "count-remove": "0"}}
+  }
+}
+JSON
+
+# Standard GitHub Actions environment plumbing
+export GITHUB_OUTPUT=$(mktemp)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${TEST_DIR}"
+export GITHUB_REPOSITORY="dsb-norge/test-repo"
+export GITHUB_SERVER_URL="https://github.com"
+export GITHUB_RUN_ID="21494130907"
+export GITHUB_WORKFLOW="Terraform CI"
+export GITHUB_ACTOR="peder"
+export GITHUB_EVENT_NAME="pull_request"
+export GH_TOKEN="fake-token"
+
+export input_metadata_files_pattern="matrix-job-meta-*.json"
+export input_pr_number="295"
+
+echo ""
+echo "============================================================"
+echo "Running step_aggregate.sh..."
+echo "============================================================"
+
+set -o allexport
+source "${_this_script_dir}/step_aggregate.sh"
+set +o allexport
+
+echo ""
+echo "============================================================"
+echo "GITHUB_OUTPUT contents:"
+echo "============================================================"
+cat "${GITHUB_OUTPUT}"
+
+echo ""
+echo "============================================================"
+echo "gh calls recorded:"
+echo "============================================================"
+cat "${GH_FAKE_CALL_LOG}"
+
+# Cleanup
+rm -rf "${TEST_DIR}"

--- a/aggregate-validation-summaries/step_aggregate.sh
+++ b/aggregate-validation-summaries/step_aggregate.sh
@@ -1,0 +1,557 @@
+#!/bin/env bash
+#
+# Source for the aggregate step.
+#
+# Reconciles per-group PR comments according to the desired set computed
+# from matrix-job-meta-*.json artifacts. See docs/Workflow-pr-comments.md
+# §4.6 for the full algorithm.
+#
+# Required environment variables:
+#   input_metadata_files_pattern  - Glob for downloaded artifacts
+#                                   (e.g. "matrix-job-meta-*.json")
+#   input_pr_number               - The PR number to act on
+#   GITHUB_REPOSITORY             - "owner/repo" (set by GitHub Actions)
+#   GITHUB_SERVER_URL             - "https://github.com" (set by GitHub Actions)
+#   GITHUB_RUN_ID                 - Workflow run ID (set by GitHub Actions)
+#   GITHUB_WORKFLOW               - Workflow display name (set by GitHub Actions)
+#   GITHUB_ACTOR                  - The actor who triggered the run
+#   GITHUB_EVENT_NAME             - The event that triggered the run
+#   GH_TOKEN  (or GITHUB_TOKEN)   - Token used by the `gh` CLI for api calls
+#
+
+# Allow unset variables so we can do graceful fallback for optional inputs.
+set +o nounset
+
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+# ============================================================================
+# State (filled in by main; module-level for testability)
+# ============================================================================
+
+# desired_groups[group_name]="env1\nenv2\n..." — newline-delimited list of envs
+declare -gA DESIRED_GROUPS=()
+
+# desired_meta[<group_name>/<env_name>]="<absolute path to metadata file>"
+declare -gA DESIRED_META=()
+
+# existing_group_comments[group_name]="<comment_id>" — one entry per
+# currently-on-PR group comment that matches our family prefix
+declare -gA EXISTING_GROUP_COMMENTS=()
+
+# per_env_anchor[env_name]="#issuecomment-<id>" — resolved at step 2,
+# used to build the Links row's `log extract` lines. Missing entries mean
+# the env has no per-env comment posted yet; the Links cell drops the line.
+declare -gA PER_ENV_ANCHOR=()
+
+# per_env_job_url[env_name]="https://github.com/.../actions/runs/<run_id>/job/<check_run_id>#logs"
+# Resolved at step 2 via the Jobs API (gh api .../runs/<id>/jobs). Missing
+# entries mean the env's matrix job couldn't be matched by name; the Links
+# cell drops the `job log` line in that case rather than emit a wrong link.
+declare -gA PER_ENV_JOB_URL=()
+
+# Tracks degraded mode (gh api list failed). When true, reconcile (delete
+# pass) is skipped — the rendered bodies are still posted so the grouped
+# table is always visible.
+DEGRADED_MODE="false"
+
+# Tracks each group processed for the groups-processed-json output.
+PROCESSED_RESULTS_JSON='[]'
+
+# ============================================================================
+# Step 1: Build desired set from artifacts
+# ============================================================================
+
+function build_desired_set {
+  start-group "Step 1: Build desired set from metadata files"
+
+  shopt -s nullglob
+  local files=(${input_metadata_files_pattern})
+  shopt -u nullglob
+
+  if [ ${#files[@]} -eq 0 ]; then
+    log-info "No metadata files matched '${input_metadata_files_pattern}'."
+    log-info "Empty desired set — will run in sweep-only mode (still need to clean up any orphans)."
+    end-group
+    return 0
+  fi
+
+  log-info "Found ${#files[@]} metadata file(s)."
+
+  local file env group
+  for file in "${files[@]}"; do
+    if ! jq -e '.' "${file}" >/dev/null 2>&1; then
+      log-warn "Skipping malformed metadata file: ${file}"
+      continue
+    fi
+
+    env=$(jq -r '.metadata.environment // empty' "${file}")
+    group=$(jq -r '.matrix_context.vars["pr-comment-group"] // empty' "${file}")
+
+    if [ -z "${env}" ]; then
+      log-warn "Skipping ${file}: no .metadata.environment"
+      continue
+    fi
+
+    if [ -z "${group}" ] || [ "${group}" = "null" ]; then
+      log-debug "Env '${env}' has no pr-comment-group — not part of any desired group"
+      continue
+    fi
+
+    log-info "Env '${env}' belongs to group '${group}'"
+
+    # Append env to the group's list, store its metadata file path.
+    if [ -n "${DESIRED_GROUPS[${group}]:-}" ]; then
+      DESIRED_GROUPS[${group}]+=$'\n'"${env}"
+    else
+      DESIRED_GROUPS[${group}]="${env}"
+    fi
+    DESIRED_META["${group}/${env}"]="${file}"
+  done
+
+  if [ ${#DESIRED_GROUPS[@]} -eq 0 ]; then
+    log-info "No envs declared a pr-comment-group — desired set is empty"
+  else
+    log-info "Desired set: ${#DESIRED_GROUPS[@]} group(s)"
+    local g
+    for g in "${!DESIRED_GROUPS[@]}"; do
+      log-info "  group '${g}': $(echo "${DESIRED_GROUPS[${g}]}" | tr '\n' ',' | sed 's/,$//')"
+    done
+  fi
+
+  end-group
+}
+
+# ============================================================================
+# Step 2 helpers: resolve per-env matrix job URLs
+# ============================================================================
+
+# Queries the GitHub Jobs API for the current workflow run and builds a map
+# of <env-name> → <job html_url + #logs anchor>. Matrix jobs in the
+# terraform-ci-cd reusable workflow have GitHub-rendered name format
+# `Terraform (<env>)`; we parse the env name out of that pattern.
+#
+# Best-effort: if the API call fails or the regex doesn't match, the env
+# is simply omitted from PER_ENV_JOB_URL and the Links cell will drop the
+# `job log` line for that env rather than render a wrong URL.
+function _resolve_per_env_job_urls {
+  local run_id="${GITHUB_RUN_ID:-}"
+  if [ -z "${run_id}" ]; then
+    log-warn "GITHUB_RUN_ID not set — cannot resolve per-env matrix job URLs"
+    return 0
+  fi
+
+  local jobs_raw
+  if ! jobs_raw=$(_gh_list_run_jobs "${GITHUB_REPOSITORY}" "${run_id}" 2>&1); then
+    log-warn "Failed to list run jobs (id=${run_id}): ${jobs_raw}"
+    log-warn "Links row will omit the 'job log' line for all envs."
+    return 0
+  fi
+
+  # _gh_list_run_jobs uses --paginate with --jq '.jobs', so multi-page
+  # output is one JSON array per page. jq -s flattens these.
+  local all_jobs
+  if ! all_jobs=$(echo "${jobs_raw}" | jq -s 'add // []' 2>/dev/null); then
+    log-warn "Failed to parse jobs JSON; Links row will omit 'job log' for all envs."
+    return 0
+  fi
+
+  local total
+  total=$(echo "${all_jobs}" | jq 'length')
+  log-info "Resolving per-env job URLs from ${total} job record(s) in run ${run_id}..."
+
+  local line name html_url env
+  while IFS=$'\t' read -r name html_url; do
+    [ -z "${name}" ] && continue
+    # Matrix job names rendered by GitHub as "<job_name> (<matrix_value>)".
+    # When this reusable workflow is called from another workflow, the
+    # caller's job name is prepended (e.g. "tf / Terraform (dsb-norge)"),
+    # so the regex is NOT anchored at start — only at end, so the trailing
+    # "(<env>)" capture is unambiguous.
+    if [[ "${name}" =~ Terraform[[:space:]]\((.+)\)$ ]]; then
+      env="${BASH_REMATCH[1]}"
+      PER_ENV_JOB_URL[${env}]="${html_url}#logs"
+      log-debug "  env '${env}' → ${PER_ENV_JOB_URL[${env}]}"
+    fi
+  done < <(echo "${all_jobs}" | jq -r '.[] | "\(.name)\t\(.html_url)"' 2>/dev/null)
+
+  log-info "Resolved ${#PER_ENV_JOB_URL[@]} per-env job URL(s)."
+}
+
+# ============================================================================
+# Step 2: List existing PR state
+# ============================================================================
+
+function list_pr_state {
+  start-group "Step 2: List existing PR comments and matrix job URLs"
+
+  # Resolve per-env matrix job URLs first (independent of PR comment listing —
+  # if comments listing fails we still want best-effort job URLs for the
+  # Links row's `job log` line).
+  _resolve_per_env_job_urls
+
+  local comments_json
+  if ! comments_json=$(_gh_list_pr_comments "${GITHUB_REPOSITORY}" "${input_pr_number}" 2>&1); then
+    log-warn "Failed to list PR comments: ${comments_json}"
+    log-warn "Entering degraded mode — reconcile (delete pass) skipped; will still post fresh bodies."
+    DEGRADED_MODE="true"
+    end-group
+    return 0
+  fi
+
+  # When --paginate returns multiple pages concatenated, the result may be
+  # multiple separate JSON arrays. Combine via jq -s 'add' to get a single
+  # flat array regardless.
+  local normalized
+  if ! normalized=$(echo "${comments_json}" | jq -s 'add // []' 2>/dev/null); then
+    log-warn "Failed to normalize PR comments JSON — entering degraded mode"
+    DEGRADED_MODE="true"
+    end-group
+    return 0
+  fi
+
+  local total
+  total=$(echo "${normalized}" | jq 'length')
+  log-info "PR has ${total} comment(s) total."
+
+  # Extract existing group comments (family prefix match).
+  # Output one line per match: "<comment_id>\t<group_name>"
+  # Group name is parsed out of the body's first line by stripping the family
+  # prefix and the surrounding backticks.
+  local group_lines
+  group_lines=$(echo "${normalized}" \
+    | jq -r --arg fam "${GROUP_COMMENT_FAMILY_PREFIX}" '
+        .[]
+        | select(.body | startswith($fam))
+        | .id as $id
+        | (.body | split("\n")[0] | sub($fam; "") | sub("^`"; "") | sub("`.*$"; "")) as $g
+        | "\($id)\t\($g)"
+      ' 2>/dev/null) || group_lines=""
+
+  if [ -n "${group_lines}" ]; then
+    local line cid gname
+    while IFS=$'\t' read -r cid gname; do
+      [ -z "${cid}" ] && continue
+      EXISTING_GROUP_COMMENTS[${gname}]="${cid}"
+      log-info "  existing group comment: '${gname}' (id=${cid})"
+    done <<<"${group_lines}"
+  else
+    log-info "  no existing group comments on PR"
+  fi
+
+  # Build per-env anchor map. For each env in any desired group, look for a
+  # comment whose body starts with the env's exact per-env prefix. If 2+
+  # match (rare; should self-heal via comment-on-pr@v2's delete-by-prefix on
+  # the next per-env run), pick the comment with the highest numeric id
+  # (newest, GitHub IDs are monotonic) and log a warning.
+  local group env
+  for group in "${!DESIRED_GROUPS[@]}"; do
+    while IFS= read -r env; do
+      [ -z "${env}" ] && continue
+      local per_env_prefix
+      per_env_prefix=$(_per_env_prefix "${env}")
+
+      local matched_ids
+      matched_ids=$(echo "${normalized}" \
+        | jq -r --arg p "${per_env_prefix}" '.[] | select(.body | startswith($p)) | .id' \
+          2>/dev/null) || matched_ids=""
+
+      # Count lines safely: grep -c returns exit 1 with no matches which
+      # would otherwise trigger a fallback that appends a stray "0".
+      local count=0
+      if [ -n "${matched_ids}" ]; then
+        count=$(echo "${matched_ids}" | wc -l | tr -d ' ')
+      fi
+
+      if [ "${count}" = "0" ]; then
+        log-debug "  env '${env}': no per-env comment posted — Links cell will show only job log"
+      elif [ "${count}" = "1" ]; then
+        PER_ENV_ANCHOR[${env}]="#issuecomment-${matched_ids}"
+        log-info "  env '${env}': resolved log-extract anchor to ${PER_ENV_ANCHOR[${env}]}"
+      else
+        local newest
+        newest=$(echo "${matched_ids}" | sort -nr | head -n1)
+        PER_ENV_ANCHOR[${env}]="#issuecomment-${newest}"
+        log-warn "  env '${env}': ${count} per-env comments match (race / stale duplicates); using newest id=${newest}"
+      fi
+    done <<<"${DESIRED_GROUPS[${group}]}"
+  done
+
+  end-group
+}
+
+# ============================================================================
+# Step 3: Render one group's comment body
+# ============================================================================
+
+# Renders the full body for one group. Writes to stdout.
+# Args:
+#   $1  - group name
+#   $2  - newline-delimited list of envs (already alphabetically sorted)
+function render_group_body {
+  local group_name="${1}"
+  local envs_nl="${2}"
+  local prefix
+  prefix=$(_group_prefix "${group_name}")
+
+  local -a envs=()
+  while IFS= read -r e; do
+    [ -n "${e}" ] && envs+=("${e}")
+  done <<<"${envs_nl}"
+
+  # ---- Header row: "|  | Step | env1 | env2 | ... |" ----
+  local header="|  | Step |"
+  local sep="|:---:|---|"
+  local env
+  for env in "${envs[@]}"; do
+    header+=" ${env} |"
+    sep+=":---:|"
+  done
+
+  # ---- Step rows ----
+  local rows=""
+  local row_def step_id emoji label
+  for row_def in "${GROUPED_TABLE_STEP_ROWS[@]}"; do
+    step_id="${row_def%%|*}"
+    local rest="${row_def#*|}"
+    emoji="${rest%%|*}"
+    label="${rest##*|}"
+
+    local row="| $(_render_step_icon_cell "${emoji}" "${label}") | ${label} |"
+    for env in "${envs[@]}"; do
+      local outcome
+      outcome=$(_extract_step_outcome "${group_name}" "${env}" "${step_id}")
+      row+=" $(_render_status_cell "${outcome}") |"
+    done
+    rows+="${row}"$'\n'
+  done
+
+  # ---- Plan Details row ----
+  local plan_details_row="| $(_render_step_icon_cell "📊" "Plan details") | Plan details |"
+  for env in "${envs[@]}"; do
+    local meta_file="${DESIRED_META[${group_name}/${env}]:-}"
+    local c_add c_change c_destroy c_import c_move c_remove
+    c_add=$(_extract_plan_count "${meta_file}" "count-add")
+    c_change=$(_extract_plan_count "${meta_file}" "count-change")
+    c_destroy=$(_extract_plan_count "${meta_file}" "count-destroy")
+    c_import=$(_extract_plan_count "${meta_file}" "count-import")
+    c_move=$(_extract_plan_count "${meta_file}" "count-move")
+    c_remove=$(_extract_plan_count "${meta_file}" "count-remove")
+    plan_details_row+=" $(_render_plan_details_cell "${c_add}" "${c_change}" "${c_destroy}" "${c_import}" "${c_move}" "${c_remove}") |"
+  done
+
+  # ---- Links row ----
+  local links_row="| $(_render_step_icon_cell "🔗" "Links") | Links |"
+  for env in "${envs[@]}"; do
+    # Resolved per-env job URL (Jobs API, step 2). Empty when not resolvable;
+    # _render_links_cell drops the line in that case (we don't emit wrong URLs).
+    local job_log_url="${PER_ENV_JOB_URL[${env}]:-}"
+    local anchor="${PER_ENV_ANCHOR[${env}]:-}"
+    links_row+=" $(_render_links_cell "${anchor}" "${job_log_url}") |"
+  done
+
+  # ---- Footer ----
+  local first_env_meta_file
+  first_env_meta_file=$(_first_meta_file_for_group "${group_name}")
+  local footer
+  footer=$(_render_footer "${first_env_meta_file}")
+
+  # ---- Assembly ----
+  printf '%s\n%s\n%s\n%s%s\n%s\n\n%s\n' \
+    "${prefix}" \
+    "${header}" \
+    "${sep}" \
+    "${rows}" \
+    "${plan_details_row}" \
+    "${links_row}" \
+    "${footer}"
+}
+
+# ----------------------------------------------------------------------------
+# Render helpers (private)
+# ----------------------------------------------------------------------------
+
+# Extract step outcome from a matrix-job-meta file. Returns "" if step not present.
+function _extract_step_outcome {
+  local group="${1}" env="${2}" step_id="${3}"
+  local file="${DESIRED_META[${group}/${env}]:-}"
+  [ -z "${file}" ] || [ ! -f "${file}" ] && { echo ""; return; }
+  jq -r --arg s "${step_id}" '.steps[$s].outcome // ""' "${file}" 2>/dev/null || echo ""
+}
+
+# Extract a single plan count from a metadata file. Empty when parse-plan
+# either didn't run or its output is missing the field.
+function _extract_plan_count {
+  local file="${1}" key="${2}"
+  [ -z "${file}" ] || [ ! -f "${file}" ] && { echo ""; return; }
+  local val
+  val=$(jq -r --arg k "${key}" '.steps["parse-plan"].outputs[$k] // ""' "${file}" 2>/dev/null || echo "")
+  [ "${val}" = "null" ] && val=""
+  echo "${val}"
+}
+
+# Pick any one metadata file from a group (for sourcing actor/event/workflow
+# in the footer — they're the same across the run).
+function _first_meta_file_for_group {
+  local group="${1}"
+  local first_env
+  first_env=$(echo "${DESIRED_GROUPS[${group}]}" | head -n1)
+  echo "${DESIRED_META[${group}/${first_env}]:-}"
+}
+
+# Render the footer line. Mirrors create-validation-summary's footer
+# (docs/Workflow-pr-comments.md §3.1).
+function _render_footer {
+  local file="${1}"
+  local actor event workflow run_id
+  if [ -n "${file}" ] && [ -f "${file}" ]; then
+    actor=$(jq -r '.workflow.actor // ""' "${file}")
+    event=$(jq -r '.workflow.event_name // ""' "${file}")
+    workflow=$(jq -r '.workflow.workflow_name // ""' "${file}")
+    run_id=$(jq -r '.workflow.run_id // ""' "${file}")
+  fi
+  # Fallback to env vars so the action still runs in degraded artifact states.
+  actor="${actor:-${GITHUB_ACTOR:-unknown}}"
+  event="${event:-${GITHUB_EVENT_NAME:-unknown}}"
+  workflow="${workflow:-${GITHUB_WORKFLOW:-unknown}}"
+  run_id="${run_id:-${GITHUB_RUN_ID:-0}}"
+
+  local run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+  echo "*Pusher: @${actor}, Action: \`${event}\`, Workflow: \`${workflow}\`, Job log: [link](${run_url})*"
+}
+
+# ============================================================================
+# Step 4: Reconcile (delete pass)
+# ============================================================================
+
+function reconcile_delete_pass {
+  start-group "Step 4: Reconcile — delete pass"
+
+  if [ "${DEGRADED_MODE}" = "true" ]; then
+    log-warn "Degraded mode — skipping delete pass."
+    end-group
+    return 0
+  fi
+
+  if [ ${#EXISTING_GROUP_COMMENTS[@]} -eq 0 ]; then
+    log-info "No existing group comments — nothing to delete."
+    end-group
+    return 0
+  fi
+
+  local existing_group existing_id action
+  for existing_group in "${!EXISTING_GROUP_COMMENTS[@]}"; do
+    existing_id="${EXISTING_GROUP_COMMENTS[${existing_group}]}"
+    if [ -n "${DESIRED_GROUPS[${existing_group}]:-}" ]; then
+      action="repost"
+      log-info "  deleting existing group comment '${existing_group}' (id=${existing_id}) — will be reposted"
+    else
+      action="orphan-deleted"
+      log-info "  deleting orphan group comment '${existing_group}' (id=${existing_id}) — not in desired set"
+    fi
+
+    if _gh_delete_comment "${GITHUB_REPOSITORY}" "${existing_id}" >/dev/null 2>&1; then
+      _record_processed "${existing_group}" "${existing_id}" "${action}"
+    else
+      log-warn "  failed to delete comment id=${existing_id} (group '${existing_group}') — continuing"
+    fi
+  done
+
+  end-group
+}
+
+# ============================================================================
+# Step 5: Post pass
+# ============================================================================
+
+function post_pass {
+  # NOTE: one log group per group processed — no outer wrapper. GitHub Actions
+  # does not support nested log groups; the prior structure ('Step 5' outer
+  # group containing per-group 'Body for...' sub-groups) rendered confusingly
+  # in the runner log UI.
+
+  if [ ${#DESIRED_GROUPS[@]} -eq 0 ]; then
+    log-info "Step 5: Post fresh group comments — no desired groups, nothing to post."
+    return 0
+  fi
+
+  log-info "Step 5: Post fresh group comments (${#DESIRED_GROUPS[@]} group(s))"
+
+  # Sort group names for deterministic output ordering.
+  local -a sorted_groups=()
+  while IFS= read -r g; do sorted_groups+=("${g}"); done < <(printf '%s\n' "${!DESIRED_GROUPS[@]}" | sort)
+
+  local group envs_sorted body body_file new_id
+  for group in "${sorted_groups[@]}"; do
+    start-group "Step 5: Posting group '${group}'"
+
+    # Sort envs alphabetically within the group (docs/Workflow-pr-comments.md §4.2)
+    envs_sorted=$(echo "${DESIRED_GROUPS[${group}]}" | sort)
+    log-info "Rendering (envs: $(echo "${envs_sorted}" | tr '\n' ',' | sed 's/,$//'))"
+
+    body=$(render_group_body "${group}" "${envs_sorted}")
+    body_file=$(mktemp)
+    printf '%s' "${body}" >"${body_file}"
+
+    log-info "Body:"
+    echo "${body}"
+
+    if new_id=$(_gh_post_comment "${GITHUB_REPOSITORY}" "${input_pr_number}" "${body_file}" 2>&1); then
+      log-info "posted: comment id=${new_id}"
+      _record_processed "${group}" "${new_id}" "posted"
+    else
+      log-warn "failed to post comment for group '${group}': ${new_id}"
+      _record_processed "${group}" "0" "post-failed"
+    fi
+
+    rm -f "${body_file}"
+    end-group
+  done
+}
+
+# ============================================================================
+# Output helpers
+# ============================================================================
+
+function _record_processed {
+  local group="${1}" comment_id="${2}" action="${3}"
+  PROCESSED_RESULTS_JSON=$(echo "${PROCESSED_RESULTS_JSON}" | jq \
+    --arg g "${group}" --arg id "${comment_id}" --arg a "${action}" \
+    '. + [{"group": $g, "comment-id": $id, "action": $a}]')
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+function main {
+  log-info "Starting aggregate-validation-summaries..."
+  log-info "Pattern:    ${input_metadata_files_pattern:-<unset>}"
+  log-info "PR number:  ${input_pr_number:-<unset>}"
+  log-info "Repository: ${GITHUB_REPOSITORY:-<unset>}"
+
+  if [ -z "${input_pr_number:-}" ]; then
+    log-error "input_pr_number is required"
+    return 1
+  fi
+  if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+    log-error "GITHUB_REPOSITORY is required (set by GitHub Actions)"
+    return 1
+  fi
+
+  build_desired_set
+  list_pr_state
+  reconcile_delete_pass
+  post_pass
+
+  set-multiline-output "groups-processed-json" "${PROCESSED_RESULTS_JSON}"
+  log-info "Done. Processed ${#DESIRED_GROUPS[@]} group(s)."
+  return 0
+}
+
+main
+_main_exit_code=$?
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  return ${_main_exit_code}
+else
+  exit ${_main_exit_code}
+fi

--- a/create-tf-vars-matrix/action.yml
+++ b/create-tf-vars-matrix/action.yml
@@ -231,6 +231,7 @@ runs:
           pr-auto-merge-enabled
           pr-auto-merge-from-actors
           pr-auto-merge-limits
+          pr-comment-group
           project-dir
           terraform-init-additional-dirs
           terraform-version

--- a/create-tf-vars-matrix/test_data/test_input_fail_yml_spec_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_fail_yml_spec_inputs-json.json
@@ -6,5 +6,6 @@
   "terraform-version": "latest",
   "tflint-version": "latest",
   "add-pr-comment": "true",
-  "verify-lock-file": "true"
+  "verify-lock-file": "true",
+  "pr-comment-group": ""
 }

--- a/create-tf-vars-matrix/test_data/test_input_happy_day_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_happy_day_inputs-json.json
@@ -1,5 +1,5 @@
 {
-  "environments-yml": "- environment: \"my-first-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  format-check-in-root-dir: false\n  terraform-init-additional-dirs-yml:\n    - \"./main\"\n    - \"./modules\"\n  goals-yml: [all, destroy-plan, destroy, apply-on-pr, destroy-plan-on-pr, destroy-on-pr]\n- environment: \"my-second-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n- environment: \"also an env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  goals-yml: [init, format, validate, lint]\n",
+  "environments-yml": "- environment: \"my-first-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  format-check-in-root-dir: false\n  pr-comment-group: \"dev\"\n  terraform-init-additional-dirs-yml:\n    - \"./main\"\n    - \"./modules\"\n  goals-yml: [all, destroy-plan, destroy, apply-on-pr, destroy-plan-on-pr, destroy-on-pr]\n- environment: \"my-second-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  pr-comment-group: \"dev\"\n- environment: \"also an env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  goals-yml: [init, format, validate, lint]\n",
   "goals-yml": "[all, dummy, apple]",
   "extra-envs-from-secrets-yml": "ARM_CLIENT_ID: ARM_CLIENT_ID_secret\nARM_SUBSCRIPTION_ID: ARM_SUBSCRIPTION_ID_secret\nARM_TENANT_ID: ARM_TENANT_ID_secret\nTF_VAR_my_custom: TF_VAR_my_custom_secret\n",
   "extra-envs-yml": "ARM_USE_OIDC: true\nARM_USE_AZUREAD: true\nANOTHER_ENV: \"1 2 3\"",
@@ -8,5 +8,6 @@
   "terraform-init-additional-dirs-yml": "- \"./main\"\n- \"./module/1\"\n- \"./module/2\"\n",
   "format-check-in-root-dir": "true",
   "add-pr-comment": "true",
-  "verify-lock-file": "true"
+  "verify-lock-file": "true",
+  "pr-comment-group": ""
 }

--- a/create-tf-vars-matrix/test_data/test_input_minimal_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_minimal_inputs-json.json
@@ -6,5 +6,6 @@
   "terraform-version": "latest",
   "tflint-version": "latest",
   "add-pr-comment": "true",
-  "verify-lock-file": "true"
+  "verify-lock-file": "true",
+  "pr-comment-group": ""
 }

--- a/create-validation-summary/action.yml
+++ b/create-validation-summary/action.yml
@@ -32,6 +32,16 @@ inputs:
   status-plan:
     description: Outcome of plan step.
     required: true
+  pr-comment-group:
+    description: |
+      Name of the comment group this environment belongs to. When non-empty:
+        - The validation table is omitted from the per-env comment body (it appears
+          in the per-group comment posted by aggregate-validation-summaries instead).
+        - A short "Part of group `<name>`" note is prepended above the plan extract.
+      The comment prefix is unchanged regardless of this value — see
+      docs/Workflow-pr-comments.md §6.2 (prefix continuity invariant).
+    required: false
+    default: ""
   include-plan-details:
     description: Whether to include plan details in the summary.
     required: false
@@ -82,6 +92,7 @@ runs:
         input_status_validate: ${{ inputs.status-validate }}
         input_status_lint: ${{ inputs.status-lint }}
         input_status_plan: ${{ inputs.status-plan }}
+        input_pr_comment_group: ${{ inputs.pr-comment-group }}
         input_include_plan_details: ${{ inputs.include-plan-details }}
         input_plan_count_add: ${{ inputs.plan-count-add }}
         input_plan_count_change: ${{ inputs.plan-count-change }}

--- a/create-validation-summary/run_all_tests.sh
+++ b/create-validation-summary/run_all_tests.sh
@@ -538,6 +538,343 @@ export input_status_verify_lock="failure"
 run_test "Lock file row renders failure with <kbd>" assert_lock_row_failure
 
 # --------------------------------------------------
+# Backwards-compatibility tests for ungrouped per-env comment shape.
+# These tests pin down the EXACT byte-level output of the historical
+# (ungrouped) per-env comment. They are the contract enforced by
+# docs/Workflow-pr-comments.md §6.1 ("Default-mode shape unchanged")
+# — any future change to comment rendering that breaks one of these
+# tests breaks the backwards-compat contract.
+# --------------------------------------------------
+
+# Test 13: Prefix is exactly "### Terraform validation summary for environment: `<env>`"
+assert_prefix_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected='### Terraform validation summary for environment: `dev`'
+  if [[ "${prefix}" != "${expected}" ]]; then
+    echo "  prefix: byte-exact mismatch"
+    echo "    expected: ${expected}"
+    echo "    actual:   ${prefix}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+run_test "Prefix is byte-exact '### Terraform validation summary for environment: \`<env>\`'" assert_prefix_byte_exact
+
+# Test 14: Full body byte-exact for the canonical all-success-no-plan scenario.
+# This is the strongest backwards-compat assert: any change to the
+# rendered output breaks this test immediately.
+assert_full_body_golden_all_success_no_plan() {
+  local prefix="${1}"
+  local summary="${2}"
+  # don't touch the indentation / newlines in the heredoc below
+  local expected
+  expected=$(cat <<'EOF'
+### Terraform validation summary for environment: `dev`
+|  | Step | Result |
+|:---:|---|---|
+| ⚙️ | Initialization | `success` |
+| 🔒 | Lock file | `success` |
+| 🖌 | Format and Style | `success` |
+| ✔ | Validate | `success` |
+| 🧹 | TFLint | `success` |
+| 📖 | Plan | `success` |
+
+Plan not available 🤷‍♀️
+
+*Pusher: @test-user, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs)*
+EOF
+)
+  if [[ "${summary}" != "${expected}" ]]; then
+    echo "  summary: byte-exact mismatch (diff below)"
+    diff <(echo "${expected}") <(echo "${summary}") | sed 's/^/    /'
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+run_test "Golden full body — all success, no plan details, no plan file" assert_full_body_golden_all_success_no_plan
+
+# Test 15: Every standard row's emoji+label is byte-exact (locks against accidental edits)
+assert_all_row_labels_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  local rows=(
+    "| ⚙️ | Initialization | "
+    "| 🔒 | Lock file | "
+    "| 🖌 | Format and Style | "
+    "| ✔ | Validate | "
+    "| 🧹 | TFLint | "
+    "| 📖 | Plan | "
+  )
+  for row in "${rows[@]}"; do
+    if [[ "${summary}" != *"${row}"* ]]; then
+      fails+="  summary: missing byte-exact row prefix '${row}'\n"
+    fi
+  done
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+run_test "Every standard row's emoji+label is byte-exact" assert_all_row_labels_byte_exact
+
+# Test 16: Table header line and alignment line are byte-exact
+assert_table_header_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  if [[ "${summary}" != *$'|  | Step | Result |\n|:---:|---|---|'* ]]; then
+    fails+="  summary: expected exact header lines '|  | Step | Result |' followed by '|:---:|---|---|'\n"
+  fi
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+run_test "Table header and alignment line are byte-exact" assert_table_header_byte_exact
+
+# Test 17: Plan Details row uses the documented <span title="..."> badge format
+assert_plan_details_row_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  local expected='| 📊 | Plan Details | <span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span> |'
+  if [[ "${summary}" != *"${expected}"* ]]; then
+    fails+="  summary: Plan Details row not byte-exact\n"
+    fails+="    expected substring: ${expected}\n"
+  fi
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_include_plan_details="true"
+run_test "Plan Details row badges are byte-exact <span title=...> shape" assert_plan_details_row_byte_exact
+
+# Test 18: Plan Details with non-zero move/import/remove appends exact <br>… badge lines
+assert_plan_details_extras_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  local expected_move='<br><span title="Resources to be moved">`🔀 2` move</span>'
+  local expected_import='<br><span title="Resources to be imported">`📥 1` import</span>'
+  local expected_remove='<br><span title="Resources to be removed">`⛓️‍💥 3` remove</span>'
+  if [[ "${summary}" != *"${expected_move}"* ]]; then
+    fails+="  summary: move badge byte-exact mismatch\n"
+  fi
+  if [[ "${summary}" != *"${expected_import}"* ]]; then
+    fails+="  summary: import badge byte-exact mismatch\n"
+  fi
+  if [[ "${summary}" != *"${expected_remove}"* ]]; then
+    fails+="  summary: remove badge byte-exact mismatch\n"
+  fi
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_include_plan_details="true"
+export input_plan_count_move="2"
+export input_plan_count_import="1"
+export input_plan_count_remove="3"
+run_test "Plan Details optional badges (move/import/remove) byte-exact" assert_plan_details_extras_byte_exact
+
+# Test 19: <details>/<summary> heading line is byte-exact
+assert_details_heading_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected='<details><summary>Show Plan (last 65k characters)</summary>'
+  if [[ "${summary}" != *"${expected}"* ]]; then
+    echo "  summary: expected exact '<details><summary>...' heading"
+    return 1
+  fi
+  # also lock the terraform code fence language tag
+  if [[ "${summary}" != *'```terraform'* ]]; then
+    echo "  summary: expected '\`\`\`terraform' code fence language tag"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+_plan_file=$(mktemp)
+echo "Resource actions are indicated with the following symbols:" > "${_plan_file}"
+export input_plan_txt_output_file="${_plan_file}"
+run_test "<details> heading and 'terraform' code fence tag are byte-exact" assert_details_heading_byte_exact
+rm -f "${_plan_file}"
+
+# Test 20: Footer line is byte-exact (down to the comma/space separators and backtick escapes)
+assert_footer_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected='*Pusher: @test-user, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs)*'
+  if [[ "${summary}" != *"${expected}"* ]]; then
+    echo "  summary: footer byte-exact mismatch"
+    echo "    expected: ${expected}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+run_test "Footer line is byte-exact" assert_footer_byte_exact
+
+# Test 21: "Plan not available 🤷‍♀️" is the byte-exact fallback (incl. emoji)
+assert_plan_not_available_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected='Plan not available 🤷‍♀️'
+  if [[ "${summary}" != *"${expected}"* ]]; then
+    echo "  summary: expected exact fallback 'Plan not available 🤷‍♀️' (incl. emoji)"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+run_test "'Plan not available 🤷‍♀️' fallback is byte-exact (incl. emoji)" assert_plan_not_available_byte_exact
+
+# Test 22: 'cancelled' outcome renders as <kbd>cancelled</kbd>
+assert_cancelled_kbd() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'<kbd>cancelled</kbd>'* ]]; then
+    echo "  summary: expected '<kbd>cancelled</kbd>'"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_status_plan="cancelled"
+run_test "Non-success outcome 'cancelled' renders as <kbd>cancelled</kbd>" assert_cancelled_kbd
+
+# Test 23: 'skipped' outcome renders as <kbd>skipped</kbd>
+assert_skipped_kbd() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'<kbd>skipped</kbd>'* ]]; then
+    echo "  summary: expected '<kbd>skipped</kbd>'"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_status_plan="skipped"
+run_test "Non-success outcome 'skipped' renders as <kbd>skipped</kbd>" assert_skipped_kbd
+
+# Test 24: empty outcome string still passes through format-status as <kbd></kbd>
+# (Non-success branch is taken; the raw value is whatever was passed.)
+assert_empty_outcome_kbd() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'<kbd></kbd>'* ]]; then
+    echo "  summary: expected '<kbd></kbd>' for empty outcome string"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_status_plan=""
+run_test "Empty outcome string renders as <kbd></kbd> (non-success branch)" assert_empty_outcome_kbd
+
+# Test 25: Plan extract source precedence — txt file wins over console file
+assert_txt_wins_over_console() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *"FROM_TXT"* ]]; then
+    echo "  summary: expected txt-file content 'FROM_TXT' to win"
+    return 1
+  fi
+  if [[ "${summary}" == *"FROM_CONSOLE"* ]]; then
+    echo "  summary: console-file content 'FROM_CONSOLE' must not appear when txt file is present"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+_txt_file=$(mktemp)
+_console_file=$(mktemp)
+echo "FROM_TXT line of plan content" > "${_txt_file}"
+cat > "${_console_file}" <<'EOF'
+Terraform used the selected providers to generate the following execution plan.
+FROM_CONSOLE line of plan content
+EOF
+export input_plan_txt_output_file="${_txt_file}"
+export input_plan_console_file="${_console_file}"
+run_test "Plan extract source precedence: txt file wins over console file" assert_txt_wins_over_console
+rm -f "${_txt_file}" "${_console_file}"
+
+# Test 26: Plan extract is capped at 65000 chars regardless of source
+assert_plan_capped_at_65k() {
+  local prefix="${1}"
+  local summary="${2}"
+  # Extract only the code-fence content
+  local code_block
+  code_block=$(echo "${summary}" | awk '/^```terraform$/{flag=1;next}/^```$/{flag=0}flag')
+  local len=${#code_block}
+  if [[ ${len} -gt 65000 ]]; then
+    echo "  summary: plan code block exceeded 65000 chars (got ${len})"
+    return 1
+  fi
+  # Should be exactly 65000 or just under (tail -c trims at byte boundary; emoji-free content so chars == bytes)
+  if [[ ${len} -lt 64000 ]]; then
+    echo "  summary: plan code block unexpectedly short (got ${len}, expected near 65000)"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+_huge_file=$(mktemp)
+# Generate ~100k of single-byte-per-char content
+yes "abcdefghij" | head -c 100000 > "${_huge_file}"
+export input_plan_txt_output_file="${_huge_file}"
+run_test "Plan extract is capped at 65000 chars" assert_plan_capped_at_65k
+rm -f "${_huge_file}"
+
+# Test 27: Refresh-line stripping in console-file path uses the exact sed pattern
+# Lines before "Terraform used the selected providers to generate the following execution"
+# must be dropped; the marker line itself and everything after kept.
+assert_console_refresh_stripping_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  if [[ "${summary}" == *"NOISE_BEFORE_MARKER"* ]]; then
+    fails+="  summary: refresh-noise line was NOT stripped (NOISE_BEFORE_MARKER leaked through)\n"
+  fi
+  if [[ "${summary}" != *"Terraform used the selected providers"* ]]; then
+    fails+="  summary: marker line itself must be retained\n"
+  fi
+  if [[ "${summary}" != *"AFTER_MARKER_LINE"* ]]; then
+    fails+="  summary: lines AFTER the marker must be retained\n"
+  fi
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+_console_file=$(mktemp)
+cat > "${_console_file}" <<'EOF'
+NOISE_BEFORE_MARKER azurerm_resource.foo: Reading...
+NOISE_BEFORE_MARKER azurerm_resource.foo: Read complete after 1s
+
+Terraform used the selected providers to generate the following execution plan.
+AFTER_MARKER_LINE will appear in the output.
+EOF
+export input_plan_console_file="${_console_file}"
+run_test "Console-file refresh-stripping retains marker + after, drops before" assert_console_refresh_stripping_exact
+rm -f "${_console_file}"
+
+# --------------------------------------------------
 # Summary
 # --------------------------------------------------
 echo ""

--- a/create-validation-summary/run_all_tests.sh
+++ b/create-validation-summary/run_all_tests.sh
@@ -59,6 +59,7 @@ reset_defaults() {
   export input_status_validate="success"
   export input_status_lint="success"
   export input_status_plan="success"
+  export input_pr_comment_group=""
   export input_include_plan_details="false"
   export input_plan_count_add="0"
   export input_plan_count_change="0"
@@ -873,6 +874,216 @@ EOF
 export input_plan_console_file="${_console_file}"
 run_test "Console-file refresh-stripping retains marker + after, drops before" assert_console_refresh_stripping_exact
 rm -f "${_console_file}"
+
+# --------------------------------------------------
+# Grouped-mode tests (pr-comment-group is non-empty).
+# Verify the new branch: validation table omitted, "Part of group ..."
+# note prepended, prefix unchanged. See docs/Workflow-pr-comments.md §3.2.
+# --------------------------------------------------
+
+# Test 28: Grouped mode — prefix is byte-identical to ungrouped mode
+# This is the §6.2 prefix-continuity invariant.
+assert_grouped_prefix_unchanged() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected='### Terraform validation summary for environment: `dev`'
+  if [[ "${prefix}" != "${expected}" ]]; then
+    echo "  prefix: byte-exact mismatch — grouped mode must keep the same prefix as ungrouped"
+    echo "    expected: ${expected}"
+    echo "    actual:   ${prefix}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+run_test "Grouped mode: prefix is byte-identical to ungrouped mode" assert_grouped_prefix_unchanged
+
+# Test 29: Grouped mode — validation table is OMITTED from body
+assert_grouped_table_omitted() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  # No standard row labels should appear
+  local forbidden_rows=(
+    "| ⚙️ | Initialization |"
+    "| 🔒 | Lock file |"
+    "| 🖌 | Format and Style |"
+    "| ✔ | Validate |"
+    "| 🧹 | TFLint |"
+    "| 📖 | Plan |"
+    "|  | Step | Result |"
+    "|:---:|---|---|"
+  )
+  for row in "${forbidden_rows[@]}"; do
+    if [[ "${summary}" == *"${row}"* ]]; then
+      fails+="  summary: grouped mode must NOT contain row '${row}'\n"
+    fi
+  done
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+run_test "Grouped mode: validation table is omitted from per-env body" assert_grouped_table_omitted
+
+# Test 30: Grouped mode — "Part of group ..." pointer is prepended (byte-exact)
+assert_grouped_note_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected='> Part of group `dev-group` — see the grouped summary below.'
+  if [[ "${summary}" != *"${expected}"* ]]; then
+    echo "  summary: expected byte-exact pointer"
+    echo "    expected: ${expected}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+run_test "Grouped mode: 'Part of group <name>' pointer is byte-exact" assert_grouped_note_byte_exact
+
+# Test 31: Grouped mode — group name is properly escaped in the note (different group name)
+assert_grouped_note_uses_input_group() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'> Part of group `prod-norge` — see the grouped summary below.'* ]]; then
+    echo "  summary: grouped note should reflect the configured group name 'prod-norge'"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="prod-norge"
+run_test "Grouped mode: note carries the configured group name" assert_grouped_note_uses_input_group
+
+# Test 32: Grouped mode — plan extract still rendered when plan file present
+assert_grouped_plan_extract_kept() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  if [[ "${summary}" != *'<details><summary>Show Plan (last 65k characters)</summary>'* ]]; then
+    fails+="  summary: grouped mode must still render the <details> plan extract block\n"
+  fi
+  if [[ "${summary}" != *'GROUPED_PLAN_BODY'* ]]; then
+    fails+="  summary: grouped mode must still include plan body content\n"
+  fi
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+_plan_file=$(mktemp)
+echo "GROUPED_PLAN_BODY content of the plan" > "${_plan_file}"
+export input_plan_txt_output_file="${_plan_file}"
+run_test "Grouped mode: plan extract is kept" assert_grouped_plan_extract_kept
+rm -f "${_plan_file}"
+
+# Test 33: Grouped mode — "Plan not available" fallback works (no plan file)
+assert_grouped_plan_not_available() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'Plan not available 🤷‍♀️'* ]]; then
+    echo "  summary: grouped mode should still produce the 'Plan not available 🤷‍♀️' fallback"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+run_test "Grouped mode: 'Plan not available 🤷‍♀️' fallback still works" assert_grouped_plan_not_available
+
+# Test 34: Grouped mode — footer is unchanged
+assert_grouped_footer_byte_exact() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected='*Pusher: @test-user, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs)*'
+  if [[ "${summary}" != *"${expected}"* ]]; then
+    echo "  summary: grouped mode footer byte-exact mismatch"
+    echo "    expected: ${expected}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+run_test "Grouped mode: footer is byte-exact (same as ungrouped)" assert_grouped_footer_byte_exact
+
+# Test 35: Grouped mode — include-plan-details=true does NOT cause Plan Details row to appear
+# (plan-details belong in the per-group comment, not the per-env grouped comment)
+assert_grouped_plan_details_row_omitted() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" == *"Plan Details"* ]]; then
+    echo "  summary: grouped mode must NOT render the Plan Details row even when include-plan-details=true"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+export input_include_plan_details="true"
+export input_plan_count_add="5"
+export input_plan_count_change="2"
+export input_plan_count_destroy="1"
+run_test "Grouped mode: Plan Details row is omitted even when include-plan-details=true" assert_grouped_plan_details_row_omitted
+
+# Test 36: Grouped mode — full body byte-exact (no plan file, default counts)
+# Strongest grouped-mode contract guard, parallel to test #14 for ungrouped.
+assert_grouped_full_body_golden() {
+  local prefix="${1}"
+  local summary="${2}"
+  local expected
+  expected=$(cat <<'EOF'
+### Terraform validation summary for environment: `dev`
+
+> Part of group `dev-group` — see the grouped summary below.
+
+Plan not available 🤷‍♀️
+
+*Pusher: @test-user, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs)*
+EOF
+)
+  if [[ "${summary}" != "${expected}" ]]; then
+    echo "  summary: grouped mode byte-exact mismatch (diff below)"
+    diff <(echo "${expected}") <(echo "${summary}") | sed 's/^/    /'
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+run_test "Grouped mode: full body byte-exact golden" assert_grouped_full_body_golden
+
+# Test 37: Empty pr-comment-group falls back to ungrouped behavior
+# This is the §6 backwards-compat invariant — the default value must not change behavior.
+assert_empty_group_acts_ungrouped() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  # Must contain the full table (ungrouped shape)
+  if [[ "${summary}" != *"| ⚙️ | Initialization |"* ]]; then
+    fails+="  summary: empty pr-comment-group must render full validation table (got grouped shape?)\n"
+  fi
+  # Must NOT contain the grouped "Part of group" note
+  if [[ "${summary}" == *"Part of group"* ]]; then
+    fails+="  summary: empty pr-comment-group must NOT add 'Part of group' note\n"
+  fi
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group=""
+run_test "Empty pr-comment-group falls back to ungrouped behavior" assert_empty_group_acts_ungrouped
 
 # --------------------------------------------------
 # Summary

--- a/create-validation-summary/step_create_validation_summary.sh
+++ b/create-validation-summary/step_create_validation_summary.sh
@@ -15,6 +15,7 @@
 #   input_status_validate      - Outcome of validate step
 #   input_status_lint          - Outcome of lint step
 #   input_status_plan          - Outcome of plan step
+#   input_pr_comment_group     - Name of comment group this env belongs to ("" = ungrouped)
 #   input_include_plan_details - Whether to include plan details in the summary
 #   input_plan_count_add       - Number of resources to be added
 #   input_plan_count_change    - Number of resources to be changed
@@ -46,10 +47,28 @@ function main {
   log-info "creating pull request comment ..."
 
   local comment_prefix="### Terraform validation summary for environment: \`${input_environment_name}\`"
+  local comment_content="${comment_prefix}"
 
-  # Build the validation summary table
-  # don't touch the indenting here
-  local comment_content="${comment_prefix}
+  # Branch on grouped vs ungrouped mode (docs/Workflow-pr-comments.md §3).
+  # Grouped mode (pr-comment-group is non-empty): omit the validation table
+  # and prepend a pointer to the per-group summary comment. The prefix above
+  # is unchanged in both modes — that is the §6.2 prefix-continuity invariant.
+  if [ -n "${input_pr_comment_group}" ]; then
+    log-info "grouped mode active (group='${input_pr_comment_group}') — omitting validation table"
+
+    # don't touch the indenting here
+    # The grouped summary comment is posted by the pr-comment-aggregator job
+    # which runs AFTER all matrix jobs, so it appears below the per-env
+    # comments in GitHub's default chronological PR conversation order.
+    comment_content="${comment_content}
+
+> Part of group \`${input_pr_comment_group}\` — see the grouped summary below."
+  else
+    log-info "ungrouped mode — rendering full validation table"
+
+    # Build the validation summary table
+    # don't touch the indenting here
+    comment_content="${comment_content}
 |  | Step | Result |
 |:---:|---|---|
 | ⚙️ | Initialization | $(format-status "${input_status_init}") |
@@ -59,27 +78,28 @@ function main {
 | 🧹 | TFLint | $(format-status "${input_status_lint}") |
 | 📖 | Plan | $(format-status "${input_status_plan}") |"
 
-  # Add plan details if enabled
-  if [ "${input_include_plan_details}" == 'true' ]; then
+    # Add plan details if enabled
+    if [ "${input_include_plan_details}" == 'true' ]; then
 
-    # don't touch the indenting here
-    comment_content="${comment_content}
+      # don't touch the indenting here
+      comment_content="${comment_content}
 | 📊 | Plan Details | <span title=\"Resources to be added\">\`💫 ${input_plan_count_add}\` add</span><br><span title=\"Resources to be changed\">\`🛠️ ${input_plan_count_change}\` change</span><br><span title=\"Resources to be destroyed\">\`💥 ${input_plan_count_destroy}\` destroy</span>"
 
-    if [ "${input_plan_count_move}" != '0' ]; then
-      comment_content="${comment_content}<br><span title=\"Resources to be moved\">\`🔀 ${input_plan_count_move}\` move</span>"
-    fi
+      if [ "${input_plan_count_move}" != '0' ]; then
+        comment_content="${comment_content}<br><span title=\"Resources to be moved\">\`🔀 ${input_plan_count_move}\` move</span>"
+      fi
 
-    if [ "${input_plan_count_import}" != '0' ]; then
-      comment_content="${comment_content}<br><span title=\"Resources to be imported\">\`📥 ${input_plan_count_import}\` import</span>"
-    fi
+      if [ "${input_plan_count_import}" != '0' ]; then
+        comment_content="${comment_content}<br><span title=\"Resources to be imported\">\`📥 ${input_plan_count_import}\` import</span>"
+      fi
 
-    if [ "${input_plan_count_remove}" != '0' ]; then
-      comment_content="${comment_content}<br><span title=\"Resources to be removed\">\`⛓️‍💥 ${input_plan_count_remove}\` remove</span>"
-    fi
+      if [ "${input_plan_count_remove}" != '0' ]; then
+        comment_content="${comment_content}<br><span title=\"Resources to be removed\">\`⛓️‍💥 ${input_plan_count_remove}\` remove</span>"
+      fi
 
-    # end of table row
-    comment_content="${comment_content} |"
+      # end of table row
+      comment_content="${comment_content} |"
+    fi
   fi
 
   # Add link to job logs

--- a/docs/Workflow-pr-comments.md
+++ b/docs/Workflow-pr-comments.md
@@ -1,0 +1,335 @@
+# PR comments
+
+Authoritative spec for all pull-request comments produced by [`terraform-ci-cd-default.yml`](../.github/workflows/terraform-ci-cd-default.yml).
+
+Out of scope: deployment-environment UI, status checks, workflow run summaries — this doc is only about the comments posted on the PR conversation timeline.
+
+## 1. When are comments posted
+
+Comments are only posted when the workflow runs against a `pull_request` event whose action is not `closed` or `converted_to_draft`. The mechanism is identical regardless of which job posts the comment: each comment carries a deterministic Markdown heading (the "prefix") and every post does a delete-by-prefix + post — so comments update in place across re-runs, never duplicate.
+
+Comments are suppressed when either:
+
+- the workflow input `add-pr-comment: false` is set (globally), or
+- a per-environment `add-pr-comment: false` override is set in `environments-yml` (per env).
+
+Both controls only affect the per-environment comments. The per-group reconcile job runs unconditionally on PR events; see §6 for why and the cost analysis.
+
+## 2. The two comment families
+
+| Family | Identity prefix | Posted by | Cardinality |
+|---|---|---|---|
+| Per-environment | `` ### Terraform validation summary for environment: `<env>` `` | matrix job for that env, via `comment-on-pr@v2` | one per env per workflow run |
+| Per-group | `` ### Terraform validation summary for group: `<group>` `` | `pr-comment-aggregator` job, via `aggregate-validation-summaries` | one per distinct non-empty `pr-comment-group` value |
+
+Both families share the prefix-based identity contract: the family prefix uniquely identifies the comment within a PR, the action lists existing comments via `gh api`, deletes any whose body starts with the matching specific prefix, and posts the freshly-built body. Bodies always start with their full prefix (heading line) so substring matching is unambiguous.
+
+Per-env prefixes use backtick-delimited env names so partial matches can't collide (e.g. `dev` doesn't match `dev-2`).
+
+## 3. Per-environment comments
+
+Each matrix job (one per env in `environments-yml`) runs `create-validation-summary` followed by `comment-on-pr@v2`. The body shape depends on whether the env declares a `pr-comment-group`.
+
+### 3.1 Ungrouped mode (default)
+
+The env has no `pr-comment-group` set (or its value is `""`). This is the historical behavior and the contract that backwards-compat tests pin down.
+
+Raw markdown:
+
+````markdown
+### Terraform validation summary for environment: `dev`
+|  | Step | Result |
+|:---:|---|---|
+| ⚙️ | Initialization | `success` |
+| 🔒 | Lock file | `success` |
+| 🖌 | Format and Style | `success` |
+| ✔ | Validate | `success` |
+| 🧹 | TFLint | `success` |
+| 📖 | Plan | `success` |
+
+<details><summary>Show Plan (last 65k characters)</summary>
+
+```terraform
+…
+```
+
+</details>
+
+*Pusher: @peder, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](https://github.com/owner/repo/actions/runs/123/job/456#logs)*
+````
+
+Rendered:
+
+> ### Terraform validation summary for environment: `dev`
+>
+> |  | Step | Result |
+> |:---:|---|---|
+> | ⚙️ | Initialization | `success` |
+> | 🔒 | Lock file | `success` |
+> | 🖌 | Format and Style | `success` |
+> | ✔ | Validate | `success` |
+> | 🧹 | TFLint | `success` |
+> | 📖 | Plan | `success` |
+>
+> <details><summary>Show Plan (last 65k characters)</summary>
+>
+> ```terraform
+> …
+> ```
+>
+> </details>
+>
+> *Pusher: @peder, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](#)*
+
+Cell formatting in the Result column:
+
+| Step outcome | Cell value |
+|---|---|
+| `success` | `` `success` `` (Markdown code-span) |
+| anything else (`failure`, `cancelled`, `skipped`, `''`) | `<kbd>failure</kbd>` etc. — the raw outcome string inside a `<kbd>` tag |
+
+#### Plan details row (optional)
+
+When `include-plan-details` is true (the workflow wires this as `steps.parse-plan.outcome == 'success'`), an extra row is appended:
+
+```markdown
+| 📊 | Plan Details | <span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span> |
+```
+
+Rules:
+
+- `add`, `change`, `destroy` lines are always present.
+- `move`, `import`, `remove` lines are appended only when their respective count is non-zero, with emojis `🔀`, `📥`, `⛓️‍💥`.
+- Lines are separated by `<br>`. Each badge is wrapped in `<span title="…">…</span>` with a human-readable description as the tooltip.
+
+#### Plan extract
+
+After the table, the comment carries the last 65,000 characters of the Terraform plan output inside a `<details>`-collapsed code fence. Source precedence:
+
+1. `plan-txt-output-file` (the `-no-color` output Terraform writes when the plan succeeds). Read via `tail -c 65000`.
+2. `plan-console-file` (captured stdout, used when the plan failed and #1 doesn't exist). Stripped of leading `… Refreshing state…` lines via `sed -n '/Terraform used the selected providers to generate the following execution/,$p'` before being capped at 65k chars.
+3. Neither file exists → the literal string `Plan not available 🤷‍♀️` is included instead.
+
+#### Footer
+
+```markdown
+*Pusher: @<actor>, Action: `<event_name>`, Workflow: `<workflow_name>`, Job log: [link](<run_url>/job/<check_run_id>#logs)*
+```
+
+`<actor>`, `<event_name>`, `<workflow_name>`, and the run/job IDs come from the `github` and `job` contexts.
+
+### 3.2 Grouped mode
+
+The env has `pr-comment-group: "<name>"` set. The per-env comment loses its validation table — that data is now in the per-group comment (§4). Everything else is unchanged so reviewers reading the env's plan extract still get the same context.
+
+Raw markdown:
+
+````markdown
+### Terraform validation summary for environment: `sub-a-dev`
+
+> Part of group `dev` — see the grouped summary below.
+
+<details><summary>Show Plan (last 65k characters)</summary>
+
+```terraform
+…
+```
+
+</details>
+
+*Pusher: @peder, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](#)*
+````
+
+Rendered:
+
+> ### Terraform validation summary for environment: `sub-a-dev`
+>
+> > Part of group `dev` — see the grouped summary below.
+>
+> <details><summary>Show Plan (last 65k characters)</summary>
+>
+> ```terraform
+> …
+> ```
+>
+> </details>
+>
+> *Pusher: @peder, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](#)*
+
+The prefix is identical to ungrouped mode. This is intentional: callers who toggle grouping on/off get in-place comment updates rather than orphan accumulation.
+
+If the plan extract is unavailable, the `<details>` block is replaced by `Plan not available 🤷‍♀️`, same as ungrouped mode.
+
+## 4. Per-group comments
+
+Every PR run triggers the `pr-comment-aggregator` job once. It downloads all `matrix-job-meta-*` artifacts (uploaded by `capture-matrix-job-meta`), partitions envs by `pr-comment-group`, and emits one comment per distinct non-empty group.
+
+### 4.1 Comment shape
+
+Raw markdown:
+
+````markdown
+### Terraform validation summary for group: `dev`
+
+|  | Step | sub-a-dev | sub-b-dev | sub-c-dev |
+|:---:|---|:---:|:---:|:---:|
+| <span title="Initialization">⚙️</span> | Initialization | <span title="success">✅</span> | <span title="success">✅</span> | <span title="failure">❌</span> |
+| <span title="Lock file">🔒</span> | Lock file | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+| <span title="Format and Style">🖌</span> | Format and Style | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+| <span title="Validate">✔</span> | Validate | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+| <span title="TFLint">🧹</span> | TFLint | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+| <span title="Plan">📖</span> | Plan | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+| <span title="Plan details">📊</span> | Plan details | <div align="left"><span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span></div> | <div align="left"><span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span><br><span title="Resources to be imported">`📥 2` import</span></div> | N/A |
+| <span title="Links">🔗</span> | Links | [log extract](#issuecomment-…)<br>[job log](https://…) | [log extract](#issuecomment-…)<br>[job log](https://…) | [job log](https://…) |
+
+*Pusher: @peder, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](https://…)*
+````
+
+Rendered:
+
+> ### Terraform validation summary for group: `dev`
+>
+> |  | Step | sub-a-dev | sub-b-dev | sub-c-dev |
+> |:---:|---|:---:|:---:|:---:|
+> | <span title="Initialization">⚙️</span> | Initialization | <span title="success">✅</span> | <span title="success">✅</span> | <span title="failure">❌</span> |
+> | <span title="Lock file">🔒</span> | Lock file | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+> | <span title="Format and Style">🖌</span> | Format and Style | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+> | <span title="Validate">✔</span> | Validate | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+> | <span title="TFLint">🧹</span> | TFLint | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+> | <span title="Plan">📖</span> | Plan | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
+> | <span title="Plan details">📊</span> | Plan details | <div align="left"><span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span></div> | <div align="left"><span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span><br><span title="Resources to be imported">`📥 2` import</span></div> | N/A |
+> | <span title="Links">🔗</span> | Links | [log extract](#)<br>[job log](#) | [log extract](#)<br>[job log](#) | [job log](#) |
+>
+> *Pusher: @peder, Action: `pull_request`, Workflow: `Terraform CI`, Job log: [link](#)*
+
+### 4.2 Column ordering
+
+Envs are sorted alphabetically by env name within the group. Stable across re-runs.
+
+### 4.3 Status emoji cells
+
+Every status cell wraps an emoji in `<span title="<outcome>">…</span>` so desktop browsers surface a tooltip naming the outcome. Mapping:
+
+| Step outcome | Emoji | `title` attribute |
+|---|:---:|---|
+| `success` | ✅ | `success` |
+| `failure` | ❌ | `failure` |
+| `cancelled` | 🚫 | `cancelled` |
+| `skipped` | ⏭️ | `skipped` |
+| `''` / step not present in env's metadata | — (em dash) | `not applicable` |
+
+The column-1 step emojis (⚙️ 🔒 🖌 ✔ 🧹 📖 📊 🔗) are also wrapped in `<span title="<step-name>">…</span>` for desktop hover discoverability.
+
+Tooltips degrade silently: GitHub's mobile apps don't render `title` attributes, and screen readers don't reliably announce them. The emoji itself carries the user-facing meaning; tooltips are an enhancement.
+
+### 4.4 Plan details row
+
+Same multi-line content as the ungrouped Plan Details row (§3.1) — one `<br>`-separated line per non-zero category, with `add` / `change` / `destroy` always shown. Each cell wraps its badge stack in `<div align="left">…</div>` so the badges anchor to the left edge of the otherwise center-aligned column. `N/A` when the plan didn't run or `parse-terraform-plan` couldn't extract counts for that env.
+
+### 4.5 Links row
+
+Per-env cell, zero to two Markdown links, one per line, separated by `<br>`. Each line is independently optional:
+
+- `log extract` — anchor to the env's per-env comment (§3.2) using GitHub's `#issuecomment-<id>` fragment. Present only when the resolver matched the env's per-env comment in the PR via `gh api repos/<owner>/<repo>/issues/<n>/comments`.
+- `job log` — direct URL to the env's matrix job log on the current workflow run, with `#logs` anchor. Present only when the resolver matched the env's matrix job in the current run via `gh api repos/<owner>/<repo>/actions/runs/<run_id>/jobs`. Matching uses the GitHub-rendered job name pattern `^Terraform \(<env>\)$`.
+
+Each line is omitted independently when its source isn't resolvable. When *both* lines would be omitted, the cell is rendered as empty rather than as a stray pipe pair — keeping the table tidy. The grouped table itself always posts; the Links column degrades gracefully.
+
+Per-env-comment lookup edge cases:
+
+- **0 matches** — `log extract` line omitted (common when the per-env `comment-on-pr` step failed or the env's matrix job failed before it ran).
+- **1 match** — `log extract` line points at `#issuecomment-<id>`.
+- **2+ matches** (race / stale duplicates not yet cleaned by `comment-on-pr@v2`'s delete-by-prefix) — `log extract` points at the comment with the highest numeric `id` (GitHub IDs are monotonic, so highest = newest). A warning naming the env is logged.
+
+If the Jobs API call itself fails (rate limit, transient 5xx), every env's `job log` line is dropped and a single warning is logged; the grouped table still renders.
+
+### 4.6 Reconcile algorithm
+
+The aggregator action runs every PR event. Its job is to make the set of group comments on the PR equal to the desired set computed from the current run's metadata:
+
+1. **Build desired set.** Read every `matrix-job-meta-*.json` artifact downloaded by `actions/download-artifact@v4`. Group entries by `matrix_context.vars.pr-comment-group`, dropping empty-string values. The desired set may be empty (no env declares a group).
+2. **List PR + run state.** Two paginated `gh api` calls:
+    - `repos/$REPO/issues/$PR/comments` — from the result, build two maps:
+      - existing group comments (body starts with `### Terraform validation summary for group: `)
+      - existing per-env comments (body starts with the exact backtick-delimited per-env prefix from §2)
+    - `repos/$REPO/actions/runs/$RUN_ID/jobs` — used to resolve each env's matrix job URL for the Links row (§4.5). Match by GitHub-rendered job name pattern `^Terraform \(<env>\)$`. Either call may fail independently: a Jobs API failure drops `job log` links from every Links cell; a PR-comments failure triggers degraded mode (skip reconcile delete pass, still post fresh bodies, will re-reconcile on next run).
+3. **Render desired.** For each desired group, sort envs alphabetically and build the prefix + body per §4.1. The Links row uses the per-env comment map (step 2) to resolve `log extract` anchors.
+4. **Reconcile (delete pass).** Walk the existing group comments:
+    - prefix not in desired set → DELETE (orphan from a removed/renamed group)
+    - prefix in desired set → DELETE (will be reposted with fresh body in step 5)
+5. **Post pass.** For each desired group, POST the rendered body.
+6. **Emit `groups-processed-json`** for logs/tests.
+
+Four scenarios collapse into the same path:
+
+| Desired groups | Existing group comments | Outcome |
+|---|---|---|
+| 0 | 0 | no-op |
+| 0 | N | sweep N orphans (caller disabled grouping) |
+| M | 0 | post M (first run with grouping enabled) |
+| M | N (any overlap) | sweep mismatched, repost matched, post new |
+
+Self-healing: at most one PR run is needed after toggling grouping on/off or renaming groups; no manual cleanup procedure.
+
+#### Degraded mode
+
+If `gh api` fails (rate limit, transient 5xx), the action logs a warning, treats the existing-comments map as empty, renders bodies with Links rows showing `job log` only (no `log extract` anchors), and attempts to post. Subsequent runs reconcile any duplicates left behind. The grouped table itself always renders.
+
+#### Failure isolation
+
+The aggregator job uses `actions/download-artifact@v4` with `continue-on-error: true` because the empty-artifact case (no envs uploaded metadata) is valid input — sweep-only mode still needs to run. The action also tolerates malformed individual metadata files: parse errors are logged, the file is skipped, the env is reported with `not applicable` cells in the table.
+
+## 5. Configuration reference
+
+All flags that influence PR-comment behavior. Boolean inputs are passed through `matrix.vars` as the strings `"true"` / `"false"`.
+
+### Workflow inputs
+
+| Input | Type | Default | Effect |
+|---|---|---|---|
+| `add-pr-comment` | bool | `true` | When `false`, suppresses the per-env comment for every env. Per-group comments still render (set per-env `add-pr-comment: false` and use the per-env override if you need different behavior). |
+| `pr-comment-group` | string | `""` | Global default for the per-env `pr-comment-group` field. Rarely useful (you almost always want per-env values). |
+
+### Per-environment fields (`environments-yml`)
+
+| Field | Type | Default | Effect |
+|---|---|---|---|
+| `add-pr-comment` | bool | inherits workflow input | Per-env override of the comment suppression. |
+| `pr-comment-group` | string | `""` (or workflow input) | When non-empty, the env's per-env comment switches to the §3.2 "grouped" shape and the env contributes a column to the matching per-group comment (§4). Envs sharing the same value are collapsed into one group comment. |
+
+### Comment suppression matrix
+
+| `add-pr-comment` workflow | `add-pr-comment` env | Per-env comment posted? |
+|:---:|:---:|:---:|
+| `true` | unset | yes |
+| `true` | `true` | yes |
+| `true` | `false` | no |
+| `false` | unset | no |
+| `false` | `true` | yes |
+| `false` | `false` | no |
+
+The per-group comment is independent of `add-pr-comment`: as long as any env declares a `pr-comment-group`, the aggregator emits the corresponding group comment regardless of whether per-env comments are suppressed. This is intentional — the group comment is the place where a reviewer expects the high-level status to surface, even if individual envs hide their plan extracts.
+
+## 6. Backwards-compatibility contract
+
+These invariants are pinned by test coverage and must hold across any future change to comment-rendering code:
+
+1. **Default-mode shape unchanged.** When no env declares `pr-comment-group`, every per-env comment is byte-identical to pre-grouping output. Same prefix, same table column count and order, same `` `success` `` / `<kbd>failure</kbd>` formatting, same Plan Details row rules, same plan-extract source precedence and 65k cap, same footer. The `create-validation-summary` action's `run_all_tests.sh` enforces this with substring assertions across every meaningful permutation.
+2. **Prefix continuity.** The per-env prefix is identical in both ungrouped and grouped modes: `` ### Terraform validation summary for environment: `<env>` ``. Toggling `pr-comment-group` on/off for an env produces an in-place update of its per-env comment, never an orphan.
+3. **No new required inputs.** All grouped-mode additions default to empty / off. A caller that touches nothing sees no behavioral change.
+4. **Per-env metadata artifact format unchanged.** The aggregator consumes the same `matrix-job-meta-*` artifacts uploaded by `capture-matrix-job-meta` that the existing `automerge` job consumes. No new artifact format, no new permission grants.
+5. **`@v0` rolling tag.** The new `aggregate-validation-summaries` action ships on `@v0` along with all other actions in this repo; calling repos on `@v0` adopt the feature automatically on release. Adoption is opt-in via the new field; no caller is forced into grouping.
+
+## 7. Action and job references
+
+Quick map from spec section to implementing code:
+
+| Section | Implementing code |
+|---|---|
+| §3.1 Ungrouped per-env comment body | [`create-validation-summary/step_create_validation_summary.sh`](../create-validation-summary/step_create_validation_summary.sh) |
+| §3.2 Grouped per-env comment body | same file, branched on `pr-comment-group` |
+| §3 Posting/replacing per-env comments | [`dsb-norge/github-actions/ci-cd/comment-on-pr@v2`](https://github.com/dsb-norge/github-actions/tree/main/ci-cd/comment-on-pr) |
+| §4 Per-group comment body + reconcile | [`aggregate-validation-summaries/step_aggregate.sh`](../aggregate-validation-summaries/step_aggregate.sh) |
+| §4.6 Source artifacts | [`capture-matrix-job-meta/step_capture.sh`](../capture-matrix-job-meta/step_capture.sh) |
+| §5 Input plumbing & per-env defaults | [`create-tf-vars-matrix/action.yml`](../create-tf-vars-matrix/action.yml) |
+| Workflow wiring | [`.github/workflows/terraform-ci-cd-default.yml`](../.github/workflows/terraform-ci-cd-default.yml) |

--- a/docs/Workflow-terraform-ci-default.md
+++ b/docs/Workflow-terraform-ci-default.md
@@ -9,7 +9,7 @@ Default DSB CI/CD workflow for terraform projects that performs various operatio
 5. Run `terraform validate`
 6. Perform linitng with TFLint
 7. If `terraform init` was successful, run `terraform plan`
-8. If called from `pull_request` event, add validation summary as comment on the PR
+8. If called from `pull_request` event, add validation summary as comment on the PR (see [Workflow-pr-comments.md](./Workflow-pr-comments.md) for the full PR comment spec, including the optional `pr-comment-group` field that collapses several envs into one combined-table comment)
 9. If any of the steps `init`, `format`, `validate`, `lint` or  `plan` failed, stop the  workflow with a failure
 10. If called from either of events `push` or `workflow_dispatch` on the default branch of the calling repo and `plan` step was successful, run `terraform apply`. I.e. the default is to perform terraform apply when merging PRs.
 


### PR DESCRIPTION
## Summary

Adds optional per-environment `pr-comment-group` field. When envs share a non-empty group value, their per-env "validation summary" comments lose the table (keeping plan extract + footer only) and a new combined summary comment per group is posted with one column per env. Reviewers of PRs that touch many envs (e.g. 3 subs × 2 stages = 6 envs) now see 2-3 scannable group tables instead of 6 stacked ones, while plan extracts stay per-env so the 65k char cap doesn't bite.

Default behavior (no env declares a group) is byte-for-byte unchanged — 15 backwards-compat tests pin this contract.

Spec: [`docs/Workflow-pr-comments.md`](docs/Workflow-pr-comments.md) — authoritative reference for both ungrouped and grouped behavior, the reconcile algorithm, status emoji map, link resolver semantics, and the backwards-compat invariants.

## Commits (atomic, in dependency order)

1. `docs: add PR comments spec` — full spec doc
2. `test: lock down ungrouped per-env comment output` — 15 byte-level tests pinning today's shape, added before any code change
3. `feat: add pr-comment-group workflow input and matrix plumbing` — workflow input + `REQ_FIELDS` + JSON test fixtures
4. `feat: support grouped mode in create-validation-summary` — branches table-on/off based on the new input
5. `feat: add aggregate-validation-summaries action` — new composite action that reconciles per-group comments (sweep + post in one pass)
6. `feat: wire pr-comment-aggregator job and grouped per-env mode` — adds the post-matrix aggregator job + matrix-side wiring
7. `docs: link Workflow-pr-comments spec from workflow overview`
8. `docs: add CLAUDE.md project guide` — in-repo guide for Claude Code sessions

## Test coverage

- `create-validation-summary/run_all_tests.sh` — **37/37 green** (12 pre-existing + 15 ungrouped backwards-compat lock-downs + 10 grouped-mode)
- `aggregate-validation-summaries/run_all_tests.sh` — **27/27 green** covering: all four §4.6 reconcile scenarios (no-op / sweep / post / mixed), alphabetical ordering, status emoji map, plan-details optional categories, left-align div, byte-exact prefix, Jobs API URL resolution for both `tf / Terraform (<env>)` and bare `Terraform (<env>)` forms + non-matrix-job filtering, degraded mode (gh api failure), malformed metadata file, ignoring ungrouped envs, multi-group ordering, output JSON, post-failure-without-abort, and no-nested-log-groups
- Total: **64/64**
- Run locally: `bash create-validation-summary/run_all_tests.sh && bash aggregate-validation-summaries/run_all_tests.sh`

## Verified end-to-end

Manual test in dsb-infra/github-terraform-config PR #227 (run 25797896322, attempt 5) — green. All grouped-comment behavior confirmed in production:

- 6 envs partitioned into 3 groups (`ikt`, `nbk`, `legacy`); `dsb-norge-dev` correctly skipped (no group)
- 3 existing group comments reconciled (deleted + reposted with fresh bodies)
- Per-env `[log extract]` anchors resolved 5/5 to `#issuecomment-<id>` fragments
- Per-env `[job log]` URLs resolved 6/6 via Jobs API (the `^Terraform (env)$` → `Terraform (env)$` regex fix made this work under the real `tf / Terraform (<env>)` naming GitHub uses for reusable workflows)
- Per-env comments correctly show `> Part of group X — see the grouped summary below.`
- Aggregator job log has 6 sibling log groups, no nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)