### PR TITLE
feat: add action-tests PR workflow with annotated summary

### DIFF
--- a/.github/scripts/aggregate-action-tests.sh
+++ b/.github/scripts/aggregate-action-tests.sh
@@ -1,0 +1,256 @@
+#!/bin/env bash
+#
+# Aggregator script for the action-tests workflow.
+#
+# Reads per-action result-*.json files (produced by the test matrix), combines
+# them with the no-tests-list (from discover-actions.sh), builds a single
+# markdown summary, and upserts a PR comment via the GitHub API.
+#
+# See docs/Testing-in-ci.md §5 (result.json shape) and §6 (comment shape +
+# upsert mechanics) for the contract this implements.
+#
+# Required environment:
+#   RESULTS_DIR         - directory containing result-*.json files
+#   NO_TESTS_LIST       - JSON array of action names without tests
+#   PR_NUMBER           - pull request number
+#   GITHUB_REPOSITORY   - "<owner>/<repo>"
+#   GITHUB_SERVER_URL   - e.g. "https://github.com"
+#   GITHUB_RUN_ID       - the workflow run id (for footer link)
+#   GITHUB_SHA          - the PR head sha (for footer)
+#   GH_TOKEN            - token with pull-requests: write (used by `gh`)
+#
+# Optional environment:
+#   GITHUB_STEP_SUMMARY - when set (always set in GitHub Actions), the body
+#                         is also appended here so the run page renders the
+#                         same table without anyone having to open a comment.
+#   DRY_RUN=true        - skip the PR comment upsert (step summary + notice
+#                         annotation still happen). Useful for local testing.
+#
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+declare -gr COMMENT_MARKER='<!-- action-tests-summary -->'
+
+function status_icon {
+  case "${1}" in
+    success)   echo '✅' ;;
+    failure)   echo '❌' ;;
+    cancelled) echo '⚠️' ;;
+    skipped)   echo '⏭️' ;;
+    *)         echo '❓' ;;
+  esac
+}
+
+function status_label {
+  case "${1}" in
+    success)   echo 'Pass' ;;
+    failure)   echo 'Fail' ;;
+    cancelled) echo 'Cancelled' ;;
+    skipped)   echo 'Skipped' ;;
+    *)         echo "${1}" ;;
+  esac
+}
+
+# Render the "Tests" column: "N / N" or "?" when counts are null.
+function tests_cell {
+  local passed="${1}" run="${2}"
+  if [[ "${passed}" == "null" || "${run}" == "null" ]]; then
+    echo '?'
+  else
+    echo "${passed} / ${run}"
+  fi
+}
+
+# Build the markdown body and print to stdout.
+function build_body {
+  local results_json="${1}" no_tests_json="${2}"
+
+  local total_suites total_run total_passed total_failed bad_outcomes
+  total_suites="$(echo "${results_json}" | jq 'length')"
+  total_run="$(echo "${results_json}"    | jq '[.[]."tests-run"    | select(. != null)] | add // 0')"
+  total_passed="$(echo "${results_json}" | jq '[.[]."tests-passed" | select(. != null)] | add // 0')"
+  total_failed="$(echo "${results_json}" | jq '[.[]."tests-failed" | select(. != null)] | add // 0')"
+  bad_outcomes="$(echo "${results_json}" | jq '[.[] | select(.outcome != "success")] | length')"
+
+  local tested_count not_tested_count
+  tested_count="${total_suites}"
+  not_tested_count="$(echo "${no_tests_json}" | jq 'length')"
+
+  printf '%s\n' "${COMMENT_MARKER}"
+  printf '### 🧪 Action test results\n\n'
+  if [[ "${bad_outcomes}" -gt 0 ]]; then
+    printf '**Total: %s tests across %s suites — %s passed, %s failed, %s suite(s) not passing**\n\n' \
+      "${total_run}" "${total_suites}" "${total_passed}" "${total_failed}" "${bad_outcomes}"
+  else
+    printf '**Total: %s tests across %s suites — %s passed, %s failed**\n\n' \
+      "${total_run}" "${total_suites}" "${total_passed}" "${total_failed}"
+  fi
+
+  printf '**Tested (%s)**\n\n' "${tested_count}"
+  if [[ "${tested_count}" -eq 0 ]]; then
+    printf '_No suites ran._\n\n'
+  else
+    printf '| Action | Result | Tests | Details |\n'
+    printf '|---|:---:|:---:|---|\n'
+    # Sort alphabetically by action name.
+    while IFS= read -r row; do
+      local action outcome run passed job_url
+      action="$(  echo "${row}" | jq -r '.action')"
+      outcome="$( echo "${row}" | jq -r '.outcome')"
+      run="$(     echo "${row}" | jq -r '."tests-run"')"
+      passed="$(  echo "${row}" | jq -r '."tests-passed"')"
+      job_url="$( echo "${row}" | jq -r '."job-url" // empty')"
+
+      local icon label cell details
+      icon="$(status_icon "${outcome}")"
+      label="$(status_label "${outcome}")"
+      cell="$(tests_cell "${passed}" "${run}")"
+      if [[ -n "${job_url}" ]]; then
+        details="[job log](${job_url})"
+      else
+        details="—"
+      fi
+
+      printf '| %s | %s %s | %s | %s |\n' \
+        "${action}" "${icon}" "${label}" "${cell}" "${details}"
+    done < <(echo "${results_json}" | jq -c 'sort_by(.action) | .[]')
+    printf '\n'
+  fi
+
+  printf '**Not tested yet (%s)** — modernization candidates\n\n' "${not_tested_count}"
+  if [[ "${not_tested_count}" -eq 0 ]]; then
+    printf '_Empty — every action has a test suite._\n\n'
+  else
+    printf '<details><summary>Show list</summary>\n\n'
+    echo "${no_tests_json}" | jq -r '.[] | "- " + .'
+    printf '\n</details>\n\n'
+  fi
+
+  printf '_Run: [workflow run](%s/%s/actions/runs/%s) · Commit: `%s`_\n' \
+    "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_SHA:0:7}"
+}
+
+# Load and combine result-*.json files into a single JSON array.
+function load_results {
+  local dir="${1}"
+  if ! compgen -G "${dir}/result-*.json" > /dev/null; then
+    echo '[]'
+    return 0
+  fi
+  jq -s '.' "${dir}"/result-*.json
+}
+
+# List existing comments with our marker. Returns JSON array of {id, created_at}.
+function list_marker_comments {
+  gh api --paginate "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+    | jq --arg marker "${COMMENT_MARKER}" \
+        '[.[] | select(.body | startswith($marker)) | {id, created_at}]'
+}
+
+# Upsert the body via gh api.
+function upsert_comment {
+  local body_file="${1}"
+
+  local matches count
+  matches="$(list_marker_comments)"
+  count="$(echo "${matches}" | jq 'length')"
+
+  if [[ "${count}" -eq 0 ]]; then
+    echo "No existing comment found — posting fresh." >&2
+    gh api -X POST "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+      -F "body=@${body_file}" >/dev/null
+    return 0
+  fi
+
+  # When multiple matches exist (defensive — shouldn't happen), keep the oldest
+  # and delete the rest, then edit the oldest in place.
+  local keep_id
+  keep_id="$(echo "${matches}" | jq -r 'sort_by(.created_at) | .[0].id')"
+
+  if [[ "${count}" -gt 1 ]]; then
+    echo "Found ${count} marker comments — keeping oldest (id=${keep_id}), deleting the rest." >&2
+    echo "${matches}" \
+      | jq -r --arg keep "${keep_id}" 'sort_by(.created_at) | .[1:][] | .id' \
+      | while IFS= read -r del_id; do
+          gh api -X DELETE "/repos/${GITHUB_REPOSITORY}/issues/comments/${del_id}" || true
+        done
+  fi
+
+  echo "Editing existing comment in place (id=${keep_id})." >&2
+  gh api -X PATCH "/repos/${GITHUB_REPOSITORY}/issues/comments/${keep_id}" \
+    -F "body=@${body_file}" >/dev/null
+}
+
+# Emit a single ::notice or ::error annotation summarizing the run, so the
+# GitHub run-page annotations panel shows the headline even on green runs.
+#
+# A run is "red" if any suite has tests-failed > 0 OR any suite's outcome
+# is anything other than "success" (covers format-drift, crashes, cancels
+# — cases where counts are null but the suite did not pass).
+function emit_headline_annotation {
+  local results_json="${1}"
+  local total_suites total_run total_passed total_failed bad_outcomes
+  total_suites="$(echo "${results_json}" | jq 'length')"
+  total_run="$(echo "${results_json}"    | jq '[.[]."tests-run"    | select(. != null)] | add // 0')"
+  total_passed="$(echo "${results_json}" | jq '[.[]."tests-passed" | select(. != null)] | add // 0')"
+  total_failed="$(echo "${results_json}" | jq '[.[]."tests-failed" | select(. != null)] | add // 0')"
+  bad_outcomes="$(echo "${results_json}" | jq '[.[] | select(.outcome != "success")] | length')"
+
+  local level title message
+  if [[ "${total_failed}" -gt 0 || "${bad_outcomes}" -gt 0 ]]; then
+    level=error
+    title='Action tests: failures'
+    message="${total_run} tests across ${total_suites} suites — ${total_passed} passed, ${total_failed} failed, ${bad_outcomes} suite(s) not passing"
+  else
+    level=notice
+    title='Action tests: all green'
+    message="${total_run} tests across ${total_suites} suites — ${total_passed} passed, ${total_failed} failed"
+  fi
+  echo "::${level} title=${title}::${message}"
+}
+
+function main {
+  : "${RESULTS_DIR:?RESULTS_DIR is required}"
+  : "${NO_TESTS_LIST:?NO_TESTS_LIST is required}"
+  : "${PR_NUMBER:?PR_NUMBER is required}"
+  : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  : "${GITHUB_SERVER_URL:?GITHUB_SERVER_URL is required}"
+  : "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+  : "${GITHUB_SHA:?GITHUB_SHA is required}"
+
+  local results_json
+  results_json="$(load_results "${RESULTS_DIR}")"
+
+  local body_file
+  body_file="$(mktemp)"
+  build_body "${results_json}" "${NO_TESTS_LIST}" > "${body_file}"
+
+  echo "=== Comment body (begin) ===" >&2
+  cat "${body_file}" >&2
+  echo "=== Comment body (end) ===" >&2
+
+  # Append the same body to the run-page step summary (if running in GitHub
+  # Actions). The HTML marker on the first line renders as nothing.
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat "${body_file}" >> "${GITHUB_STEP_SUMMARY}"
+    echo "Appended summary to \$GITHUB_STEP_SUMMARY." >&2
+  fi
+
+  emit_headline_annotation "${results_json}"
+
+  if [[ "${DRY_RUN:-false}" == "true" ]]; then
+    echo "DRY_RUN=true — skipping comment upsert." >&2
+    rm -f "${body_file}"
+    return 0
+  fi
+
+  : "${GH_TOKEN:?GH_TOKEN is required for comment upsert (set DRY_RUN=true to skip)}"
+  upsert_comment "${body_file}"
+  rm -f "${body_file}"
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/.github/scripts/discover-actions.sh
+++ b/.github/scripts/discover-actions.sh
@@ -56,7 +56,9 @@ function main {
     else
       without_tests+="${name}"$'\n'
     fi
-  done < <(find "${repo_root}" -mindepth 2 -maxdepth 2 -name action.yml -not -path '*/.github/*' | sort)
+  done < <(find "${repo_root}" -mindepth 2 -maxdepth 2 \
+    \( -name action.yml -o -name action.yaml \) -not -path '*/.github/*' \
+    | sort)
 
   local tests_matrix no_tests_list
   tests_matrix="$(printf '%s' "${with_tests}" | sort -u | jq -Rsc 'split("\n") | map(select(length > 0))')"

--- a/.github/scripts/discover-actions.sh
+++ b/.github/scripts/discover-actions.sh
@@ -1,0 +1,82 @@
+#!/bin/env bash
+#
+# Discovery script for the action-tests workflow.
+#
+# Scans top-level composite actions (directories containing action.yml at
+# repo-root + 1 level deep) and partitions them into:
+#   - tests-matrix:  JSON array of action names that have run_all_tests.sh
+#   - no-tests-list: JSON array of action names that do not (or are excluded)
+#
+# Outputs are written to $GITHUB_OUTPUT when set (workflow use), otherwise
+# printed to stdout (standalone smoke testing).
+#
+# See docs/Testing-in-ci.md §2.1 and §3 for the contract this implements.
+#
+# Environment:
+#   GITHUB_OUTPUT (optional) - GitHub Actions outputs file path
+#   REPO_ROOT     (optional) - defaults to `git rev-parse --show-toplevel`
+#
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+# Hard exclusions: actions skipped regardless of whether run_all_tests.sh exists.
+# Keep this list in sync with docs/Testing-in-ci.md §3.
+EXCLUDED=(
+  create-tf-vars-matrix
+)
+
+function is_excluded {
+  local name="${1}"
+  local entry
+  for entry in "${EXCLUDED[@]}"; do
+    [[ "${entry}" == "${name}" ]] && return 0
+  done
+  return 1
+}
+
+function main {
+  local repo_root
+  repo_root="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+
+  local with_tests="" without_tests=""
+  local action_yml dir name
+  while IFS= read -r action_yml; do
+    dir="$(dirname "${action_yml}")"
+    name="$(basename "${dir}")"
+
+    if is_excluded "${name}"; then
+      without_tests+="${name}"$'\n'
+      continue
+    fi
+
+    if [[ -f "${dir}/run_all_tests.sh" ]]; then
+      with_tests+="${name}"$'\n'
+    else
+      without_tests+="${name}"$'\n'
+    fi
+  done < <(find "${repo_root}" -mindepth 2 -maxdepth 2 -name action.yml -not -path '*/.github/*' | sort)
+
+  local tests_matrix no_tests_list
+  tests_matrix="$(printf '%s' "${with_tests}" | sort -u | jq -Rsc 'split("\n") | map(select(length > 0))')"
+  no_tests_list="$(printf '%s' "${without_tests}" | sort -u | jq -Rsc 'split("\n") | map(select(length > 0))')"
+
+  echo "Discovery results:" >&2
+  echo "  with tests    ($(echo "${tests_matrix}" | jq -r 'length')): ${tests_matrix}" >&2
+  echo "  without tests ($(echo "${no_tests_list}" | jq -r 'length')): ${no_tests_list}" >&2
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "tests-matrix=${tests_matrix}"
+      echo "no-tests-list=${no_tests_list}"
+    } >> "${GITHUB_OUTPUT}"
+  else
+    echo "tests-matrix=${tests_matrix}"
+    echo "no-tests-list=${no_tests_list}"
+  fi
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -92,11 +92,12 @@ jobs:
           sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' "${log_file}" > "${stripped}"
 
           # Format-drift check: every suite must emit the canonical summary lines.
-          # See docs/Testing-in-ci.md §4.
+          # See docs/Testing-in-ci.md §4. Regex anchors on both ends (after ANSI
+          # strip) so a suffix like "Tests run: 7 (extra)" is rejected as drift.
           missing=()
-          grep -qE '^Tests run:[[:space:]]+[0-9]+'    "${stripped}" || missing+=('Tests run:')
-          grep -qE '^Tests passed:[[:space:]]+[0-9]+' "${stripped}" || missing+=('Tests passed:')
-          grep -qE '^Tests failed:[[:space:]]+[0-9]+' "${stripped}" || missing+=('Tests failed:')
+          grep -qE '^Tests run:[[:space:]]+[0-9]+[[:space:]]*$'    "${stripped}" || missing+=('Tests run:')
+          grep -qE '^Tests passed:[[:space:]]+[0-9]+[[:space:]]*$' "${stripped}" || missing+=('Tests passed:')
+          grep -qE '^Tests failed:[[:space:]]+[0-9]+[[:space:]]*$' "${stripped}" || missing+=('Tests failed:')
 
           if [[ ${#missing[@]} -gt 0 ]]; then
             outcome=failure

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -1,0 +1,226 @@
+name: "Action tests"
+#
+# Runs the run_all_tests.sh suites for every modern composite action in this
+# repo on every pull request, in parallel. Reports an aggregated summary as a
+# single PR comment, and exposes a stable `tests-conclusion` check for branch
+# protection.
+#
+# Spec: docs/Testing-in-ci.md
+# Discovery script: .github/scripts/discover-actions.sh
+# Aggregator script: .github/scripts/aggregate-action-tests.sh
+#
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+# Cancel previous runs for the same PR / ref when a new commit lands.
+concurrency:
+  group: action-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  discover:
+    name: "🔎 Discover actions"
+    # Fork PRs cannot post the summary comment (read-only token) — skip entirely.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    outputs:
+      tests-matrix: ${{ steps.discover.outputs.tests-matrix }}
+      no-tests-list: ${{ steps.discover.outputs.no-tests-list }}
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v6
+
+      - name: "🔎 Partition actions by test-suite presence"
+        id: discover
+        run: bash .github/scripts/discover-actions.sh
+
+  test:
+    name: "🧪 Test"
+    needs: discover
+    if: needs.discover.outputs.tests-matrix != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read   # for gh api .../jobs lookup (job URL resolution)
+    strategy:
+      fail-fast: false
+      matrix:
+        action: ${{ fromJSON(needs.discover.outputs.tests-matrix) }}
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v6
+
+      # Runs the suite, enforces the canonical summary-line contract (§4),
+      # parses counts, writes result.json, emits annotations, and finally
+      # exits with the suite's real exit code. Everything happens in this
+      # single step because GitHub Actions does not propagate
+      # steps.<id>.outputs.* from a step that exits non-zero — splitting
+      # into multiple steps would lose the log path / counts on failure.
+      - name: "🧪 Run ${{ matrix.action }} tests"
+        id: run-tests
+        env:
+          ACTION_NAME: ${{ matrix.action }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -o pipefail
+
+          start_ts=$(date +%s)
+          mkdir -p _test-out _artifact
+          log_file="_test-out/${ACTION_NAME}.log"
+          stripped="${log_file}.stripped"
+
+          set +e
+          bash "${ACTION_NAME}/run_all_tests.sh" 2>&1 | tee "${log_file}"
+          test_exit=${PIPESTATUS[0]}
+          set -e
+
+          duration=$(( $(date +%s) - start_ts ))
+
+          # Strip ANSI escapes once so subsequent grep/awk can match colored output.
+          sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' "${log_file}" > "${stripped}"
+
+          # Format-drift check: every suite must emit the canonical summary lines.
+          # See docs/Testing-in-ci.md §4.
+          missing=()
+          grep -qE '^Tests run:[[:space:]]+[0-9]+'    "${stripped}" || missing+=('Tests run:')
+          grep -qE '^Tests passed:[[:space:]]+[0-9]+' "${stripped}" || missing+=('Tests passed:')
+          grep -qE '^Tests failed:[[:space:]]+[0-9]+' "${stripped}" || missing+=('Tests failed:')
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            outcome=failure
+            run_sum=null; pass_sum=null; fail_sum=null
+            echo "::error title=Suite format drift::${ACTION_NAME}/run_all_tests.sh did not emit canonical summary lines (missing: ${missing[*]}). See docs/Testing-in-ci.md §4 and docs/Action-implementation-guide.md."
+            # Force failure even if the suite happened to exit 0; drift alone is enough.
+            [[ ${test_exit} -eq 0 ]] && test_exit=1
+          else
+            run_sum=$( awk '/^Tests run:[[:space:]]+[0-9]+/    {sum += $3} END {print sum+0}' "${stripped}")
+            pass_sum=$(awk '/^Tests passed:[[:space:]]+[0-9]+/ {sum += $3} END {print sum+0}' "${stripped}")
+            fail_sum=$(awk '/^Tests failed:[[:space:]]+[0-9]+/ {sum += $3} END {print sum+0}' "${stripped}")
+            if [[ ${test_exit} -eq 0 ]]; then
+              outcome=success
+            else
+              outcome=failure
+              echo "::error title=Action tests failed::${ACTION_NAME}: ${pass_sum}/${run_sum} tests passed (${fail_sum} failed)"
+            fi
+          fi
+
+          # Resolve the specific matrix job URL via the API. Matrix job names are
+          # "<job-name> (<matrix-value>)" — match on the trailing "(<action>)" suffix.
+          job_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          if api_jobs=$(gh api --paginate "/repos/${REPO}/actions/runs/${RUN_ID}/jobs" 2>/dev/null); then
+            resolved=$(echo "${api_jobs}" \
+              | jq -r --arg suffix "(${ACTION_NAME})" \
+                  '.jobs[] | select(.name | endswith($suffix)) | .html_url' \
+              | head -n1)
+            [[ -n "${resolved}" ]] && job_url="${resolved}"
+          fi
+
+          out="_artifact/result-${ACTION_NAME}.json"
+          jq -n \
+            --arg     action   "${ACTION_NAME}" \
+            --arg     outcome  "${outcome}" \
+            --argjson run      "${run_sum}" \
+            --argjson passed   "${pass_sum}" \
+            --argjson failed   "${fail_sum}" \
+            --argjson duration "${duration}" \
+            --arg     job_url  "${job_url}" \
+            '{
+              action: $action,
+              outcome: $outcome,
+              "tests-run": $run,
+              "tests-passed": $passed,
+              "tests-failed": $failed,
+              "duration-seconds": $duration,
+              "job-url": $job_url
+            }' > "${out}"
+
+          echo "Captured result for ${ACTION_NAME}:"
+          cat "${out}"
+
+          exit "${test_exit}"
+
+      - name: "📤 Upload result artifact"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-result-${{ matrix.action }}
+          path: _artifact/result-${{ matrix.action }}.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  summary:
+    name: "📝 Aggregate summary"
+    needs: [discover, test]
+    if: |
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@v6
+
+      - name: "📥 Download all test result artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          pattern: test-result-*
+          merge-multiple: true
+          path: _results
+
+      - name: "📝 Build summary and upsert PR comment"
+        env:
+          RESULTS_DIR: _results
+          NO_TESTS_LIST: ${{ needs.discover.outputs.no-tests-list }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/aggregate-action-tests.sh
+
+  # Stable check name for branch protection. Aggregates the matrix into one
+  # status — independent of how the matrix grows. See docs/Testing-in-ci.md §2.4.
+  tests-conclusion:
+    name: "tests-conclusion"
+    needs: [discover, test]
+    if: |
+      always() &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🛑 Verify all suites passed"
+        env:
+          DISCOVER_RESULT: ${{ needs.discover.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          echo "discover result: ${DISCOVER_RESULT}"
+          echo "test result:     ${TEST_RESULT}"
+
+          if [[ "${DISCOVER_RESULT}" != "success" ]]; then
+            echo "::error title=Discover failed::discover job result was '${DISCOVER_RESULT}'"
+            exit 1
+          fi
+
+          # 'test' job result is the worst across matrix entries.
+          # 'skipped' is acceptable (happens when tests-matrix is empty).
+          case "${TEST_RESULT}" in
+            success|skipped)
+              echo "All test suites passed (or none to run)."
+              ;;
+            failure|cancelled|*)
+              echo "::error title=Tests failed::test job result was '${TEST_RESULT}'"
+              exit 1
+              ;;
+          esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,12 @@ run: |
   source "${{ github.action_path }}/step_<name>.sh"
 ```
 
+### PRs are gated by per-action test suites
+
+`.github/workflows/action-tests.yml` runs every action's `run_all_tests.sh` in parallel on each PR and exposes a single `tests-conclusion` check (intended to be required by branch protection). Result is reported as a PR comment, run-page annotations, and a `$GITHUB_STEP_SUMMARY` block — all three driven by the result-JSON artifacts each matrix job uploads.
+
+Suites must emit the canonical `Tests run: N` / `Tests passed: N` / `Tests failed: N` summary lines verbatim — CI parses them and fails the suite on drift. Full design and verification procedures: [docs/Testing-in-ci.md](docs/Testing-in-ci.md).
+
 ## Common commands
 
 ```bash

--- a/auto-merge-pr/run_all_tests.sh
+++ b/auto-merge-pr/run_all_tests.sh
@@ -558,13 +558,13 @@ echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}              TEST SUMMARY                 ${NC}"
 echo -e "${YELLOW}============================================${NC}"
 echo ""
-echo -e "Total tests: ${TESTS_RUN}"
-echo -e "${GREEN}Passed: ${TESTS_PASSED}${NC}"
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "${GREEN}Tests passed: ${TESTS_PASSED}${NC}"
 if [[ ${TESTS_FAILED} -gt 0 ]]; then
-  echo -e "${RED}Failed: ${TESTS_FAILED}${NC}"
+  echo -e "${RED}Tests failed: ${TESTS_FAILED}${NC}"
   exit 1
 else
-  echo -e "Failed: 0"
+  echo -e "Tests failed: 0"
   echo ""
   echo -e "${GREEN}All tests passed!${NC}"
   exit 0

--- a/docs/Action-implementation-guide.md
+++ b/docs/Action-implementation-guide.md
@@ -423,6 +423,7 @@ fi
 - **Use a `reset_defaults` or `create_metadata_file` helper** to reduce boilerplate if many tests share structure.
 - **Cover edge cases**: empty inputs, null values, invalid JSON, missing fields, boundary values.
 - **Exit with code 1 if any test failed** so CI can catch regressions.
+- **Emit the canonical summary lines** — three lines, exactly: `Tests run:    <N>`, `Tests passed: <N>`, `Tests failed: <N>`. These are parsed by the [action-tests workflow](../.github/workflows/action-tests.yml) to populate per-action and total test counts in the PR comment summary. ANSI color codes around the numbers are fine; the format of the rest of the line must not drift (no "Total tests:", no "Passed:", etc.). See [Testing-in-ci.md §4](Testing-in-ci.md#4-test-count-parsing-contract) for the full parsing contract.
 
 ---
 

--- a/docs/Testing-in-ci.md
+++ b/docs/Testing-in-ci.md
@@ -1,0 +1,453 @@
+# Testing in CI
+
+Living spec for the workflow that runs this repo's composite-action test suites on every pull request and reports the result as a single aggregated PR comment.
+
+This doc is the source of truth for *what* gets tested, *why*, and *how*. Code in [`.github/workflows/action-tests.yml`](../.github/workflows/action-tests.yml) and [`.github/scripts/`](../.github/scripts/) is expected to conform to this spec. If the design changes, update this file first.
+
+Out of scope: the test suites themselves (their layout is described in [Action-implementation-guide.md](Action-implementation-guide.md)), branch-protection configuration on the GitHub side, and any tests for the reusable workflows under `.github/workflows/terraform-*.yml`.
+
+## 1. Goals and non-goals
+
+### Goals
+
+- Run every modern `run_all_tests.sh` suite automatically on each PR, in parallel.
+- Surface the result as a single PR comment so reviewers see at a glance which actions were exercised and which aren't.
+- Expose a single, stable status check (`tests-conclusion`) that can later be required by branch protection — independent of how the matrix grows.
+- Make the not-tested set visible too, so the comment doubles as a nudge toward modernization.
+
+### Non-goals
+
+- Running tests for actions that don't yet have a `run_all_tests.sh` (those rows just appear under "Not tested yet").
+- Per-step granularity in the PR comment (suite-level pass/fail + counts is enough; job logs cover detail).
+- Running on PRs from forks — see §7.
+
+## 2. Workflow shape
+
+Four jobs, in this order:
+
+```text
+discover  ─►  test (matrix, fan-out)  ─►  summary  ─►  tests-conclusion
+                                          (PR comment)   (required check)
+```
+
+### 2.1 `discover`
+
+Scans top-level `*/action.yml` files in the checkout. For each action directory, classifies as:
+
+- **has-tests** if `run_all_tests.sh` exists, *and* the directory is not on the explicit exclusion list (§3).
+- **no-tests** otherwise.
+
+Emits two job outputs:
+
+- `tests-matrix` — JSON array of action names with tests, fed straight into the `test` matrix.
+- `no-tests-list` — JSON array of action names without tests, consumed by `summary`.
+
+Dynamic discovery means newly-added test suites are picked up automatically; no workflow edit is needed when a legacy action gets modernized.
+
+### 2.2 `test` (matrix)
+
+One job per entry in `tests-matrix`. `fail-fast: false` so all suites run regardless of any single failure. Each job has two steps:
+
+1. **🧪 Run `<action>` tests** — runs `bash <action>/run_all_tests.sh`, tee's stdout to a log file, enforces the canonical summary-line contract (§4), parses counts (§4), resolves the matrix job URL, writes the result JSON (§5), emits any failure/drift annotation (§11), and finally exits with the suite's real exit code.
+2. **📤 Upload result artifact** (`if: always()`) — uploads the result JSON as `test-result-<action>` so the summary job can aggregate it.
+
+All the per-action logic lives inside step 1 because GitHub Actions does **not** propagate `steps.<id>.outputs.*` from a step that exits non-zero. If parsing/annotating happened in a follow-up step reading those outputs, the log path would be empty on failure and counts would always render as `?`. Doing everything in one shell means the same process that has the log path also writes the artifact.
+
+When a suite fails (real test failure, format drift, or non-zero exit for any other reason), the run-tests step exits non-zero → the matrix job fails → `tests-conclusion` (§2.4) catches it via `needs.test.result`. The upload step uses `if: always()`, so the result JSON is still produced and uploaded even when the run-tests step failed. The summary job uses `if: !cancelled()`, so it still runs and posts/upserts the comment even when some matrix entries failed.
+
+### 2.3 `summary`
+
+Runs after `discover` + `test`. Conditions:
+
+- `if: !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false`
+- `permissions: pull-requests: write, contents: read`
+
+Steps:
+
+1. Downloads all `test-result-*` artifacts (merge-multiple).
+2. Calls [`.github/scripts/aggregate-action-tests.sh`](../.github/scripts/aggregate-action-tests.sh), which builds the markdown (§6) and:
+   - upserts the PR comment via `gh api`;
+   - appends the same body to `$GITHUB_STEP_SUMMARY` so the run page shows it inline (§11);
+   - emits a single headline annotation summarizing the totals (§11).
+
+### 2.4 `tests-conclusion`
+
+Single, no-matrix terminal job. `needs: [discover, test]`, with the same fork guard as §7:
+
+```yaml
+if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+```
+
+Fails if `needs.discover.result != success`, or if `needs.test.result` is `failure` or `cancelled`. Treats `success` and `skipped` as passing (`skipped` happens when `tests-matrix` is empty). This is the stable check name that branch protection will be configured to require — independent of which suites exist at any given time.
+
+## 3. Discovery rules and exclusions
+
+Discovery globs `*/action.yml` from the repo root. The following directories are **excluded by name**, regardless of whether `run_all_tests.sh` is present:
+
+| Excluded | Reason |
+|---|---|
+| `create-tf-vars-matrix` | Has a known-flaky `test_action_source.sh` harness that requires a real tty and may fail on pristine main. Documented in [`CLAUDE.md`](../CLAUDE.md). Not yet ported to the modern `run_all_tests.sh` shape. |
+
+`.github/` is naturally excluded because the glob is `*/action.yml`, not `**/action.yml`.
+
+When an excluded directory gets a real `run_all_tests.sh` later, drop it from the exclusion list in the same PR.
+
+## 4. Test-count parsing contract
+
+The per-action test job parses these three lines from the suite's stdout:
+
+```text
+Tests run:    <N>
+Tests passed: <N>
+Tests failed: <N>
+```
+
+This format is set by the template in [Action-implementation-guide.md §`run_all_tests.sh`](Action-implementation-guide.md#run_all_testssh--automated-tests) and is currently emitted by all 8 modern suites.
+
+Multi-step orchestrator scripts (e.g. [`aggregate-validation-summaries/run_all_tests.sh`](../aggregate-validation-summaries/run_all_tests.sh)) emit these lines once **per delegated step script**. The parser sums them, so the action's totals are the sum across its sub-suites.
+
+ANSI color codes around the numbers are tolerated — the parser greps with a regex that allows optional escape sequences before the digit.
+
+### 4.1 What if a new suite diverges from this format?
+
+Two options, in order of preference:
+
+1. Fix the suite to match the convention (it's three lines of `echo`).
+2. Add a fallback parser to the workflow that handles the divergence.
+
+(2) is a last resort. Drift makes the spec less useful.
+
+### 4.2 Drift is enforced by CI
+
+The workflow validates each suite's stdout against this format and **fails the test job** if any of the three lines is missing. The drifted suite shows up in the PR comment as ❌ Fail with `?` for counts, and the run page gets a `::error title=Suite format drift` annotation pointing here.
+
+This means a new (or modified) suite that doesn't emit the canonical lines will block merge through the [`tests-conclusion`](#24-tests-conclusion) check. The check is intentionally strict — quiet drift would erode the comment's usefulness over time.
+
+## 5. Result-JSON artifact shape
+
+Each `test-result-<action>` artifact contains exactly one file `result-<action>.json` with this shape:
+
+```json
+{
+  "action": "parse-terraform-plan",
+  "outcome": "success",
+  "tests-run": 20,
+  "tests-passed": 20,
+  "tests-failed": 0,
+  "duration-seconds": 14,
+  "job-url": "https://github.com/.../actions/runs/123/job/456"
+}
+```
+
+- `outcome` is `success` (suite exited 0 and emitted the canonical summary lines) or `failure` (any other case — non-zero exit and/or format drift). Cancelled jobs never reach the artifact-write step, so `cancelled`/`skipped` outcomes never appear on disk.
+- `job-url` points to the specific matrix job's page. Resolved at runtime via `gh api /repos/{owner}/{repo}/actions/runs/{run_id}/jobs`, filtering for the job whose name ends with `(<action>)`. Falls back to the run page URL if the lookup fails.
+- On format drift (§4.2), `tests-run`/`tests-passed`/`tests-failed` are all `null` and the comment renders them as `?`. On a non-drift failure the counts are always parseable, so they're always integers.
+
+## 6. PR comment shape
+
+Single comment per PR. Identified by an HTML-comment marker on the first line. Upsert semantics: if a comment matching the marker exists, edit in place; otherwise post fresh.
+
+Marker:
+
+```html
+<!-- action-tests-summary -->
+```
+
+This is *not* a backtick-delimited heading prefix like the `aggregate-validation-summaries` action uses, because we only have one comment per PR — substring collision isn't a concern, and an HTML comment is invisible to readers.
+
+Body layout (red example shown; on a green run the row table is all ✅ and the headline drops the trailing "… suite(s) not passing" clause):
+
+````markdown
+<!-- action-tests-summary -->
+### 🧪 Action test results
+
+**Total: 212 tests across 8 suites — 210 passed, 2 failed, 1 suite(s) not passing**
+
+**Tested (8)**
+
+| Action | Result | Tests | Details |
+|---|:---:|:---:|---|
+| aggregate-validation-summaries | ✅ Pass | 28 / 28 | [job log](…) |
+| auto-merge-pr | ✅ Pass | 24 / 24 | [job log](…) |
+| parse-terraform-plan | ❌ Fail | 5 / 7 | [job log](…) |
+| … | … | … | … |
+
+**Not tested yet (10)** — modernization candidates
+
+<details><summary>Show list</summary>
+
+- create-tf-vars-matrix
+- export-env-vars
+- terraform-init
+- …
+
+</details>
+
+_Run: [workflow run](https://github.com/…/actions/runs/<id>) · Commit: `<sha>`_
+````
+
+Conventions:
+
+- Status icons match `aggregate-validation-summaries`: ✅ success, ❌ failure, ⚠ cancelled, ⏭ skipped. In practice only ✅ and ❌ show up — see §5 (outcomes that reach the artifact).
+- The headline has two variants: `… <passed> passed, <failed> failed` on a fully green run, and `… <passed> passed, <failed> failed, <N> suite(s) not passing` whenever any suite isn't a clean pass. Same logic powers the headline annotation (§11.2).
+- The "Tests" column shows `passed / run`. Failed count = `run - passed`; not shown explicitly to keep the table tight. A drifted suite shows as `?` here.
+- "Not tested yet" is collapsed by default (`<details>`) so it doesn't dominate once it shrinks. It is *always* present, even when empty — an empty list communicates "we test everything", which is a meaningful state.
+- Both action lists are alphabetically sorted.
+- Tested rows are sorted alphabetically. Failed rows are *not* hoisted to the top — relative ordering stays stable across PRs and the status icon already draws the eye.
+
+### 6.1 Upsert mechanics
+
+[`aggregate-action-tests.sh`](../.github/scripts/aggregate-action-tests.sh):
+
+1. `gh api --paginate /repos/{owner}/{repo}/issues/{pr}/comments` to list comments.
+2. Filter to those whose body starts with `<!-- action-tests-summary -->`.
+3. If exactly one match: `gh api -X PATCH /repos/{owner}/{repo}/issues/comments/{id} -F body=@<file>` (edit in place).
+4. If zero matches: `gh api -X POST /repos/{owner}/{repo}/issues/{pr}/comments -F body=@<file>` (fresh).
+5. If two or more matches (shouldn't happen, but guard anyway): delete all but the oldest, then PATCH the oldest.
+
+GitHub API failure during list/post: log a warning, exit non-zero, fail the `summary` job. The `tests-conclusion` job does *not* depend on `summary`, so a posting failure doesn't gate the PR — but it does light up the workflow with a clear red signal.
+
+## 7. Triggers and fork handling
+
+```yaml
+on:
+  pull_request:
+  workflow_dispatch:
+```
+
+Fork guard:
+
+```yaml
+if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+```
+
+This guard lives on `discover`, `summary`, and `tests-conclusion`. The `test` matrix job is implicitly gated because it has `needs: discover` — when discover is skipped, the matrix is too. The summary job has the same fork condition AND-ed into its existing `if:`.
+
+The workflow does **not** run on PRs from forks. `GITHUB_TOKEN` is read-only on fork PRs and the summary job couldn't post the comment; running the matrix without a working summary defeats the purpose. DSB's working model is internal contributors, so this is acceptable. If a fork-PR use case appears later, revisit — the safe path would be to skip-only-the-comment, not switch to `pull_request_target`.
+
+`workflow_dispatch` is included for manual triggering during development of the workflow itself.
+
+Path filters: intentionally omitted. Suites are cheap (seconds each), and "did this workflow run at all" being load-bearing for branch protection is simpler with no filters.
+
+## 8. Files involved
+
+| Path | Purpose |
+|---|---|
+| `docs/Testing-in-ci.md` | This doc. |
+| `.github/workflows/action-tests.yml` | The PR workflow (§2). |
+| `.github/scripts/discover-actions.sh` | Discovery script (§2.1, §3). |
+| `.github/scripts/aggregate-action-tests.sh` | Summary builder + PR-comment upsert (§6). |
+| `<action>/run_all_tests.sh` | The actual test suites — owned by each action, not by this workflow. |
+
+The two `.github/scripts/` files follow the script conventions from [Action-implementation-guide.md](Action-implementation-guide.md): `#!/bin/env bash`, `set -o nounset`, a `main` function, and an explicit `exit ${_main_exit_code}` at the end. They do *not* live inside composite actions — they're internal to this one workflow.
+
+`jq`, `yq`, `gh`, `python3`, and standard coreutils are assumed to be present on the `ubuntu-latest` runner. No install logic is bundled.
+
+## 9. Adding a new test suite
+
+When a legacy action gets modernized and gains a `run_all_tests.sh`:
+
+1. Make sure the suite prints the three `Tests run:` / `Tests passed:` / `Tests failed:` lines (§4).
+2. Drop the action name from the §3 exclusion list if it was there.
+3. That's it — discovery picks it up automatically on the next PR run.
+
+## 10. Removing a test suite
+
+If a suite needs to be skipped (e.g. genuinely flaky on CI, pending fix):
+
+1. Add the action's directory name to the §3 exclusion table with a short reason and a tracking link.
+2. Re-run CI and confirm the action moves from the "Tested" section to "Not tested yet".
+
+Don't disable suites by deleting their `run_all_tests.sh` — the exclusion table is the audit trail.
+
+## 11. Run-page reporting
+
+The PR comment (§6) is the primary view, but it lives on the PR conversation timeline and is hidden on non-PR triggers like `workflow_dispatch`. To make the same information visible directly on the **workflow run page**, the workflow also emits annotations and writes a step summary.
+
+### 11.1 Per-suite annotations
+
+Each `test` matrix job emits at most one annotation via the workflow log commands (`::error`, `::warning`, `::notice`) depending on the suite's outcome:
+
+| Outcome | Annotation level | Title | Message |
+|---|---|---|---|
+| `success` | _(silent)_ | — | — |
+| `failure` (format drift, §4.2) | `::error` | `Suite format drift` | `<action>/run_all_tests.sh did not emit canonical summary lines (missing: …). See docs/Testing-in-ci.md §4 and docs/Action-implementation-guide.md.` |
+| `failure` (suite exited non-zero, format OK) | `::error` | `Action tests failed` | `<action>: <passed>/<run> tests passed (<failed> failed)` |
+| `cancelled` | _(silent)_ | — | — |
+
+Two emissions never coexist: drift is detected before parsing, and a drifted suite is always classified as `failure` with the drift annotation. A non-drift failure always has parseable counts because the drift check passed first.
+
+Success is deliberately silent — a green run with 8 passing matrix entries shouldn't produce 8 noise annotations. Cancelled jobs are also silent because the merged run-tests step never reaches the annotation code when SIGTERM'd; GitHub's own "Job was cancelled" marker covers the case.
+
+### 11.2 Aggregate headline annotation
+
+The `summary` job emits **one** annotation summarizing the whole run:
+
+| Condition | Level | Title | Message |
+|---|---|---|---|
+| Any `tests-failed > 0` or any suite `outcome != "success"` | `::error` | `Action tests: failures` | `<run> tests across <suites> suites — <passed> passed, <failed> failed, <N> suite(s) not passing` |
+| All suites passed | `::notice` | `Action tests: all green` | `<run> tests across <suites> suites — <passed> passed, 0 failed` |
+
+The `outcome != "success"` condition matters because a suite hit by §4.2 format drift (or any crash before the count lines are emitted) has `tests-failed = null`, which would otherwise count as zero. The suite-level outcome catches it.
+
+This guarantees every PR run has at least one annotation in the Annotations panel — green runs get one notice with the headline numbers; red runs get the headline error plus one per-suite error.
+
+### 11.3 Step summary
+
+The `summary` job also appends the full markdown body (the same one used for the PR comment, §6) to `$GITHUB_STEP_SUMMARY`. This renders on the workflow run page's "Summary" tab. The HTML marker on the first line is invisible there.
+
+Step summaries are scoped to a single run — they don't accumulate or get reconciled across runs, so the upsert mechanics from §6.1 don't apply here.
+
+### Why two mechanisms
+
+The PR comment, annotations, and step summary serve different audiences:
+
+- **PR comment** — for reviewers scanning the PR conversation. Persistent, edits in place across re-runs.
+- **Annotations** — for anyone scanning a workflow run for what went wrong. Short, high-signal, surfaced in multiple places in the GitHub UI (the run page, the PR checks pane, status check tooltips).
+- **Step summary** — for anyone on the run page who wants the full picture without opening a comment or clicking through to a PR. Also the only run-page view that survives for non-PR triggers.
+
+The same totals appear in all three, so they stay consistent — there's a single source of truth (the result-JSON artifacts) feeding all three.
+
+## 12. Verification
+
+When changing anything in this workflow — the YAML, either of the scripts, or the spec — verify it both locally before pushing and live in CI after pushing. Skip these steps and you risk breaking the only signal that catches regressions across this whole repo.
+
+### 12.1 Local smoke tests (before pushing)
+
+**YAML and bash syntax** — fast sanity check:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/action-tests.yml'))"
+bash -n .github/scripts/discover-actions.sh
+bash -n .github/scripts/aggregate-action-tests.sh
+```
+
+**Discovery script** — confirm it partitions actions correctly:
+
+```bash
+bash .github/scripts/discover-actions.sh
+# Expect: tests-matrix=[...] and no-tests-list=[...] on stdout, with create-tf-vars-matrix
+# in the no-tests list (regardless of file presence — see §3).
+```
+
+**Aggregator script** — exercise it with fixture results in DRY_RUN so it builds the markdown without trying to post:
+
+```bash
+results_dir=$(mktemp -d)
+cat > "${results_dir}/result-foo.json" <<'JSON'
+{"action":"foo","outcome":"success","tests-run":10,"tests-passed":10,"tests-failed":0,"duration-seconds":3,"job-url":"https://example.com/job/1"}
+JSON
+cat > "${results_dir}/result-bar.json" <<'JSON'
+{"action":"bar","outcome":"failure","tests-run":8,"tests-passed":6,"tests-failed":2,"duration-seconds":5,"job-url":"https://example.com/job/2"}
+JSON
+
+DRY_RUN=true \
+GITHUB_STEP_SUMMARY=/tmp/step-summary.md \
+RESULTS_DIR="${results_dir}" \
+NO_TESTS_LIST='["create-tf-vars-matrix","terraform-init"]' \
+PR_NUMBER=1 \
+GITHUB_REPOSITORY=dsb-norge/github-actions-terraform \
+GITHUB_SERVER_URL=https://github.com \
+GITHUB_RUN_ID=1 \
+GITHUB_SHA=0000000 \
+bash .github/scripts/aggregate-action-tests.sh
+# Expect: markdown body printed on stderr, ::error annotation for 2 failures,
+# step summary appended to /tmp/step-summary.md, "DRY_RUN=true — skipping comment upsert."
+```
+
+**Suite-format conformance sweep** — every suite must emit the canonical lines (§4). Run them all and grep:
+
+```bash
+for d in */run_all_tests.sh; do
+  log=$(bash "${d}" 2>&1)
+  stripped=$(echo "${log}" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g')
+  for needle in 'Tests run:' 'Tests passed:' 'Tests failed:'; do
+    if ! echo "${stripped}" | grep -qE "^${needle}[[:space:]]+[0-9]+"; then
+      echo "DRIFT: ${d} missing '${needle}'"
+    fi
+  done
+done
+# Expect: no DRIFT output. CI enforces this too (§4.2), but catching it locally is faster.
+```
+
+**End-to-end dry run** — chain discover + every suite + aggregator and inspect the rendered comment body. Useful when changing the markdown layout:
+
+```bash
+tmp=$(mktemp); GITHUB_OUTPUT="${tmp}" bash .github/scripts/discover-actions.sh
+tests_matrix=$(grep '^tests-matrix='   "${tmp}" | cut -d= -f2-)
+no_tests_list=$(grep '^no-tests-list=' "${tmp}" | cut -d= -f2-)
+rm -f "${tmp}"
+
+results_dir=$(mktemp -d)
+for a in $(echo "${tests_matrix}" | jq -r '.[]'); do
+  out=$(bash "${a}/run_all_tests.sh" 2>&1) || true
+  stripped=$(echo "${out}" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g')
+  r=$(awk '/^Tests run:[[:space:]]+[0-9]+/    {s+=$3} END {print s+0}' <<<"${stripped}")
+  p=$(awk '/^Tests passed:[[:space:]]+[0-9]+/ {s+=$3} END {print s+0}' <<<"${stripped}")
+  f=$(awk '/^Tests failed:[[:space:]]+[0-9]+/ {s+=$3} END {print s+0}' <<<"${stripped}")
+  jq -n --arg a "$a" --arg o success --argjson r "$r" --argjson p "$p" --argjson f "$f" --argjson d 0 \
+    --arg u "https://github.com/dsb-norge/github-actions-terraform/actions/runs/0" \
+    '{action:$a,outcome:$o,"tests-run":$r,"tests-passed":$p,"tests-failed":$f,"duration-seconds":$d,"job-url":$u}' \
+    > "${results_dir}/result-${a}.json"
+done
+
+DRY_RUN=true RESULTS_DIR="${results_dir}" NO_TESTS_LIST="${no_tests_list}" \
+  PR_NUMBER=0 GITHUB_REPOSITORY=dsb-norge/github-actions-terraform \
+  GITHUB_SERVER_URL=https://github.com GITHUB_RUN_ID=0 GITHUB_SHA=0000000 \
+  bash .github/scripts/aggregate-action-tests.sh 2>&1
+rm -rf "${results_dir}"
+```
+
+### 12.2 Live CI verification (after pushing)
+
+Push the branch and open a draft PR. Then confirm each surface works.
+
+**Job status** — every job in the workflow should turn green (or `tests-conclusion` should turn red if any suite legitimately failed):
+
+```bash
+gh pr checks <pr-number>
+```
+
+Expect rows for `🔎 Discover actions`, one `🧪 Test (<action>)` per modern suite, `📝 Aggregate summary`, and `tests-conclusion` (the gate job is intentionally plain so the required-check label reads cleanly).
+
+**PR comment** — should appear once on the first run, edit in place on subsequent runs (`updated_at` advances; the comment count stays at one):
+
+```bash
+gh api repos/<owner>/<repo>/issues/<pr-number>/comments \
+  --jq '.[] | select(.body | startswith("<!-- action-tests-summary -->")) | {id, created_at, updated_at}'
+
+# Body footer should reference the latest workflow run id:
+gh api repos/<owner>/<repo>/issues/comments/<id> --jq '.body' | grep '_Run:'
+```
+
+**Annotations** — both per-suite and headline annotations should appear:
+
+```bash
+run_id=<from gh pr checks output>
+for job_id in $(gh api "repos/<owner>/<repo>/actions/runs/${run_id}/jobs" --paginate --jq '.jobs[].id'); do
+  job_name=$(gh api "repos/<owner>/<repo>/actions/jobs/${job_id}" --jq '.name')
+  anns=$(gh api "repos/<owner>/<repo>/check-runs/${job_id}/annotations" \
+    --jq '.[] | "[" + .annotation_level + "] " + (.title // "") + ": " + (.message // "")' 2>/dev/null)
+  [[ -n "${anns}" ]] && { echo "--- ${job_name} ---"; echo "${anns}"; }
+done
+```
+
+Expect: at minimum a `[notice]` headline from the `📝 Aggregate summary` job; on a red run, also one `[error]` per failed suite from the corresponding `🧪 Test (<action>)` jobs.
+
+**Step summary** — open the workflow run page in the browser; the "Summary" tab should render the same markdown as the PR comment (totals, tested table, not-tested-yet list, footer with run link). This is the only surface that's not API-accessible; visual check only.
+
+**Deprecation warnings** — scan all job logs to ensure no action version is throwing deprecation notices:
+
+```bash
+for job_id in $(gh api "repos/<owner>/<repo>/actions/runs/${run_id}/jobs" --paginate --jq '.jobs[].id'); do
+  gh api "repos/<owner>/<repo>/actions/jobs/${job_id}/logs" 2>/dev/null \
+    | grep -iE 'node\.js [0-9]+ actions are deprecated|deprecation' \
+    | head -2
+done
+```
+
+(Internal Node `Buffer()` warnings from third-party actions can be ignored; they're not actionable from this workflow.)
+
+### 12.3 Suite-conformance sweep on legacy modernization
+
+When converting a legacy action to gain a `run_all_tests.sh`, run the conformance sweep from §12.1 against just the new file before opening the PR. CI will catch drift on push (§4.2), but failing fast locally saves a round-trip.

--- a/docs/Testing-in-ci.md
+++ b/docs/Testing-in-ci.md
@@ -32,7 +32,7 @@ discover  ─►  test (matrix, fan-out)  ─►  summary  ─►  tests-conclus
 
 ### 2.1 `discover`
 
-Scans top-level `*/action.yml` files in the checkout. For each action directory, classifies as:
+Scans top-level `*/action.yml` and `*/action.yaml` files in the checkout (both extensions exist in this repo). For each action directory, classifies as:
 
 - **has-tests** if `run_all_tests.sh` exists, *and* the directory is not on the explicit exclusion list (§3).
 - **no-tests** otherwise.
@@ -82,13 +82,13 @@ Fails if `needs.discover.result != success`, or if `needs.test.result` is `failu
 
 ## 3. Discovery rules and exclusions
 
-Discovery globs `*/action.yml` from the repo root. The following directories are **excluded by name**, regardless of whether `run_all_tests.sh` is present:
+Discovery globs both `*/action.yml` and `*/action.yaml` from the repo root. The following directories are **excluded by name**, regardless of whether `run_all_tests.sh` is present:
 
 | Excluded | Reason |
 |---|---|
 | `create-tf-vars-matrix` | Has a known-flaky `test_action_source.sh` harness that requires a real tty and may fail on pristine main. Documented in [`CLAUDE.md`](../CLAUDE.md). Not yet ported to the modern `run_all_tests.sh` shape. |
 
-`.github/` is naturally excluded because the glob is `*/action.yml`, not `**/action.yml`.
+`.github/` is naturally excluded because the glob is `*/action.{yml,yaml}`, not `**/action.{yml,yaml}`.
 
 When an excluded directory gets a real `run_all_tests.sh` later, drop it from the exclusion list in the same PR.
 
@@ -106,7 +106,7 @@ This format is set by the template in [Action-implementation-guide.md §`run_all
 
 Multi-step orchestrator scripts (e.g. [`aggregate-validation-summaries/run_all_tests.sh`](../aggregate-validation-summaries/run_all_tests.sh)) emit these lines once **per delegated step script**. The parser sums them, so the action's totals are the sum across its sub-suites.
 
-ANSI color codes around the numbers are tolerated — the parser greps with a regex that allows optional escape sequences before the digit.
+ANSI color codes around the numbers are tolerated — escapes are stripped before matching. Each line is anchored on both ends (`^Tests run:[[:space:]]+[0-9]+[[:space:]]*$`) so a suffix like `Tests run: 7 (extra info)` is rejected as drift; a trailing space or two is fine.
 
 ### 4.1 What if a new suite diverges from this format?
 
@@ -355,15 +355,15 @@ bash .github/scripts/aggregate-action-tests.sh
 # step summary appended to /tmp/step-summary.md, "DRY_RUN=true — skipping comment upsert."
 ```
 
-**Suite-format conformance sweep** — every suite must emit the canonical lines (§4). Run them all and grep:
+**Suite-format conformance sweep** — every suite must emit the canonical lines (§4). Run them all and grep with the same anchored regex CI uses:
 
 ```bash
 for d in */run_all_tests.sh; do
   log=$(bash "${d}" 2>&1)
   stripped=$(echo "${log}" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g')
   for needle in 'Tests run:' 'Tests passed:' 'Tests failed:'; do
-    if ! echo "${stripped}" | grep -qE "^${needle}[[:space:]]+[0-9]+"; then
-      echo "DRIFT: ${d} missing '${needle}'"
+    if ! echo "${stripped}" | grep -qE "^${needle}[[:space:]]+[0-9]+[[:space:]]*$"; then
+      echo "DRIFT: ${d} missing or non-canonical '${needle}'"
     fi
   done
 done


### PR DESCRIPTION
## Motivation

This repo ships ~18 composite actions; 8 currently have modern `run_all_tests.sh` suites (per `docs/Action-implementation-guide.md`), and more land as legacy actions are converted. Until now those suites only ran locally — there was no CI signal to catch a broken test in review. This PR adds a workflow that runs every existing suite on each PR, reports the result on three surfaces, and exposes one stable status check intended to be required by branch protection.

## What lands

**Workflow** — `.github/workflows/action-tests.yml`

Four jobs: `discover` (dynamically partitions actions into has-tests / no-tests) → `test` (matrix, one job per suite, `fail-fast: false`) → `summary` (PR comment + step summary + headline annotation) → `tests-conclusion` (the single check name to require).

**Three reporting surfaces, same totals:**

1. **PR comment** — one upserted comment with a totals headline, a `passed/run` table for tested suites, and a collapsed list of suites without tests (modernization candidates).
2. **Run-page annotations** — per-suite `::error` for failed/drifted suites, plus one headline `::notice` (green) or `::error` (red) summarizing the whole run.
3. **Step summary** — the same markdown body appended to `$GITHUB_STEP_SUMMARY`, so the workflow run page's Summary tab shows the table inline.

**Canonical summary-line contract, enforced**

Suites must emit `Tests run: N` / `Tests passed: N` / `Tests failed: N` on stdout. The workflow validates this; any suite missing one of the lines fails its matrix job with a `::error title=Suite format drift` annotation and blocks `tests-conclusion`. Spec §4.2.

**Living spec** — `docs/Testing-in-ci.md`

Full design as the source of truth: discovery rules, result-JSON shape, comment shape + upsert mechanics, fork handling, reporting surfaces, and a verification section (§12) with copy-paste local smoke-tests and live-CI checks for future implementers.

**Conformance fix** — `auto-merge-pr/run_all_tests.sh`

Was emitting `Total tests: / Passed: / Failed:` — switched to the canonical format so its counts aggregate.

## Verified live on this PR

- ✅ Happy path: 212 tests across 8 suites, all green, `[notice]` headline annotation, comment upserted in place across pushes.
- ✅ Format drift: deliberately broke one suite's summary lines — `tests-conclusion` went red, `Suite format drift` annotation fired, comment showed `?` counts.
- ✅ Partial-failure: deliberately failed 2 of 7 tests in one suite — counts showed `5 / 7`, per-suite `::error` annotated `5/7 tests passed (2 failed)`, headline annotated `… 1 suite(s) not passing`, `tests-conclusion` red.
- Each test was reverted; final commits are clean.

## Follow-ups (out of scope for this PR)

- Mark `tests-conclusion` required on `main` in branch-protection settings.
- As legacy actions get modernized and gain a `run_all_tests.sh`, they automatically join the matrix on the next PR — no workflow edit needed.