### PR TITLE
feat: add Plan time row (mm:ss) to PR comment tables

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -513,6 +513,11 @@ jobs:
           # count is missing/'?' (see docs/Workflow-pr-comments.md).
           plan-count-total: ${{ steps.parse-plan.outputs.count-total }}
           plan-has-output-only-changes: ${{ steps.parse-plan.outputs.has-output-only-changes }}
+          # Wall-clock duration of the terraform plan command (mm:ss). Always
+          # populated by terraform-plan@v0 — even when plan fails — so the
+          # Plan time row in the PR comment surfaces "slow + failing" at a
+          # glance instead of forcing a click into the job log.
+          plan-time: ${{ steps.plan.outputs.plan-time }}
         continue-on-error: true # allow job to continue, step outcome is ignored
 
       - name: 🏷️ Add validation summary as pull request comment

--- a/aggregate-validation-summaries/helpers_additional.sh
+++ b/aggregate-validation-summaries/helpers_additional.sh
@@ -113,6 +113,25 @@ function _render_plan_details_cell {
   echo "${cell}"
 }
 
+# Render the Plan time cell for a single env in the grouped table.
+# Empty input → "—" (matches the existing 'not applicable' fallback from
+# _status_emoji_and_title for missing data). Non-empty values are wrapped
+# in backticks for a monospace look that aligns with the rest of the
+# data badges in the table.
+# Both branches wrap the cell in <span title="mm:ss (minutes:seconds)"> so
+# desktop-hover discloses the value's unit — even on the em-dash branch,
+# where the dash itself communicates absence and the tooltip explains
+# what would otherwise be there.
+function _render_plan_time_cell {
+  local v="${1:-}"
+  local title='mm:ss (minutes:seconds)'
+  if [ -z "${v}" ]; then
+    echo "<span title=\"${title}\">—</span>"
+    return
+  fi
+  echo "<span title=\"${title}\">\`${v}\`</span>"
+}
+
 # Render the Links cell for a single env (0-2 lines, <br>-separated).
 # Each argument may be empty — the corresponding line is omitted. Both empty
 # yields an empty cell rather than a row of stray pipes.

--- a/aggregate-validation-summaries/helpers_additional.sh
+++ b/aggregate-validation-summaries/helpers_additional.sh
@@ -6,11 +6,14 @@
 # by helpers.sh.
 #
 
-# Family prefix shared by every per-group comment this action manages.
-# Used both for delete-by-prefix reconciliation and to identify orphans
-# whose specific group name is no longer in the desired set.
+# Family marker shared by every per-group comment this action manages.
+# Lives on the first line of the body as an HTML comment so it's invisible
+# to readers. The per-group marker (built via _group_marker) extends this
+# with the group name and a trailing ' -->', allowing a single PR to host
+# multiple group comments and have each one upserted independently.
+# Renders to nothing in the GitHub Markdown view.
 # See docs/Workflow-pr-comments.md §2.
-declare -gr GROUP_COMMENT_FAMILY_PREFIX='### Terraform validation summary for group: '
+declare -gr GROUP_COMMENT_MARKER_FAMILY='<!-- terraform-validation-summary-group:'
 
 # Per-env comment prefix template (uses backtick-delimited env name so
 # partial matches can't collide).
@@ -20,10 +23,20 @@ function _per_env_prefix {
   echo "### Terraform validation summary for environment: \`${env_name}\`"
 }
 
-# Specific group comment prefix for one group name.
+# Specific group comment H3 heading (rendered immediately after the marker
+# at the top of the body). Kept for visible identification — users still
+# see "for group: \`<group>\`" — but no longer load-bearing for upsert
+# identity. The marker (_group_marker) is the load-bearing handle.
 function _group_prefix {
   local group_name="${1}"
-  echo "${GROUP_COMMENT_FAMILY_PREFIX}\`${group_name}\`"
+  echo "### Terraform validation summary for group: \`${group_name}\`"
+}
+
+# Per-group HTML marker. Unique per group so multiple groups on the same
+# PR can be upserted independently.
+function _group_marker {
+  local group_name="${1}"
+  echo "${GROUP_COMMENT_MARKER_FAMILY}${group_name} -->"
 }
 
 # Map a GitHub Actions step outcome string to the (emoji, title) pair used
@@ -190,4 +203,11 @@ function _gh_delete_comment {
 function _gh_post_comment {
   local repo="${1}" pr="${2}" body_file="${3}"
   gh api -X POST "repos/${repo}/issues/${pr}/comments" -F "body=@${body_file}" --jq '.id'
+}
+
+# Edits an existing comment in place. Body file convention matches
+# _gh_post_comment so callers can use the same temp file for either op.
+function _gh_patch_comment {
+  local repo="${1}" comment_id="${2}" body_file="${3}"
+  gh api -X PATCH "repos/${repo}/issues/comments/${comment_id}" -F "body=@${body_file}" --jq '.id'
 }

--- a/aggregate-validation-summaries/run_all_tests.sh
+++ b/aggregate-validation-summaries/run_all_tests.sh
@@ -60,6 +60,20 @@ case "$*" in
     fi
     echo '{"deleted": true}'
     ;;
+  *"-X PATCH"*"/issues/comments/"*)
+    if [ "${GH_FAKE_PATCH_EXIT:-0}" != "0" ]; then
+      exit "${GH_FAKE_PATCH_EXIT}"
+    fi
+    # Extract the comment id from the URL and echo it — matches production
+    # _gh_patch_comment which uses --jq '.id' on the response.
+    # URL form: repos/<repo>/issues/comments/<id>
+    for arg in "$@"; do
+      if [[ "${arg}" == repos/*"/issues/comments/"* ]]; then
+        echo "${arg##*/}"
+        break
+      fi
+    done
+    ;;
   *"-X POST"*)
     if [ "${GH_FAKE_POST_EXIT:-0}" != "0" ]; then
       exit "${GH_FAKE_POST_EXIT}"
@@ -79,7 +93,7 @@ FAKE_GH
   export GH_FAKE_CALL_LOG="${TEST_DIR}/gh-calls.log"
   export GH_FAKE_LIST_RESPONSE_FILE="${TEST_DIR}/list-response.json"
   export GH_FAKE_JOBS_RESPONSE_FILE="${TEST_DIR}/jobs-response.json"
-  unset GH_FAKE_LIST_EXIT GH_FAKE_DELETE_EXIT GH_FAKE_POST_EXIT GH_FAKE_JOBS_EXIT
+  unset GH_FAKE_LIST_EXIT GH_FAKE_DELETE_EXIT GH_FAKE_POST_EXIT GH_FAKE_PATCH_EXIT GH_FAKE_JOBS_EXIT
   echo "[]" > "${GH_FAKE_LIST_RESPONSE_FILE}"
   echo "[]" > "${GH_FAKE_JOBS_RESPONSE_FILE}"
   : > "${GH_FAKE_CALL_LOG}"
@@ -253,9 +267,9 @@ test_empty_desired_empty_existing_is_noop() {
 }
 
 test_sweep_only_orphans() {
-  # No desired groups, but PR has an existing group comment from a prior run
+  # No desired groups, but PR has an existing marker comment from a prior run
   cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
-[{"id": 5001, "body": "### Terraform validation summary for group: `stale-group`\nold body"}]
+[{"id": 5001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:stale-group -->\n### Terraform validation summary for group: `stale-group`\nold body"}]
 JSON
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
@@ -264,6 +278,9 @@ JSON
   fi
   if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
     echo "did not expect POST when desired set is empty"; return 1
+  fi
+  if grep -q 'PATCH' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect PATCH on orphan"; return 1
   fi
   return 0
 }
@@ -292,27 +309,33 @@ test_post_when_no_existing() {
   return 0
 }
 
-test_mixed_reconcile() {
-  # One desired group, one orphan, one matching-prefix-existing
+test_mixed_orphan_delete_and_patch() {
+  # One desired group ('dev'), one orphan ('obsolete-group').
+  # Existing 'dev' marker is PATCHed in place (stable identity), orphan
+  # is deleted, no POST is needed.
   write_meta "alpha-dev" "dev"
   cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
 [
-  {"id": 7001, "body": "### Terraform validation summary for group: `dev`\nold matching body"},
-  {"id": 7002, "body": "### Terraform validation summary for group: `obsolete-group`\norphan body"}
+  {"id": 7001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold body"},
+  {"id": 7002, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:obsolete-group -->\n### Terraform validation summary for group: `obsolete-group`\norphan body"}
 ]
 JSON
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
-  # Both existing must be deleted (one as repost, one as orphan)
-  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7001' "${GH_FAKE_CALL_LOG}"; then
-    echo "expected DELETE of matching-prefix existing 7001"; return 1
+  # 'dev' marker is patched in place — NOT deleted
+  if grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7001' "${GH_FAKE_CALL_LOG}"; then
+    echo "did NOT expect DELETE of existing 'dev' marker 7001 — it should be PATCHed"; return 1
   fi
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/7001' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of existing 'dev' marker 7001"; return 1
+  fi
+  # Orphan marker is deleted
   if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7002' "${GH_FAKE_CALL_LOG}"; then
     echo "expected DELETE of orphan 7002"; return 1
   fi
-  # And we should have posted the fresh body for 'dev'
-  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
-    echo "expected 1 POST for desired 'dev'"; return 1
+  # No POST: 'dev' was upserted via PATCH, not a fresh post.
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST when existing marker is patched in place"; return 1
   fi
   return 0
 }
@@ -514,7 +537,7 @@ test_grouped_footer_is_condensed_v024() {
   return 0
 }
 
-test_post_pass_does_not_nest_log_groups() {
+test_upsert_pass_does_not_nest_log_groups() {
   # GitHub Actions does not support nested log groups. Verify that no
   # ::group:: line appears before a matching ::endgroup:: while another
   # ::group:: is already open.
@@ -621,13 +644,18 @@ test_plan_details_left_align_div() {
   return 0
 }
 
-test_group_prefix_byte_exact() {
+test_group_marker_then_prefix_byte_exact() {
   write_meta "envA" "dev"
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
-  # The first line of the rendered body must be the byte-exact group prefix
+  # Body line 1 must be the HTML marker (load-bearing for upsert identity).
+  # Body line 2 must be the byte-exact group H3 (still visible to readers).
+  if ! grep -q '^<!-- terraform-validation-summary-group:dev -->$' "${TEST_DIR}/step.log"; then
+    echo "expected byte-exact marker line '<!-- terraform-validation-summary-group:dev -->'"
+    return 1
+  fi
   if ! grep -q '^### Terraform validation summary for group: `dev`$' "${TEST_DIR}/step.log"; then
-    echo "expected byte-exact group prefix line"
+    echo "expected byte-exact H3 group heading"
     return 1
   fi
   return 0
@@ -701,8 +729,8 @@ test_multiple_groups_sorted_alphabetically() {
   fi
   # Per-group log group names appear in alpha order
   local order
-  order=$(grep -oE "Step 5: Posting group '[^']+'" "${TEST_DIR}/step.log" | head -3 | tr '\n' ' ')
-  local expected="Step 5: Posting group 'alpha' Step 5: Posting group 'mike' Step 5: Posting group 'zebra' "
+  order=$(grep -oE "Step 5: Upsert group '[^']+'" "${TEST_DIR}/step.log" | head -3 | tr '\n' ' ')
+  local expected="Step 5: Upsert group 'alpha' Step 5: Upsert group 'mike' Step 5: Upsert group 'zebra' "
   if [[ "${order}" != "${expected}" ]]; then
     echo "groups not in alphabetical order"
     echo "got:      ${order}"
@@ -713,15 +741,16 @@ test_multiple_groups_sorted_alphabetically() {
 }
 
 test_groups_processed_json_output() {
+  # 'dev' is desired but has no existing marker → posted fresh.
+  # 'obsolete' has an existing marker but is not desired → orphan-deleted.
   write_meta "envA" "dev"
   cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
-[{"id": 8001, "body": "### Terraform validation summary for group: `obsolete`\n"}]
+[{"id": 8001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:obsolete -->\n### Terraform validation summary for group: `obsolete`\n"}]
 JSON
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
   local processed
   processed=$(get_processed_json)
-  # Must include both orphan-deleted and posted entries
   if ! echo "${processed}" | jq -e '.[] | select(.action == "orphan-deleted" and .group == "obsolete")' >/dev/null; then
     echo "expected orphan-deleted entry for 'obsolete'"
     echo "got: ${processed}"
@@ -859,6 +888,172 @@ test_plan_time_row_position() {
   return 0
 }
 
+# --------------------------------------------------------------------------
+# Marker-based upsert behaviour
+# --------------------------------------------------------------------------
+
+# Existing single marker comment for desired group → PATCHed in place
+# (stable comment id; no fresh POST, no DELETE).
+test_existing_marker_is_patched() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 6001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold body"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6001' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of existing marker comment 6001"
+    grep -E 'PATCH|POST|DELETE' "${GH_FAKE_CALL_LOG}" || true
+    return 1
+  fi
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST when existing marker can be patched"; return 1
+  fi
+  if grep -q 'DELETE' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect DELETE when only a single matching marker exists"; return 1
+  fi
+  # Processed JSON should record action=patched
+  local processed
+  processed=$(get_processed_json)
+  if ! echo "${processed}" | jq -e '.[] | select(.action == "patched" and .group == "dev" and ."comment-id" == "6001")' >/dev/null; then
+    echo "expected processed-json entry {group: 'dev', action: 'patched', id: 6001}"
+    echo "got: ${processed}"
+    return 1
+  fi
+  return 0
+}
+
+# Multiple marker comments for the SAME group (pre-existing duplicates) →
+# oldest is PATCHed, the rest are deleted. Self-healing.
+test_duplicate_markers_delete_extras_patch_oldest() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[
+  {"id": 6100, "created_at": "2026-02-01T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nmid-age dup"},
+  {"id": 6200, "created_at": "2026-03-01T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nnewest dup"},
+  {"id": 6050, "created_at": "2026-01-15T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\noldest — should be kept"}
+]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Oldest (6050) is patched, the two newer are deleted
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6050' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of oldest duplicate 6050"
+    grep -E 'PATCH|POST|DELETE' "${GH_FAKE_CALL_LOG}" || true
+    return 1
+  fi
+  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/6100' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected DELETE of duplicate 6100"; return 1
+  fi
+  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/6200' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected DELETE of duplicate 6200"; return 1
+  fi
+  # Patched and duplicate-deleted should both appear in processed-json
+  local processed
+  processed=$(get_processed_json)
+  if ! echo "${processed}" | jq -e '.[] | select(.action == "patched" and ."comment-id" == "6050")' >/dev/null; then
+    echo "expected processed.action=patched id=6050"; echo "got: ${processed}"; return 1
+  fi
+  if ! echo "${processed}" | jq -e '[.[] | select(.action == "duplicate-deleted")] | length == 2' >/dev/null; then
+    echo "expected 2 duplicate-deleted entries"; echo "got: ${processed}"; return 1
+  fi
+  return 0
+}
+
+# Legacy comment from the pre-marker era (body starts with the H3, no
+# marker) → ignored: no DELETE, no PATCH. The system posts a fresh
+# marked comment alongside it (the no-migration trade-off — operators
+# clean up legacy comments by hand).
+test_legacy_prefix_only_comment_is_ignored() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 6300, "created_at": "2025-12-01T10:00:00Z", "body": "### Terraform validation summary for group: `dev`\nlegacy body without marker"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/6300' "${GH_FAKE_CALL_LOG}"; then
+    echo "legacy comment 6300 MUST NOT be deleted (no migration policy)"; return 1
+  fi
+  if grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6300' "${GH_FAKE_CALL_LOG}"; then
+    echo "legacy comment 6300 MUST NOT be patched"; return 1
+  fi
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
+    echo "expected exactly 1 POST (fresh marked comment alongside legacy)"; return 1
+  fi
+  return 0
+}
+
+# Marker comment body line 1 must be the per-group marker; line 2 the H3.
+# Pinning byte-level shape so accidental drift in render_group_body breaks
+# this test (and only this test).
+test_body_starts_with_marker_then_h3() {
+  write_meta "envA" "dev"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # The rendered body is echoed into the step log right after a
+  # 'aggregate-validation-summaries: Body:' line; capture the next two
+  # non-blank lines (marker + H3).
+  local body_lines
+  body_lines=$(awk '/Body:$/ {flag=1; next} flag && NF {print; if (++n == 2) exit}' "${TEST_DIR}/step.log")
+  local expected
+  expected=$'<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`'
+  if [[ "${body_lines}" != "${expected}" ]]; then
+    echo "expected marker + H3 as first two body lines (byte-exact)"
+    echo "expected: ${expected//$'\n'/ \\n }"
+    echo "got:      ${body_lines//$'\n'/ \\n }"
+    return 1
+  fi
+  return 0
+}
+
+# Two distinct groups (dev + prod) both have existing markers → both get
+# PATCHed in their own pass, neither is deleted, no POST occurs. Verifies
+# per-group markers route correctly when multiple group comments coexist.
+test_multiple_groups_each_patched() {
+  write_meta "envA" "dev"
+  write_meta "envB" "prod"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[
+  {"id": 6400, "created_at": "2026-01-15T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold dev"},
+  {"id": 6500, "created_at": "2026-01-15T10:00:00Z", "body": "<!-- terraform-validation-summary-group:prod -->\n### Terraform validation summary for group: `prod`\nold prod"}
+]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6400' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of dev marker 6400"; return 1
+  fi
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6500' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of prod marker 6500"; return 1
+  fi
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST when both groups have existing markers"; return 1
+  fi
+  if grep -q 'DELETE' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect DELETE when no orphans and no duplicates"; return 1
+  fi
+  return 0
+}
+
+# PATCH failure → fall back to POST so the comment is still visible.
+test_patch_failure_falls_back_to_post() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 6600, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold body"}]
+JSON
+  export GH_FAKE_PATCH_EXIT=22
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE} — PATCH failure should not abort"; return 1; }
+  # PATCH was attempted on 6600, failed, then POST as fallback
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6600' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH attempt before fallback"; return 1
+  fi
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
+    echo "expected exactly 1 POST as fallback after PATCH failure"; return 1
+  fi
+  return 0
+}
+
 test_post_failure_recorded_without_aborting() {
   write_meta "envA" "g"
   export GH_FAKE_POST_EXIT=22
@@ -881,7 +1076,7 @@ test_post_failure_recorded_without_aborting() {
 run_test "empty desired + empty existing is a no-op"                       test_empty_desired_empty_existing_is_noop
 run_test "sweep mode: empty desired + orphan existing → delete only"       test_sweep_only_orphans
 run_test "post mode: desired + no existing → post only"                    test_post_when_no_existing
-run_test "mixed reconcile: orphan deleted + matching reposted"             test_mixed_reconcile
+run_test "mixed upsert: orphan deleted + matching marker patched in place" test_mixed_orphan_delete_and_patch
 run_test "envs render in alphabetical column order"                        test_alphabetical_column_order
 run_test "per-env anchor resolved → log-extract link rendered"             test_per_env_anchor_resolved
 run_test "anchor missing + job URL resolved → Links shows only job log"    test_per_env_anchor_missing_but_job_url_resolved_shows_only_job_log
@@ -891,14 +1086,14 @@ run_test "Jobs API failure → 'job log' line omitted for all envs"          tes
 run_test "job URL resolution handles 'caller / Terraform (env)' prefix"   test_job_url_resolution_handles_caller_prefixed_name
 run_test "job URL resolution handles bare 'Terraform (env)' too"          test_job_url_resolution_handles_bare_name
 run_test "job URL resolution skips non-matrix jobs"                       test_job_url_resolution_skips_non_matrix_jobs
-run_test "post pass does NOT nest log groups"                              test_post_pass_does_not_nest_log_groups
+run_test "upsert pass does NOT nest log groups"                            test_upsert_pass_does_not_nest_log_groups
 run_test "grouped comment footer is condensed v0.24 [Job log] only"       test_grouped_footer_is_condensed_v024
 run_test "per-env anchor picks newest comment id when duplicates exist"    test_per_env_anchor_picks_newest_when_duplicates
 run_test "status emoji map covers success/failure/cancelled/skipped"       test_status_emoji_map
 run_test "Plan Details: optional categories appear only when non-zero"     test_plan_details_optional_categories
 run_test "Plan Details cell wraps in <div align='left'>"                   test_plan_details_left_align_div
-run_test "group prefix line is byte-exact"                                 test_group_prefix_byte_exact
-run_test "degraded mode: gh list fails → skip delete, still post"          test_degraded_mode_when_list_fails
+run_test "group marker + H3 prefix lines are byte-exact"                   test_group_marker_then_prefix_byte_exact
+run_test "degraded mode: gh list fails → skip orphan delete, fresh POST"   test_degraded_mode_when_list_fails
 run_test "malformed metadata file is skipped with warning"                 test_malformed_metadata_is_skipped
 run_test "envs without pr-comment-group are ignored"                       test_envs_without_group_are_ignored
 run_test "multiple groups are posted in alphabetical order"                test_multiple_groups_sorted_alphabetically
@@ -910,6 +1105,12 @@ run_test "Plan time row reflects per-env values across multi-env group"    test_
 run_test "Plan time row sits between Plan details and Links rows"           test_plan_time_row_position
 run_test "missing input_pr_number fails the step"                          test_missing_pr_number_fails_fast
 run_test "post failure does not abort, recorded in output"                 test_post_failure_recorded_without_aborting
+run_test "existing marker comment → PATCHed in place (stable id)"          test_existing_marker_is_patched
+run_test "duplicate markers → delete extras, PATCH oldest"                 test_duplicate_markers_delete_extras_patch_oldest
+run_test "legacy prefix-only comment → ignored (no-migration policy)"      test_legacy_prefix_only_comment_is_ignored
+run_test "body starts with marker on line 1, H3 on line 2"                 test_body_starts_with_marker_then_h3
+run_test "multiple groups: each marker patched independently"              test_multiple_groups_each_patched
+run_test "PATCH failure → fall back to POST"                               test_patch_failure_falls_back_to_post
 
 # ============================================================================
 echo ""

--- a/aggregate-validation-summaries/run_all_tests.sh
+++ b/aggregate-validation-summaries/run_all_tests.sh
@@ -110,11 +110,19 @@ teardown() {
 }
 
 # Create a metadata file in TEST_DIR.
-# Usage: write_meta <env> [group] [fmt_outcome] [extra-counts-json]
+# Usage: write_meta <env> [group] [fmt_outcome] [extra-counts-json] [plan_time]
+# When plan_time is non-empty, the plan step's outputs include a
+# "plan-time" entry — mimicking what terraform-plan@v0 now publishes.
+# Empty / unset preserves the pre-plan-time fixture shape so older tests
+# stay backwards-compatible.
 write_meta() {
-  local env="${1}" group="${2:-}" fmt_outcome="${3:-success}" counts="${4:-}"
+  local env="${1}" group="${2:-}" fmt_outcome="${3:-success}" counts="${4:-}" plan_time="${5:-}"
   local counts_default='{"count-add":"0","count-change":"0","count-destroy":"0","count-import":"0","count-move":"0","count-remove":"0"}'
   local counts_use="${counts:-${counts_default}}"
+  local plan_outputs='{}'
+  if [ -n "${plan_time}" ]; then
+    plan_outputs="{\"plan-time\": \"${plan_time}\"}"
+  fi
   cat > "${TEST_DIR}/matrix-job-meta-${env}.json" <<JSON
 {
   "metadata": {"environment": "${env}", "captured_at": "2026-01-30T12:00:00Z", "schema_version": "2.0.0"},
@@ -130,7 +138,7 @@ write_meta() {
     "fmt":         {"outcome": "${fmt_outcome}", "conclusion": "${fmt_outcome}", "outputs": {}},
     "validate":    {"outcome": "success", "conclusion": "success", "outputs": {}},
     "lint":        {"outcome": "success", "conclusion": "success", "outputs": {}},
-    "plan":        {"outcome": "success", "conclusion": "success", "outputs": {}},
+    "plan":        {"outcome": "success", "conclusion": "success", "outputs": ${plan_outputs}},
     "parse-plan":  {"outcome": "success", "conclusion": "success", "outputs": ${counts_use}}
   }
 }
@@ -734,7 +742,7 @@ test_step_row_order_byte_exact() {
   local log="${TEST_DIR}/step.log"
   # Extract just the table body rows in order
   local lines
-  lines=$(grep -oE '^\| <span title="[^"]+">' "${log}" | head -8)
+  lines=$(grep -oE '^\| <span title="[^"]+">' "${log}" | head -9)
   local expected='| <span title="Initialization">
 | <span title="Lock file">
 | <span title="Format and Style">
@@ -742,6 +750,7 @@ test_step_row_order_byte_exact() {
 | <span title="TFLint">
 | <span title="Plan">
 | <span title="Plan details">
+| <span title="Plan time">
 | <span title="Links">'
   if [[ "${lines}" != "${expected}" ]]; then
     echo "step row order mismatch"
@@ -764,6 +773,87 @@ test_missing_pr_number_fails_fast() {
   fi
   if ! grep -q 'input_pr_number is required' "${TEST_DIR}/step.log"; then
     echo "expected 'input_pr_number is required' error"
+    return 1
+  fi
+  return 0
+}
+
+# --------------------------------------------------------------------------
+# Plan time row
+# --------------------------------------------------------------------------
+
+# Plan time present in metadata → backtick-wrapped value wrapped in a
+# <span title="mm:ss (minutes:seconds)"> so desktop hover surfaces the unit.
+test_plan_time_row_renders_value() {
+  write_meta "envA" "g" "success" "" "1:23"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  local expected='| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |'
+  if ! grep -qF "${expected}" "${log}"; then
+    echo "expected Plan time row with value-cell tooltip"
+    echo "expected line: ${expected}"
+    grep -F 'Plan time' "${log}" | sed 's/^/  /'
+    return 1
+  fi
+  return 0
+}
+
+# Plan time absent from metadata → cell renders the 'not applicable' dash,
+# still wrapped in the same tooltip so the column meaning stays discoverable.
+test_plan_time_row_renders_em_dash_when_missing() {
+  write_meta "envA" "g"  # no plan_time → plan.outputs is '{}'
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  local expected='| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">—</span> |'
+  if ! grep -qF "${expected}" "${log}"; then
+    echo "expected em-dash cell with tooltip for missing plan-time"
+    echo "expected line: ${expected}"
+    grep -F 'Plan time' "${log}" | sed 's/^/  /'
+    return 1
+  fi
+  return 0
+}
+
+# Multi-env group: each env's Plan time cell reflects its own metadata,
+# rows are emitted in alphabetical column order. Each cell carries the
+# same tooltip — present-value and em-dash branches alike.
+test_plan_time_row_per_env() {
+  # Alphabetical column order makes the env-to-cell mapping predictable.
+  write_meta "alpha" "g" "success" "" "0:42"
+  write_meta "bravo" "g" "success" "" ""        # missing → "—"
+  write_meta "charlie" "g" "success" "" "2:05"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  # Build expected row: icon | label | alpha-cell | bravo-cell | charlie-cell
+  local expected='| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`0:42`</span> | <span title="mm:ss (minutes:seconds)">—</span> | <span title="mm:ss (minutes:seconds)">`2:05`</span> |'
+  if ! grep -qF "${expected}" "${log}"; then
+    echo "expected per-env Plan time row not found"
+    echo "expected line: ${expected}"
+    grep -F 'Plan time' "${log}" | sed 's/^/  /'
+    return 1
+  fi
+  return 0
+}
+
+# Plan time row sits between Plan Details and Links.
+test_plan_time_row_position() {
+  write_meta "envA" "g" "success" "" "0:05"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  local pd_line pt_line links_line
+  pd_line=$(grep -n '| <span title="Plan details">' "${log}" | head -n1 | cut -d: -f1)
+  pt_line=$(grep -n '| <span title="Plan time">'    "${log}" | head -n1 | cut -d: -f1)
+  links_line=$(grep -n '| <span title="Links">'     "${log}" | head -n1 | cut -d: -f1)
+  if [ -z "${pd_line}" ] || [ -z "${pt_line}" ] || [ -z "${links_line}" ]; then
+    echo "expected Plan details, Plan time and Links rows all present (pd=${pd_line} pt=${pt_line} links=${links_line})"
+    return 1
+  fi
+  if ! { [ "${pt_line}" -gt "${pd_line}" ] && [ "${pt_line}" -lt "${links_line}" ]; }; then
+    echo "expected Plan time row between Plan details (${pd_line}) and Links (${links_line}); got pt=${pt_line}"
     return 1
   fi
   return 0
@@ -814,6 +904,10 @@ run_test "envs without pr-comment-group are ignored"                       test_
 run_test "multiple groups are posted in alphabetical order"                test_multiple_groups_sorted_alphabetically
 run_test "groups-processed-json output records every action"               test_groups_processed_json_output
 run_test "table step rows appear in spec order"                            test_step_row_order_byte_exact
+run_test "Plan time row renders backtick-wrapped value when present"        test_plan_time_row_renders_value
+run_test "Plan time row renders em-dash '—' when plan-time missing"         test_plan_time_row_renders_em_dash_when_missing
+run_test "Plan time row reflects per-env values across multi-env group"    test_plan_time_row_per_env
+run_test "Plan time row sits between Plan details and Links rows"           test_plan_time_row_position
 run_test "missing input_pr_number fails the step"                          test_missing_pr_number_fails_fast
 run_test "post failure does not abort, recorded in output"                 test_post_failure_recorded_without_aborting
 

--- a/aggregate-validation-summaries/step_aggregate.sh
+++ b/aggregate-validation-summaries/step_aggregate.sh
@@ -339,6 +339,17 @@ function render_group_body {
     plan_details_row+=" $(_render_plan_details_cell "${c_add}" "${c_change}" "${c_destroy}" "${c_import}" "${c_move}" "${c_remove}") |"
   done
 
+  # ---- Plan time row ----
+  # Sits below Plan details so timing reads as supplementary plan info,
+  # not as a step-status row alongside init/fmt/validate/lint/plan.
+  local plan_time_row="| $(_render_step_icon_cell "⏱" "Plan time") | Plan time |"
+  for env in "${envs[@]}"; do
+    local meta_file="${DESIRED_META[${group_name}/${env}]:-}"
+    local pt
+    pt=$(_extract_plan_time "${meta_file}")
+    plan_time_row+=" $(_render_plan_time_cell "${pt}") |"
+  done
+
   # ---- Links row ----
   local links_row="| $(_render_step_icon_cell "🔗" "Links") | Links |"
   for env in "${envs[@]}"; do
@@ -356,12 +367,15 @@ function render_group_body {
   footer=$(_render_footer "${first_env_meta_file}")
 
   # ---- Assembly ----
-  printf '%s\n%s\n%s\n%s%s\n%s\n\n%s\n' \
+  # rows ends with a trailing newline; the rest are plain rows with no
+  # trailing newline, so the format string supplies the line breaks.
+  printf '%s\n%s\n%s\n%s%s\n%s\n%s\n\n%s\n' \
     "${prefix}" \
     "${header}" \
     "${sep}" \
     "${rows}" \
     "${plan_details_row}" \
+    "${plan_time_row}" \
     "${links_row}" \
     "${footer}"
 }
@@ -385,6 +399,19 @@ function _extract_plan_count {
   [ -z "${file}" ] || [ ! -f "${file}" ] && { echo ""; return; }
   local val
   val=$(jq -r --arg k "${key}" '.steps["parse-plan"].outputs[$k] // ""' "${file}" 2>/dev/null || echo "")
+  [ "${val}" = "null" ] && val=""
+  echo "${val}"
+}
+
+# Extract the plan-time (mm:ss) emitted by terraform-plan from the metadata
+# file. Empty when terraform-plan didn't run for this env or the file is
+# from a prior version that didn't expose the output. The caller's
+# rendering helper (_render_plan_time_cell) maps empty → "—".
+function _extract_plan_time {
+  local file="${1}"
+  [ -z "${file}" ] || [ ! -f "${file}" ] && { echo ""; return; }
+  local val
+  val=$(jq -r '.steps.plan.outputs["plan-time"] // ""' "${file}" 2>/dev/null || echo "")
   [ "${val}" = "null" ] && val=""
   echo "${val}"
 }

--- a/aggregate-validation-summaries/step_aggregate.sh
+++ b/aggregate-validation-summaries/step_aggregate.sh
@@ -34,8 +34,11 @@ declare -gA DESIRED_GROUPS=()
 # desired_meta[<group_name>/<env_name>]="<absolute path to metadata file>"
 declare -gA DESIRED_META=()
 
-# existing_group_comments[group_name]="<comment_id>" — one entry per
-# currently-on-PR group comment that matches our family prefix
+# existing_group_comments[group_name]="<id1>\n<id2>\n..." — newline-
+# delimited list of every PR comment currently matching our family marker
+# for that group. Multiple IDs per group can happen when an earlier run
+# orphaned duplicates; the upsert pass picks the oldest to keep (stable
+# identity) and deletes the rest.
 declare -gA EXISTING_GROUP_COMMENTS=()
 
 # per_env_anchor[env_name]="#issuecomment-<id>" — resolved at step 2,
@@ -49,9 +52,11 @@ declare -gA PER_ENV_ANCHOR=()
 # cell drops the `job log` line in that case rather than emit a wrong link.
 declare -gA PER_ENV_JOB_URL=()
 
-# Tracks degraded mode (gh api list failed). When true, reconcile (delete
-# pass) is skipped — the rendered bodies are still posted so the grouped
-# table is always visible.
+# Tracks degraded mode (gh api list failed). When true, the upsert pass
+# skips its delete branch and posts fresh bodies instead — the grouped
+# table is always visible, even if we can't be sure what's already on the
+# PR. Duplicates from this degraded mode will self-heal on the next clean
+# run (the duplicate-deleted branch of the upsert algorithm).
 DEGRADED_MODE="false"
 
 # Tracks each group processed for the groups-processed-json output.
@@ -192,7 +197,7 @@ function list_pr_state {
   local comments_json
   if ! comments_json=$(_gh_list_pr_comments "${GITHUB_REPOSITORY}" "${input_pr_number}" 2>&1); then
     log-warn "Failed to list PR comments: ${comments_json}"
-    log-warn "Entering degraded mode — reconcile (delete pass) skipped; will still post fresh bodies."
+    log-warn "Entering degraded mode — upsert will post fresh bodies instead of editing in place."
     DEGRADED_MODE="true"
     end-group
     return 0
@@ -213,26 +218,41 @@ function list_pr_state {
   total=$(echo "${normalized}" | jq 'length')
   log-info "PR has ${total} comment(s) total."
 
-  # Extract existing group comments (family prefix match).
-  # Output one line per match: "<comment_id>\t<group_name>"
-  # Group name is parsed out of the body's first line by stripping the family
-  # prefix and the surrounding backticks.
+  # Find existing group comments by HTML marker on the first line of the
+  # body: '<!-- terraform-validation-summary-group:<group> -->'. Multiple
+  # IDs per group are tolerated (and self-healed in the upsert pass).
+  # Group name is parsed by stripping the family prefix and the trailing
+  # ' -->' marker close.
+  #
+  # Legacy comments from the pre-marker era (body starts with the H3
+  # heading rather than the marker) are not matched here — they sit
+  # untouched on the PR and the upsert pass posts a fresh marked comment
+  # alongside them. This is the documented "no-migration" trade-off
+  # (docs/Workflow-pr-comments.md §2.1).
   local group_lines
   group_lines=$(echo "${normalized}" \
-    | jq -r --arg fam "${GROUP_COMMENT_FAMILY_PREFIX}" '
+    | jq -r --arg fam "${GROUP_COMMENT_MARKER_FAMILY}" '
         .[]
         | select(.body | startswith($fam))
         | .id as $id
-        | (.body | split("\n")[0] | sub($fam; "") | sub("^`"; "") | sub("`.*$"; "")) as $g
-        | "\($id)\t\($g)"
+        | .created_at as $created
+        | (.body | split("\n")[0] | sub($fam; "") | sub(" -->.*$"; "")) as $g
+        | "\($id)\t\($created)\t\($g)"
       ' 2>/dev/null) || group_lines=""
 
   if [ -n "${group_lines}" ]; then
-    local line cid gname
-    while IFS=$'\t' read -r cid gname; do
+    local line cid created gname
+    while IFS=$'\t' read -r cid created gname; do
       [ -z "${cid}" ] && continue
-      EXISTING_GROUP_COMMENTS[${gname}]="${cid}"
-      log-info "  existing group comment: '${gname}' (id=${cid})"
+      # Pack as "<created_at>|<id>" so a later 'sort' gives the oldest first
+      # — created_at is ISO-8601, lexicographically sortable. The upsert
+      # pass picks the head of the sorted list to keep, deletes the rest.
+      if [ -n "${EXISTING_GROUP_COMMENTS[${gname}]:-}" ]; then
+        EXISTING_GROUP_COMMENTS[${gname}]+=$'\n'"${created}|${cid}"
+      else
+        EXISTING_GROUP_COMMENTS[${gname}]="${created}|${cid}"
+      fi
+      log-info "  existing group comment: '${gname}' (id=${cid}, created=${created})"
     done <<<"${group_lines}"
   else
     log-info "  no existing group comments on PR"
@@ -290,7 +310,8 @@ function list_pr_state {
 function render_group_body {
   local group_name="${1}"
   local envs_nl="${2}"
-  local prefix
+  local marker prefix
+  marker=$(_group_marker "${group_name}")
   prefix=$(_group_prefix "${group_name}")
 
   local -a envs=()
@@ -367,9 +388,15 @@ function render_group_body {
   footer=$(_render_footer "${first_env_meta_file}")
 
   # ---- Assembly ----
-  # rows ends with a trailing newline; the rest are plain rows with no
+  # The HTML marker is line 1 and the load-bearing identity for upserts —
+  # see docs/Workflow-pr-comments.md §2. The H3 'prefix' line follows; it
+  # is still rendered (visible to readers) but no longer used for comment
+  # identification, so the H3 wording can be tweaked freely as long as
+  # the marker is unchanged.
+  # 'rows' ends with a trailing newline; the rest are plain rows with no
   # trailing newline, so the format string supplies the line breaks.
-  printf '%s\n%s\n%s\n%s%s\n%s\n%s\n\n%s\n' \
+  printf '%s\n%s\n%s\n%s\n%s%s\n%s\n%s\n\n%s\n' \
+    "${marker}" \
     "${prefix}" \
     "${header}" \
     "${sep}" \
@@ -441,69 +468,76 @@ function _render_footer {
 }
 
 # ============================================================================
-# Step 4: Reconcile (delete pass)
+# Step 4: Orphan-delete pass — drop marker comments whose group is no
+# longer in the desired set. Desired groups themselves are handled by the
+# upsert pass below (PATCH-in-place + dedupe).
 # ============================================================================
 
-function reconcile_delete_pass {
-  start-group "Step 4: Reconcile — delete pass"
+function orphan_delete_pass {
+  start-group "Step 4: Delete orphan group comments"
 
   if [ "${DEGRADED_MODE}" = "true" ]; then
-    log-warn "Degraded mode — skipping delete pass."
+    log-warn "Degraded mode — skipping orphan delete pass."
     end-group
     return 0
   fi
 
   if [ ${#EXISTING_GROUP_COMMENTS[@]} -eq 0 ]; then
-    log-info "No existing group comments — nothing to delete."
+    log-info "No existing group comments — nothing to clean up."
     end-group
     return 0
   fi
 
-  local existing_group existing_id action
+  local existing_group entry created cid
   for existing_group in "${!EXISTING_GROUP_COMMENTS[@]}"; do
-    existing_id="${EXISTING_GROUP_COMMENTS[${existing_group}]}"
+    # Only orphan if the group is NOT in the desired set. Desired groups
+    # are kept (one survivor) by the upsert pass.
     if [ -n "${DESIRED_GROUPS[${existing_group}]:-}" ]; then
-      action="repost"
-      log-info "  deleting existing group comment '${existing_group}' (id=${existing_id}) — will be reposted"
-    else
-      action="orphan-deleted"
-      log-info "  deleting orphan group comment '${existing_group}' (id=${existing_id}) — not in desired set"
+      continue
     fi
-
-    if _gh_delete_comment "${GITHUB_REPOSITORY}" "${existing_id}" >/dev/null 2>&1; then
-      _record_processed "${existing_group}" "${existing_id}" "${action}"
-    else
-      log-warn "  failed to delete comment id=${existing_id} (group '${existing_group}') — continuing"
-    fi
+    # Delete every comment for this orphan group — markers from prior
+    # double-posts could accumulate here too.
+    while IFS= read -r entry; do
+      [ -z "${entry}" ] && continue
+      created="${entry%%|*}"
+      cid="${entry##*|}"
+      log-info "  deleting orphan group comment '${existing_group}' (id=${cid}, created=${created})"
+      if _gh_delete_comment "${GITHUB_REPOSITORY}" "${cid}" >/dev/null 2>&1; then
+        _record_processed "${existing_group}" "${cid}" "orphan-deleted"
+      else
+        log-warn "  failed to delete comment id=${cid} (group '${existing_group}') — continuing"
+      fi
+    done <<<"${EXISTING_GROUP_COMMENTS[${existing_group}]}"
   done
 
   end-group
 }
 
 # ============================================================================
-# Step 5: Post pass
+# Step 5: Upsert pass — for every desired group, either PATCH the
+# oldest existing marker comment (stable identity across runs, no
+# re-pinging of subscribers) or POST a fresh one. Duplicate marker
+# comments for the same group are deleted in the same pass so the
+# system is self-healing — if a prior run posted twice (e.g. degraded
+# mode + later recovery), the next clean run leaves exactly one comment
+# per group.
 # ============================================================================
 
-function post_pass {
-  # NOTE: one log group per group processed — no outer wrapper. GitHub Actions
-  # does not support nested log groups; the prior structure ('Step 5' outer
-  # group containing per-group 'Body for...' sub-groups) rendered confusingly
-  # in the runner log UI.
-
+function upsert_pass {
   if [ ${#DESIRED_GROUPS[@]} -eq 0 ]; then
-    log-info "Step 5: Post fresh group comments — no desired groups, nothing to post."
+    log-info "Step 5: Upsert group comments — no desired groups, nothing to upsert."
     return 0
   fi
 
-  log-info "Step 5: Post fresh group comments (${#DESIRED_GROUPS[@]} group(s))"
+  log-info "Step 5: Upsert group comments (${#DESIRED_GROUPS[@]} group(s))"
 
   # Sort group names for deterministic output ordering.
   local -a sorted_groups=()
   while IFS= read -r g; do sorted_groups+=("${g}"); done < <(printf '%s\n' "${!DESIRED_GROUPS[@]}" | sort)
 
-  local group envs_sorted body body_file new_id
+  local group envs_sorted body body_file
   for group in "${sorted_groups[@]}"; do
-    start-group "Step 5: Posting group '${group}'"
+    start-group "Step 5: Upsert group '${group}'"
 
     # Sort envs alphabetically within the group (docs/Workflow-pr-comments.md §4.2)
     envs_sorted=$(echo "${DESIRED_GROUPS[${group}]}" | sort)
@@ -516,17 +550,84 @@ function post_pass {
     log-info "Body:"
     echo "${body}"
 
-    if new_id=$(_gh_post_comment "${GITHUB_REPOSITORY}" "${input_pr_number}" "${body_file}" 2>&1); then
-      log-info "posted: comment id=${new_id}"
-      _record_processed "${group}" "${new_id}" "posted"
-    else
-      log-warn "failed to post comment for group '${group}': ${new_id}"
-      _record_processed "${group}" "0" "post-failed"
-    fi
+    _upsert_one_group "${group}" "${body_file}"
 
     rm -f "${body_file}"
     end-group
   done
+}
+
+# Upsert a single group's comment. Picks the oldest existing marker
+# comment (lowest created_at, since GitHub IDs are monotonic but the
+# created_at field is the canonical timestamp) to keep, deletes any
+# others, then PATCHes the keeper. If none exist, POSTs fresh.
+#
+# In degraded mode (PR comments listing failed) we don't know what
+# exists, so we always POST fresh — duplicates will self-heal on the
+# next clean run via this same dedupe branch.
+function _upsert_one_group {
+  local group="${1}" body_file="${2}"
+
+  if [ "${DEGRADED_MODE}" = "true" ]; then
+    log-warn "Degraded mode — posting fresh (cannot list existing comments to upsert)."
+    _post_fresh "${group}" "${body_file}"
+    return
+  fi
+
+  local entries="${EXISTING_GROUP_COMMENTS[${group}]:-}"
+  if [ -z "${entries}" ]; then
+    log-info "No existing marker comment for '${group}' — posting fresh."
+    _post_fresh "${group}" "${body_file}"
+    return
+  fi
+
+  # Sort entries by created_at (ISO-8601, lexicographic). Oldest first.
+  local sorted_entries
+  sorted_entries=$(echo "${entries}" | sort)
+  local keep_entry
+  keep_entry=$(echo "${sorted_entries}" | head -n1)
+  local keep_id="${keep_entry##*|}"
+  local keep_created="${keep_entry%%|*}"
+
+  # Delete every entry except the keeper.
+  local entry created cid
+  while IFS= read -r entry; do
+    [ -z "${entry}" ] && continue
+    created="${entry%%|*}"
+    cid="${entry##*|}"
+    if [ "${cid}" = "${keep_id}" ]; then
+      continue
+    fi
+    log-info "  duplicate '${group}' marker comment (id=${cid}, created=${created}) — deleting"
+    if _gh_delete_comment "${GITHUB_REPOSITORY}" "${cid}" >/dev/null 2>&1; then
+      _record_processed "${group}" "${cid}" "duplicate-deleted"
+    else
+      log-warn "  failed to delete duplicate id=${cid} for '${group}' — continuing"
+    fi
+  done <<<"${sorted_entries}"
+
+  # PATCH the keeper.
+  log-info "Editing existing comment in place (id=${keep_id}, created=${keep_created})."
+  if _gh_patch_comment "${GITHUB_REPOSITORY}" "${keep_id}" "${body_file}" >/dev/null 2>&1; then
+    _record_processed "${group}" "${keep_id}" "patched"
+  else
+    log-warn "PATCH failed for '${group}' (id=${keep_id}) — posting fresh as fallback."
+    _post_fresh "${group}" "${body_file}"
+  fi
+}
+
+# Internal: POST a fresh comment for a group. Used by _upsert_one_group
+# on the "no existing comment" and "degraded mode" branches.
+function _post_fresh {
+  local group="${1}" body_file="${2}"
+  local new_id
+  if new_id=$(_gh_post_comment "${GITHUB_REPOSITORY}" "${input_pr_number}" "${body_file}" 2>&1); then
+    log-info "posted: comment id=${new_id}"
+    _record_processed "${group}" "${new_id}" "posted"
+  else
+    log-warn "failed to post comment for group '${group}': ${new_id}"
+    _record_processed "${group}" "0" "post-failed"
+  fi
 }
 
 # ============================================================================
@@ -561,8 +662,8 @@ function main {
 
   build_desired_set
   list_pr_state
-  reconcile_delete_pass
-  post_pass
+  orphan_delete_pass
+  upsert_pass
 
   set-multiline-output "groups-processed-json" "${PROCESSED_RESULTS_JSON}"
   log-info "Done. Processed ${#DESIRED_GROUPS[@]} group(s)."

--- a/create-validation-summary/action.yml
+++ b/create-validation-summary/action.yml
@@ -89,6 +89,14 @@ inputs:
       reviewers can still see the output diff.
     required: false
     default: "false"
+  plan-time:
+    description: |
+      Wall-clock duration of the `terraform plan` invocation, formatted as
+      `mm:ss` (typically wired from terraform-plan's `plan-time` output).
+      Rendered as a trailing row of the validation table. Defaults to "N/A"
+      when not provided — matches the convention used by `plan-count-*`.
+    required: false
+    default: "N/A"
 outputs:
   prefix:
     description: Validation summary prefix string.
@@ -121,6 +129,7 @@ runs:
         input_plan_count_remove: ${{ inputs.plan-count-remove }}
         input_plan_count_total: ${{ inputs.plan-count-total }}
         input_plan_has_output_only_changes: ${{ inputs.plan-has-output-only-changes }}
+        input_plan_time: ${{ inputs.plan-time }}
         input_job_check_run_id: ${{ job.check_run_id }}
       run: |
         set -o allexport

--- a/create-validation-summary/run_all_tests.sh
+++ b/create-validation-summary/run_all_tests.sh
@@ -75,6 +75,9 @@ reset_defaults() {
   # plan-has-output-only-changes: default to 'false'. Only the output-only
   # branch test overrides this.
   export input_plan_has_output_only_changes="false"
+  # plan-time: default 'N/A' matches the action.yml default and is what the
+  # Plan time row renders when terraform-plan didn't supply a duration.
+  export input_plan_time="N/A"
   export input_job_check_run_id="87654321"
 
   export GITHUB_SERVER_URL="https://github.com"
@@ -581,6 +584,7 @@ assert_full_body_golden_all_success_no_plan() {
 | ✔ | Validate | `success` |
 | 🧹 | TFLint | `success` |
 | 📖 | Plan | `success` |
+| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`N/A`</span> |
 
 Plan not available 🤷‍♀️
 
@@ -609,6 +613,7 @@ assert_all_row_labels_byte_exact() {
     "| ✔ | Validate | "
     "| 🧹 | TFLint | "
     "| 📖 | Plan | "
+    "| ⏱ | Plan time | "
   )
   for row in "${rows[@]}"; do
     if [[ "${summary}" != *"${row}"* ]]; then
@@ -1260,6 +1265,7 @@ assert_golden_no_changes_body() {
 | ✔ | Validate | `success` |
 | 🧹 | TFLint | `success` |
 | 📖 | Plan | `success` |
+| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`N/A`</span> |
 
 Plan: no changes ✅
 
@@ -1375,6 +1381,110 @@ export input_plan_count_total="0"
 export input_plan_has_output_only_changes="true"
 run_test "Grouped + count-total=0 + output-only → keep <details>" assert_grouped_output_only_keeps_details
 rm -f "${_plan_file}"
+
+# --------------------------------------------------
+# Plan time row (added in v0.X — terraform-plan now publishes wall-clock
+# duration of the plan command; create-validation-summary renders it as
+# a trailing row of the ungrouped validation table).
+# --------------------------------------------------
+
+# Plan time row: renders mm:ss when input provided, wrapped in a
+# <span title="mm:ss (minutes:seconds)"> so desktop hover surfaces the unit.
+assert_plan_time_row_with_value() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |'* ]]; then
+    echo "  summary: expected backtick-wrapped value cell with format tooltip"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_plan_time="1:23"
+run_test "Plan time row renders backtick-wrapped mm:ss value with tooltip" assert_plan_time_row_with_value
+
+# Plan time row: defaults to N/A when caller passes nothing (matches
+# the create-validation-summary input default and plan-count-* convention).
+# Tooltip wrapper applies to the N/A branch too so hover-discovery works
+# even when there's no timing recorded.
+assert_plan_time_row_default_na() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`N/A`</span> |'* ]]; then
+    echo "  summary: expected default N/A cell with format tooltip"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+run_test "Plan time row defaults to 'N/A' with tooltip when input not supplied" assert_plan_time_row_default_na
+
+# Plan time row: rendered even when Plan Details is off (Plan time row is
+# always emitted in ungrouped mode; Plan Details row is conditional).
+assert_plan_time_without_plan_details() {
+  local prefix="${1}"
+  local summary="${2}"
+  local fails=""
+  if [[ "${summary}" != *'| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`0:45`</span> |'* ]]; then
+    fails+="  summary: expected Plan time row (with tooltip) to render without Plan Details\n"
+  fi
+  if [[ "${summary}" == *"Plan Details"* ]]; then
+    fails+="  summary: Plan Details row should NOT appear when include-plan-details=false\n"
+  fi
+  if [[ -n "${fails}" ]]; then
+    echo -e "${fails}"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_plan_time="0:45"
+export input_include_plan_details="false"
+run_test "Plan time row renders even when Plan Details row is omitted" assert_plan_time_without_plan_details
+
+# Plan time row: omitted in grouped mode (whole validation table is
+# omitted from per-env body in grouped mode — see docs/Workflow-pr-comments.md §3).
+assert_plan_time_omitted_in_grouped_mode() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" == *"Plan time"* ]]; then
+    echo "  summary: Plan time row must NOT appear in grouped per-env body"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+export input_plan_time="2:00"
+run_test "Plan time row omitted in grouped mode (table moves to per-group comment)" assert_plan_time_omitted_in_grouped_mode
+
+# Plan time row placement: appears AFTER Plan Details when both are present
+# (per design — Plan time goes below Plan Details).
+assert_plan_time_after_plan_details() {
+  local prefix="${1}"
+  local summary="${2}"
+  # Extract the bit between Plan Details opener and the blank line that
+  # closes the table. Plan time row must be after Plan Details in that span.
+  local pd_pos pt_pos
+  pd_pos=$(echo "${summary}" | grep -n '| 📊 | Plan Details |' | head -n1 | cut -d: -f1)
+  pt_pos=$(echo "${summary}" | grep -n '| ⏱ | Plan time |'   | head -n1 | cut -d: -f1)
+  if [ -z "${pd_pos}" ] || [ -z "${pt_pos}" ]; then
+    echo "  summary: expected both Plan Details and Plan time rows present (pd=${pd_pos}, pt=${pt_pos})"
+    return 1
+  fi
+  if [ "${pt_pos}" -le "${pd_pos}" ]; then
+    echo "  summary: Plan time row (line ${pt_pos}) must appear AFTER Plan Details (line ${pd_pos})"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_include_plan_details="true"
+export input_plan_count_add="1"
+export input_plan_count_change="0"
+export input_plan_count_destroy="0"
+export input_plan_time="3:14"
+run_test "Plan time row appears after Plan Details when both rendered" assert_plan_time_after_plan_details
 
 # --------------------------------------------------
 # Summary

--- a/create-validation-summary/step_create_validation_summary.sh
+++ b/create-validation-summary/step_create_validation_summary.sh
@@ -25,6 +25,7 @@
 #   input_plan_count_remove    - Number of resources to be removed
 #   input_plan_count_total     - Sum across categories ('' or '?' = not available; ≥0 numeric otherwise)
 #   input_plan_has_output_only_changes - 'true' when plan changes outputs only (no resource changes)
+#   input_plan_time            - Wall-clock duration of 'terraform plan' formatted as mm:ss (defaults to 'N/A')
 #   input_job_check_run_id     - The check run ID for the current job
 #
 # Standard GitHub environment variables used:
@@ -92,6 +93,16 @@ function main {
       # end of table row
       comment_content="${comment_content} |"
     fi
+
+    # Plan time row — always rendered (after Plan Details if it was included,
+    # otherwise directly after the Plan row). 'N/A' when the upstream
+    # 'terraform-plan' action didn't supply a value, matching the
+    # plan-count-* defaults. The <span title> wrapper surfaces the format
+    # hint on desktop hover, matching the badge convention used by the
+    # Plan Details row.
+    # don't touch the indenting here
+    comment_content="${comment_content}
+| ⏱ | Plan time | <span title=\"mm:ss (minutes:seconds)\">\`${input_plan_time:-N/A}\`</span> |"
   fi
 
   # Build the link to this env's job log (used in the footer).

--- a/docs/Workflow-pr-comments.md
+++ b/docs/Workflow-pr-comments.md
@@ -6,25 +6,34 @@ Out of scope: deployment-environment UI, status checks, workflow run summaries �
 
 ## 1. When are comments posted
 
-Comments are only posted when the workflow runs against a `pull_request` event whose action is not `closed` or `converted_to_draft`. The mechanism is identical regardless of which job posts the comment: each comment carries a deterministic Markdown heading (the "prefix") and every post does a delete-by-prefix + post — so comments update in place across re-runs, never duplicate.
+Comments are only posted when the workflow runs against a `pull_request` event whose action is not `closed` or `converted_to_draft`. Each comment carries a deterministic identity handle so re-runs update in place rather than duplicating. The two families use different mechanisms — see §2.
 
 Comments are suppressed when either:
 
 - the workflow input `add-pr-comment: false` is set (globally), or
 - a per-environment `add-pr-comment: false` override is set in `environments-yml` (per env).
 
-Both controls only affect the per-environment comments. The per-group reconcile job runs unconditionally on PR events; see §6 for why and the cost analysis.
+Both controls only affect the per-environment comments. The per-group aggregator job runs unconditionally on PR events; see §6 for why and the cost analysis.
 
 ## 2. The two comment families
 
-| Family | Identity prefix | Posted by | Cardinality |
-|---|---|---|---|
-| Per-environment | `` ### Terraform validation summary for environment: `<env>` `` | matrix job for that env, via `comment-on-pr@v2` | one per env per workflow run |
-| Per-group | `` ### Terraform validation summary for group: `<group>` `` | `pr-comment-aggregator` job, via `aggregate-validation-summaries` | one per distinct non-empty `pr-comment-group` value |
+| Family | Identity handle | Lifecycle | Posted by | Cardinality |
+|---|---|---|---|---|
+| Per-environment | H3 heading `` ### Terraform validation summary for environment: `<env>` `` (first line of body) | delete-by-prefix + post | matrix job for that env, via `comment-on-pr@v2` | one per env per workflow run |
+| Per-group | HTML marker `<!-- terraform-validation-summary-group:<group> -->` (first line of body) | upsert-by-marker (PATCH-in-place or POST) | `pr-comment-aggregator` job, via `aggregate-validation-summaries` | one per distinct non-empty `pr-comment-group` value |
 
-Both families share the prefix-based identity contract: the family prefix uniquely identifies the comment within a PR, the action lists existing comments via `gh api`, deletes any whose body starts with the matching specific prefix, and posts the freshly-built body. Bodies always start with their full prefix (heading line) so substring matching is unambiguous.
+The two families use **different identity contracts** because they have different lifecycles:
 
-Per-env prefixes use backtick-delimited env names so partial matches can't collide (e.g. `dev` doesn't match `dev-2`).
+- **Per-env** uses a visible H3 prefix as the load-bearing handle. Each run does delete-by-prefix + post, so per-env comments get a new comment id every run (subscribers re-pinged). Cheap and simple for a one-shot job.
+- **Per-group** uses an invisible HTML marker as the load-bearing handle. Each run does PATCH-in-place on the oldest existing marker comment for that group (stable comment id, no re-ping), and deletes any duplicate markers in the same pass — self-healing against past races or degraded runs. Comments without the marker are ignored (see §2.1 below). Per-group markers are unique per group name so multiple groups on the same PR are upserted independently.
+
+The H3 line `` ### Terraform validation summary for group: `<group>` `` still appears (visible to readers, line 2 of the body) but is no longer load-bearing — only the HTML marker is. The H3 wording can be tweaked freely as long as the marker is unchanged.
+
+Per-env prefixes use backtick-delimited env names so partial matches can't collide (e.g. `dev` doesn't match `dev-2`). Per-group markers don't need this since the colon + ` -->` close make the boundary unambiguous.
+
+### 2.1 No migration policy
+
+When `aggregate-validation-summaries` rolls out, existing per-group comments from prior versions don't yet carry the HTML marker — they only have the H3 heading. The new code ignores those legacy comments rather than deleting them: the next run posts a fresh marked comment alongside, and operators clean up the legacy one by hand if they want. This is an intentional trade-off — adding marker detection on the legacy H3 path would require a transitional shim, and given how rare PR-runs-after-release are for a given PR, the one-time double-post is the simpler choice. Subsequent runs upsert the marked comment normally.
 
 ## 3. Per-environment comments
 
@@ -177,6 +186,7 @@ Every PR run triggers the `pr-comment-aggregator` job once. It downloads all `ma
 Raw markdown:
 
 ````markdown
+<!-- terraform-validation-summary-group:dev -->
 ### Terraform validation summary for group: `dev`
 
 |  | Step | sub-a-dev | sub-b-dev | sub-c-dev |
@@ -263,37 +273,41 @@ Per-env-comment lookup edge cases:
 
 If the Jobs API call itself fails (rate limit, transient 5xx), every env's `job log` line is dropped and a single warning is logged; the grouped table still renders.
 
-### 4.7 Reconcile algorithm
+### 4.7 Upsert algorithm
 
-The aggregator action runs every PR event. Its job is to make the set of group comments on the PR equal to the desired set computed from the current run's metadata:
+The aggregator action runs every PR event. Its job is to make the set of marked group comments on the PR equal to the desired set computed from the current run's metadata, **editing in place** rather than recreating, so subscribers aren't re-pinged on every push.
 
 1. **Build desired set.** Read every `matrix-job-meta-*.json` artifact downloaded by `actions/download-artifact@v4`. Group entries by `matrix_context.vars.pr-comment-group`, dropping empty-string values. The desired set may be empty (no env declares a group).
 2. **List PR + run state.** Two paginated `gh api` calls:
     - `repos/$REPO/issues/$PR/comments` — from the result, build two maps:
-      - existing group comments (body starts with `### Terraform validation summary for group: `)
+      - existing group comments (body **starts with** `<!-- terraform-validation-summary-group:`). The group name is parsed out of the marker. Multiple matches per group are retained as a list of `(created_at, id)` pairs.
       - existing per-env comments (body starts with the exact backtick-delimited per-env prefix from §2)
-    - `repos/$REPO/actions/runs/$RUN_ID/jobs` — used to resolve each env's matrix job URL for the Links row (§4.6). Match by GitHub-rendered job name pattern `^Terraform \(<env>\)$`. Either call may fail independently: a Jobs API failure drops `job log` links from every Links cell; a PR-comments failure triggers degraded mode (skip reconcile delete pass, still post fresh bodies, will re-reconcile on next run).
-3. **Render desired.** For each desired group, sort envs alphabetically and build the prefix + body per §4.1. The Links row uses the per-env comment map (step 2) to resolve `log extract` anchors.
-4. **Reconcile (delete pass).** Walk the existing group comments:
-    - prefix not in desired set → DELETE (orphan from a removed/renamed group)
-    - prefix in desired set → DELETE (will be reposted with fresh body in step 5)
-5. **Post pass.** For each desired group, POST the rendered body.
-6. **Emit `groups-processed-json`** for logs/tests.
+    - `repos/$REPO/actions/runs/$RUN_ID/jobs` — used to resolve each env's matrix job URL for the Links row (§4.6). Match by GitHub-rendered job name pattern `^Terraform \(<env>\)$`. Either call may fail independently: a Jobs API failure drops `job log` links from every Links cell; a PR-comments failure triggers degraded mode (see below).
+3. **Render desired.** For each desired group, sort envs alphabetically and build the marker + H3 prefix + body per §4.1. The Links row uses the per-env comment map (step 2) to resolve `log extract` anchors.
+4. **Orphan delete pass.** Walk the existing marker comments. For each group **not** in the desired set, DELETE every matching marker comment (an orphan from a removed/renamed group can have accumulated duplicates).
+5. **Upsert pass.** For each desired group:
+    - **0 existing marker comments** → POST a fresh marked body.
+    - **1 existing** → PATCH that comment in place. Same comment id across runs, so subscribers don't get re-notified.
+    - **2+ existing** (duplicates from past races or degraded runs) → sort by `created_at` ascending, DELETE every entry except the oldest, then PATCH the oldest. The system is self-healing: one clean run collapses duplicates.
+    - **PATCH failure** (transient 5xx, comment removed mid-run, etc.) → fall back to POST so the comment is still visible on the PR.
+6. **Emit `groups-processed-json`** with one entry per action (`patched`, `posted`, `orphan-deleted`, `duplicate-deleted`, `post-failed`) for logs/tests.
 
-Four scenarios collapse into the same path:
+Scenarios:
 
-| Desired groups | Existing group comments | Outcome |
+| Desired groups | Existing marker comments | Outcome |
 |---|---|---|
 | 0 | 0 | no-op |
 | 0 | N | sweep N orphans (caller disabled grouping) |
-| M | 0 | post M (first run with grouping enabled) |
-| M | N (any overlap) | sweep mismatched, repost matched, post new |
+| M | 0 | post M (first run with grouping enabled, or no-migration legacy: see §2.1) |
+| M | M, 1 marker each | PATCH M in place (no new comment ids, no re-ping) |
+| M | M+K (duplicates) | PATCH oldest M, delete K dupes |
+| M | N (mixed: some desired, some orphan) | PATCH desired, delete orphans |
 
-Self-healing: at most one PR run is needed after toggling grouping on/off or renaming groups; no manual cleanup procedure.
+Self-healing: at most one PR run is needed after toggling grouping on/off, renaming groups, or recovering from a degraded run.
 
 #### Degraded mode
 
-If `gh api` fails (rate limit, transient 5xx), the action logs a warning, treats the existing-comments map as empty, renders bodies with Links rows showing `job log` only (no `log extract` anchors), and attempts to post. Subsequent runs reconcile any duplicates left behind. The grouped table itself always renders.
+If `gh api` listing fails (rate limit, transient 5xx), the action can't tell what already exists on the PR. It logs a warning, skips the orphan delete pass, and the upsert pass POSTs fresh bodies (no PATCH attempt). Any duplicates left behind are collapsed on the next clean run via step 5's "2+ existing" branch. The grouped table itself always renders.
 
 #### Failure isolation
 
@@ -349,7 +363,7 @@ Quick map from spec section to implementing code:
 | §3.1 Ungrouped per-env comment body | [`create-validation-summary/step_create_validation_summary.sh`](../create-validation-summary/step_create_validation_summary.sh) |
 | §3.2 Grouped per-env comment body | same file, branched on `pr-comment-group` |
 | §3 Posting/replacing per-env comments | [`dsb-norge/github-actions/ci-cd/comment-on-pr@v2`](https://github.com/dsb-norge/github-actions/tree/main/ci-cd/comment-on-pr) |
-| §4 Per-group comment body + reconcile | [`aggregate-validation-summaries/step_aggregate.sh`](../aggregate-validation-summaries/step_aggregate.sh) |
+| §4 Per-group comment body + upsert | [`aggregate-validation-summaries/step_aggregate.sh`](../aggregate-validation-summaries/step_aggregate.sh) |
 | §4.7 Source artifacts | [`capture-matrix-job-meta/step_capture.sh`](../capture-matrix-job-meta/step_capture.sh) |
 | §5 Input plumbing & per-env defaults | [`create-tf-vars-matrix/action.yml`](../create-tf-vars-matrix/action.yml) |
 | Workflow wiring | [`.github/workflows/terraform-ci-cd-default.yml`](../.github/workflows/terraform-ci-cd-default.yml) |

--- a/docs/Workflow-pr-comments.md
+++ b/docs/Workflow-pr-comments.md
@@ -46,6 +46,7 @@ Raw markdown:
 | ✔ | Validate | `success` |
 | 🧹 | TFLint | `success` |
 | 📖 | Plan | `success` |
+| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |
 
 <details><summary>Plan: 7 changes ℹ️</summary>
 
@@ -70,6 +71,7 @@ Rendered:
 > | ✔ | Validate | `success` |
 > | 🧹 | TFLint | `success` |
 > | 📖 | Plan | `success` |
+> | ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |
 >
 > <details><summary>Plan: 7 changes ℹ️</summary>
 >
@@ -102,6 +104,18 @@ Rules:
 - `move`, `import`, `remove` lines are appended only when their respective count is non-zero, with emojis `🔀`, `📥`, `⛓️‍💥`.
 - Lines are separated by `<br>`. Each badge is wrapped in `<span title="…">…</span>` with a human-readable description as the tooltip.
 
+#### Plan time row
+
+Always rendered as the trailing row of the validation table:
+
+```markdown
+| ⏱ | Plan time | `mm:ss` |
+```
+
+The value is the wall-clock duration of the `terraform plan` invocation, formatted as `mm:ss` (minutes can exceed 99 — e.g. `120:05` — though CI plans rarely cross an hour). The value is sourced from `terraform-plan@v0`'s `plan-time` output and is always populated, including when the plan command failed — surfacing "slow AND failing" in a single row instead of forcing reviewers into the job log. When the caller does not supply a value, the cell renders `` `N/A` `` (matching the `plan-count-*` defaults).
+
+The cell is wrapped in `<span title="mm:ss (minutes:seconds)">…</span>` (around both the value and the `N/A` fallback) so desktop hover surfaces the format hint, matching the badge convention used by the Plan Details row and the status-emoji cells.
+
 #### Plan extract
 
 The plan-extract block has four rendering modes, selected by the `plan-count-total` and `plan-has-output-only-changes` inputs (typically sourced from `parse-terraform-plan`'s `count-total` and `has-output-only-changes` outputs):
@@ -130,7 +144,7 @@ A single bare Markdown link. Pusher / event / workflow data is intentionally omi
 
 ### 3.2 Grouped mode
 
-The env has `pr-comment-group: "<name>"` set. The per-env comment loses its validation table — that data is now in the per-group comment (§4). The plan extract block, the `Plan not available 🤷‍♀️` short-circuit, and the footer behave identically to ungrouped mode. No back-pointer to the group summary is rendered — the grouped summary itself anchor-links to every per-env comment via its Links row (§4.5), so navigation goes the natural top-down direction.
+The env has `pr-comment-group: "<name>"` set. The per-env comment loses its validation table — that data is now in the per-group comment (§4). The plan extract block, the `Plan not available 🤷‍♀️` short-circuit, and the footer behave identically to ungrouped mode. No back-pointer to the group summary is rendered — the grouped summary itself anchor-links to every per-env comment via its Links row (§4.6), so navigation goes the natural top-down direction.
 
 Raw markdown (no-changes example):
 
@@ -174,6 +188,7 @@ Raw markdown:
 | <span title="TFLint">🧹</span> | TFLint | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
 | <span title="Plan">📖</span> | Plan | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
 | <span title="Plan details">📊</span> | Plan details | <div align="left"><span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span></div> | <div align="left"><span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span><br><span title="Resources to be imported">`📥 2` import</span></div> | N/A |
+| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`0:42`</span> | <span title="mm:ss (minutes:seconds)">`2:05`</span> | <span title="mm:ss (minutes:seconds)">—</span> |
 | <span title="Links">🔗</span> | Links | [log extract](#issuecomment-…)<br>[job log](https://…) | [log extract](#issuecomment-…)<br>[job log](https://…) | [job log](https://…) |
 
 [Job log](https://…)
@@ -192,6 +207,7 @@ Rendered:
 > | <span title="TFLint">🧹</span> | TFLint | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
 > | <span title="Plan">📖</span> | Plan | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
 > | <span title="Plan details">📊</span> | Plan details | <div align="left"><span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span></div> | <div align="left"><span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span><br><span title="Resources to be imported">`📥 2` import</span></div> | N/A |
+> | <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`0:42`</span> | <span title="mm:ss (minutes:seconds)">`2:05`</span> | <span title="mm:ss (minutes:seconds)">—</span> |
 > | <span title="Links">🔗</span> | Links | [log extract](#)<br>[job log](#) | [log extract](#)<br>[job log](#) | [job log](#) |
 >
 > [Job log](#)
@@ -212,7 +228,7 @@ Every status cell wraps an emoji in `<span title="<outcome>">…</span>` so desk
 | `skipped` | ⏭️ | `skipped` |
 | `''` / step not present in env's metadata | — (em dash) | `not applicable` |
 
-The column-1 step emojis (⚙️ 🔒 🖌 ✔ 🧹 📖 📊 🔗) are also wrapped in `<span title="<step-name>">…</span>` for desktop hover discoverability.
+The column-1 step emojis (⚙️ 🔒 🖌 ✔ 🧹 📖 📊 ⏱ 🔗) are also wrapped in `<span title="<step-name>">…</span>` for desktop hover discoverability.
 
 Tooltips degrade silently: GitHub's mobile apps don't render `title` attributes, and screen readers don't reliably announce them. The emoji itself carries the user-facing meaning; tooltips are an enhancement.
 
@@ -220,7 +236,17 @@ Tooltips degrade silently: GitHub's mobile apps don't render `title` attributes,
 
 Same multi-line content as the ungrouped Plan Details row (§3.1) — one `<br>`-separated line per non-zero category, with `add` / `change` / `destroy` always shown. Each cell wraps its badge stack in `<div align="left">…</div>` so the badges anchor to the left edge of the otherwise center-aligned column. `N/A` when the plan didn't run or `parse-terraform-plan` couldn't extract counts for that env.
 
-### 4.5 Links row
+### 4.5 Plan time row
+
+Per-env cell holds the wall-clock duration of `terraform plan` for that env, formatted as `mm:ss` and wrapped in backticks for a monospace look (e.g. `` `0:42` ``, `` `2:05` ``). The value is sourced from `.steps.plan.outputs["plan-time"]` in the env's matrix-job-meta artifact — `capture-matrix-job-meta` picks it up automatically from the converted `terraform-plan@v0` step's outputs.
+
+When the value is missing (env's metadata file omits the field, e.g. plan was skipped or the env ran on an older terraform-plan release), the cell renders the em-dash `—`. This matches the §4.3 "not applicable" convention used for missing step outcomes, so missing-data cells across the table look uniform.
+
+Both branches (value and em-dash) wrap the cell content in `<span title="mm:ss (minutes:seconds)">…</span>` — so hovering on an em-dash cell still teaches the column's intent, not just its absence.
+
+The row is always emitted as long as the group has at least one env; it sits between the Plan details row (§4.4) and the Links row (§4.6).
+
+### 4.6 Links row
 
 Per-env cell, zero to two Markdown links, one per line, separated by `<br>`. Each line is independently optional:
 
@@ -237,7 +263,7 @@ Per-env-comment lookup edge cases:
 
 If the Jobs API call itself fails (rate limit, transient 5xx), every env's `job log` line is dropped and a single warning is logged; the grouped table still renders.
 
-### 4.6 Reconcile algorithm
+### 4.7 Reconcile algorithm
 
 The aggregator action runs every PR event. Its job is to make the set of group comments on the PR equal to the desired set computed from the current run's metadata:
 
@@ -246,7 +272,7 @@ The aggregator action runs every PR event. Its job is to make the set of group c
     - `repos/$REPO/issues/$PR/comments` — from the result, build two maps:
       - existing group comments (body starts with `### Terraform validation summary for group: `)
       - existing per-env comments (body starts with the exact backtick-delimited per-env prefix from §2)
-    - `repos/$REPO/actions/runs/$RUN_ID/jobs` — used to resolve each env's matrix job URL for the Links row (§4.5). Match by GitHub-rendered job name pattern `^Terraform \(<env>\)$`. Either call may fail independently: a Jobs API failure drops `job log` links from every Links cell; a PR-comments failure triggers degraded mode (skip reconcile delete pass, still post fresh bodies, will re-reconcile on next run).
+    - `repos/$REPO/actions/runs/$RUN_ID/jobs` — used to resolve each env's matrix job URL for the Links row (§4.6). Match by GitHub-rendered job name pattern `^Terraform \(<env>\)$`. Either call may fail independently: a Jobs API failure drops `job log` links from every Links cell; a PR-comments failure triggers degraded mode (skip reconcile delete pass, still post fresh bodies, will re-reconcile on next run).
 3. **Render desired.** For each desired group, sort envs alphabetically and build the prefix + body per §4.1. The Links row uses the per-env comment map (step 2) to resolve `log extract` anchors.
 4. **Reconcile (delete pass).** Walk the existing group comments:
     - prefix not in desired set → DELETE (orphan from a removed/renamed group)
@@ -324,6 +350,6 @@ Quick map from spec section to implementing code:
 | §3.2 Grouped per-env comment body | same file, branched on `pr-comment-group` |
 | §3 Posting/replacing per-env comments | [`dsb-norge/github-actions/ci-cd/comment-on-pr@v2`](https://github.com/dsb-norge/github-actions/tree/main/ci-cd/comment-on-pr) |
 | §4 Per-group comment body + reconcile | [`aggregate-validation-summaries/step_aggregate.sh`](../aggregate-validation-summaries/step_aggregate.sh) |
-| §4.6 Source artifacts | [`capture-matrix-job-meta/step_capture.sh`](../capture-matrix-job-meta/step_capture.sh) |
+| §4.7 Source artifacts | [`capture-matrix-job-meta/step_capture.sh`](../capture-matrix-job-meta/step_capture.sh) |
 | §5 Input plumbing & per-env defaults | [`create-tf-vars-matrix/action.yml`](../create-tf-vars-matrix/action.yml) |
 | Workflow wiring | [`.github/workflows/terraform-ci-cd-default.yml`](../.github/workflows/terraform-ci-cd-default.yml) |

--- a/terraform-plan/action.yml
+++ b/terraform-plan/action.yml
@@ -45,6 +45,9 @@ outputs:
   json-output-file:
     description: "The output of the terraform plan in JSON format, ie. processed by the 'terraform show -json' command."
     value: ${{ steps.plan-json.outputs.tf-plan-json-output-file }}
+  plan-time:
+    description: "Wall-clock duration of the 'terraform plan' invocation, formatted as 'mm:ss'. Always populated — even when the plan command fails — so PR-comment tables can surface timing alongside the outcome."
+    value: ${{ steps.plan.outputs.plan-time }}
 runs:
   using: "composite"
   steps:

--- a/terraform-plan/action.yml
+++ b/terraform-plan/action.yml
@@ -65,48 +65,15 @@ runs:
         end-group
     - id: plan
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         TF_IN_AUTOMATION: "true"
+        input_working_directory: ${{ inputs.working-directory }}
+        input_environment_name: ${{ inputs.environment-name }}
+        input_extra_global_args: ${{ inputs.extra-global-args }}
+        input_extra_plan_args: ${{ inputs.extra-plan-args }}
       run: |
-        # run terraform plan
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        PLAN_CONSOLE_OUT_FILE="${GITHUB_WORKSPACE}/tf-plan-console-output-${{ inputs.environment-name }}.txt"
-        PLAN_TF_OUT_FILE="${GITHUB_WORKSPACE}/tf-plan-${{ inputs.environment-name }}.plan"
-        set-output 'tf-plan-console-output-file' "${PLAN_CONSOLE_OUT_FILE}"
-        set-output 'tf-plan-tf-output-file' "${PLAN_TF_OUT_FILE}"
-
-        PLAN_CMD="terraform ${{ inputs.extra-global-args }} plan -detailed-exitcode -input=false -no-color -out=${PLAN_TF_OUT_FILE} ${{ inputs.extra-plan-args }}"
-        log-info "command string is '${PLAN_CMD}'"
-        start-group "'terraform plan' in '$(ws-path $(pwd))'"
-
-        # Need this to properly catch terraform exit code
-        set -o pipefail
-
-        # Github runner gets confused by set commands, make sure 'continue-on-error: true' still applies after 'set -o pipefail'
-        set +e
-        ${PLAN_CMD} 2>&1 | tee ${PLAN_CONSOLE_OUT_FILE}
-        PLAN_EXIT_CODE=${?}
-
-        set-output 'tf-plan-exitcode' "${PLAN_EXIT_CODE}"
-
-        # make sure '2' is consider 'success'
-        # 'terraform plan' exits with exit code 2 upon success when changes are present
-        #   https://www.terraform.io/docs/commands/plan.html#detailed-exitcode
-        if [ "${PLAN_EXIT_CODE}" == "0" ]; then
-          log-info 'successfully planned Terraform configuration, no changes indicated.'
-        elif [ "${PLAN_EXIT_CODE}" == "2" ]; then
-          PLAN_EXIT_CODE=0
-          log-info 'successfully planned Terraform configuration, changes indicated!'
-        else
-          log-error "failed to plan Terraform configuration, exit code: ${PLAN_EXIT_CODE}"
-          PLAN_EXIT_CODE=-1
-        fi
-        end-group
-
-        exit ${PLAN_EXIT_CODE}
+        set -o allexport
+        source "${{ github.action_path }}/step_plan.sh"
       continue-on-error: true # allow action to continue, execution status is returned by the last step
     - id: plan-upload
       if: steps.plan.outcome != 'cancelled' && steps.plan.outcome != 'skipped'
@@ -118,34 +85,24 @@ runs:
     - id: plan-show
       if: steps.plan.outcome == 'success'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      env:
+        input_working_directory: ${{ inputs.working-directory }}
+        input_environment_name: ${{ inputs.environment-name }}
+        input_plan_tf_output_file: ${{ steps.plan.outputs.tf-plan-tf-output-file }}
       run: |
-        # create plan.txt file
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        start-group "output the plan as txt"
-        PLAN_TF_OUT_FILE="${{ steps.plan.outputs.tf-plan-tf-output-file }}"
-        PLAN_TXT_OUT_FILE="${GITHUB_WORKSPACE}/tf-plan-${{ inputs.environment-name }}.txt"
-        set-output 'tf-plan-txt-output-file' "${PLAN_TXT_OUT_FILE}"
-        terraform show -no-color ${PLAN_TF_OUT_FILE} 2>&1 | tee ${PLAN_TXT_OUT_FILE}
-        end-group
+        set -o allexport
+        source "${{ github.action_path }}/step_plan_show.sh"
       continue-on-error: true # allow action to continue, execution status is returned by the last step
     - id: plan-json
       if: steps.plan.outcome == 'success'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      env:
+        input_working_directory: ${{ inputs.working-directory }}
+        input_environment_name: ${{ inputs.environment-name }}
+        input_plan_tf_output_file: ${{ steps.plan.outputs.tf-plan-tf-output-file }}
       run: |
-        # create plan.json file
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        start-group "output the plan as json"
-        PLAN_TF_OUT_FILE="${{ steps.plan.outputs.tf-plan-tf-output-file }}"
-        PLAN_JSON_OUT_FILE="${GITHUB_WORKSPACE}/tf-plan-${{ inputs.environment-name }}.json"
-        set-output 'tf-plan-json-output-file' "${PLAN_JSON_OUT_FILE}"
-        terraform show -json ${PLAN_TF_OUT_FILE} > ${PLAN_JSON_OUT_FILE} 2>&1
-        end-group
+        set -o allexport
+        source "${{ github.action_path }}/step_plan_json.sh"
       continue-on-error: true # allow action to continue, execution status is returned by the last step
     - id: plan-json-upload
       if: steps.plan-json.outcome == 'success'

--- a/terraform-plan/helpers_additional.sh
+++ b/terraform-plan/helpers_additional.sh
@@ -1,0 +1,17 @@
+#!/bin/env bash
+#
+# Action-specific helpers for terraform-plan.
+# Auto-loaded by helpers.sh.
+#
+
+# Format an integer seconds count as 'mm:ss'.
+# Minutes are zero-padded only to width 1 (so '0:07', '1:23'); seconds are
+# always zero-padded to width 2. Minutes may exceed 99 — CI plans rarely
+# do, but the format degrades gracefully (e.g. '120:05'). No hours field
+# on purpose: keeps the renderer trivial and the display unambiguous.
+function format-duration-mmss {
+  local total="${1:-0}"
+  local minutes=$((total / 60))
+  local seconds=$((total % 60))
+  printf '%d:%02d' "${minutes}" "${seconds}"
+}

--- a/terraform-plan/run_all_tests.sh
+++ b/terraform-plan/run_all_tests.sh
@@ -1,0 +1,36 @@
+#!/bin/env bash
+#
+# Orchestrates the per-step test suites for terraform-plan.
+#
+# Each per-step script (run_tests_step_*.sh) emits the canonical
+#   Tests run:    <N>
+#   Tests passed: <N>
+#   Tests failed: <N>
+# lines that the action-tests workflow parses (docs/Testing-in-ci.md §4).
+# The workflow SUMS those lines across all matches in the orchestrator's
+# stdout, so this script must NOT emit a fourth aggregate block —
+# doing so would double-count (see docs/Testing-in-ci.md §4 paragraph on
+# multi-step orchestrators).
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+overall_exit=0
+
+run_suite() {
+  local script="${1}"
+  local label="${2}"
+
+  echo ""
+  echo -e "${YELLOW}>>> Running ${label}${NC}"
+  bash "${script}" || overall_exit=1
+}
+
+run_suite "${_this_script_dir}/run_tests_step_plan.sh"      "step_plan.sh tests"
+run_suite "${_this_script_dir}/run_tests_step_plan_show.sh" "step_plan_show.sh tests"
+run_suite "${_this_script_dir}/run_tests_step_plan_json.sh" "step_plan_json.sh tests"
+
+exit ${overall_exit}

--- a/terraform-plan/run_local_step_plan.sh
+++ b/terraform-plan/run_local_step_plan.sh
@@ -15,13 +15,15 @@ export GITHUB_WORKSPACE="${RUNNER_TEMP}"
 WORK_DIR="${RUNNER_TEMP}/envs/sandbox"
 mkdir -p "${WORK_DIR}"
 
-# Stub terraform that exits 2 (success-with-changes).
+# Stub terraform that exits 2 (success-with-changes) after a short sleep
+# so the plan-time output is non-zero.
 STUB_DIR="${RUNNER_TEMP}/stub-bin"
 mkdir -p "${STUB_DIR}"
 cat >"${STUB_DIR}/terraform" <<'EOF'
 #!/bin/env bash
 echo "stub terraform $*"
 echo "Plan: 1 to add, 0 to change, 0 to destroy."
+sleep 1
 exit 2
 EOF
 chmod +x "${STUB_DIR}/terraform"

--- a/terraform-plan/run_local_step_plan.sh
+++ b/terraform-plan/run_local_step_plan.sh
@@ -1,0 +1,41 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_plan.sh.
+# Simulates GitHub Actions environment using a stub 'terraform' binary,
+# so no real terraform install or backend is needed.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+WORK_DIR="${RUNNER_TEMP}/envs/sandbox"
+mkdir -p "${WORK_DIR}"
+
+# Stub terraform that exits 2 (success-with-changes).
+STUB_DIR="${RUNNER_TEMP}/stub-bin"
+mkdir -p "${STUB_DIR}"
+cat >"${STUB_DIR}/terraform" <<'EOF'
+#!/bin/env bash
+echo "stub terraform $*"
+echo "Plan: 1 to add, 0 to change, 0 to destroy."
+exit 2
+EOF
+chmod +x "${STUB_DIR}/terraform"
+export TF_BIN="${STUB_DIR}/terraform"
+
+export input_working_directory="${WORK_DIR}"
+export input_environment_name="sandbox"
+export input_extra_global_args=""
+export input_extra_plan_args=""
+
+source "${_this_script_dir}/step_plan.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"

--- a/terraform-plan/run_tests_step_plan.sh
+++ b/terraform-plan/run_tests_step_plan.sh
@@ -1,0 +1,203 @@
+#!/bin/env bash
+#
+# Tests for step_plan.sh
+#
+# Uses a stub 'terraform' binary (injected via TF_BIN) so tests don't
+# require — and never call — the real terraform binary. The stub records
+# its argv when MOCK_TF_ARGV_FILE is set and obeys MOCK_TF_EXIT,
+# MOCK_TF_STDOUT, MOCK_TF_SLEEP env vars.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+# Fresh GITHUB_OUTPUT, workspace, working dir; clear MOCK_TF_* overrides
+# left by previous tests.
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+  WORK_DIR="${RUNNER_TEMP}/work"
+  mkdir -p "${WORK_DIR}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_environment_name="testenv"
+  export input_extra_global_args=""
+  export input_extra_plan_args=""
+
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_SLEEP MOCK_TF_ARGV_FILE
+}
+
+# Install a stub 'terraform' binary configurable per-test via env vars.
+# Captures argv to MOCK_TF_ARGV_FILE if that variable is set when the
+# stub is invoked. Path is exported as TF_BIN so step_plan.sh picks it
+# up without needing to alter PATH (the legacy action shells out to bare
+# 'terraform'; the script reads TF_BIN to allow this seam).
+install_stub_terraform() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/terraform" <<'STUB'
+#!/bin/env bash
+# Recorded argv (one line per invocation)
+if [ -n "${MOCK_TF_ARGV_FILE:-}" ]; then
+  printf '%s\n' "$*" >>"${MOCK_TF_ARGV_FILE}"
+fi
+if [ -n "${MOCK_TF_STDOUT:-}" ]; then
+  printf '%s\n' "${MOCK_TF_STDOUT}"
+fi
+if [ "${MOCK_TF_SLEEP:-0}" -gt 0 ]; then
+  sleep "${MOCK_TF_SLEEP}"
+fi
+exit "${MOCK_TF_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/terraform"
+  export TF_BIN="${stub_dir}/terraform"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_plan.sh"
+  ) >/tmp/test_output_plan.txt 2>&1
+  LAST_EXIT=$?
+}
+
+get_output() {
+  local key="${1}"
+  grep "^${key}=" "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-
+}
+
+# assert <name> <command...>
+# Runs the command and reports pass/fail. The command's stderr is captured
+# alongside the step's output for diagnostics on failure.
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat /tmp/test_output_plan.txt 2>/dev/null || true
+    echo "--- /step output ---"
+    echo "--- GITHUB_OUTPUT ---"
+    cat "${GITHUB_OUTPUT}" 2>/dev/null || true
+    echo "--- /GITHUB_OUTPUT ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}         TERRAFORM-PLAN STEP TESTS         ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Test: Happy path, no changes (terraform exit 0)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+export MOCK_TF_STDOUT="No changes. Your infrastructure matches the configuration."
+run_step
+assert "Exit 0: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Exit 0: tf-plan-exitcode output is '0'" \
+  test "$(get_output tf-plan-exitcode)" = "0"
+assert "Exit 0: no-changes log line present" \
+  grep -q "no changes indicated" /tmp/test_output_plan.txt
+assert "Exit 0: console output file path is published" \
+  test -n "$(get_output tf-plan-console-output-file)"
+assert "Exit 0: console output file exists and contains stub stdout" \
+  grep -q "No changes" "$(get_output tf-plan-console-output-file)"
+
+# ----------------------------------------------------------------------
+# Test: Happy path, with changes (terraform exit 2 → script exit 0,
+#                                 raw 2 still published)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=2
+export MOCK_TF_STDOUT="Plan: 1 to add, 0 to change, 0 to destroy."
+run_step
+assert "Exit 2: step exits 0 (success-with-changes normalized)" \
+  test "${LAST_EXIT}" -eq 0
+assert "Exit 2: tf-plan-exitcode publishes raw '2'" \
+  test "$(get_output tf-plan-exitcode)" = "2"
+assert "Exit 2: success-with-changes log line present" \
+  grep -q "changes indicated" /tmp/test_output_plan.txt
+
+# ----------------------------------------------------------------------
+# Test: Failure (terraform exit 1 → script exits non-zero)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=1
+export MOCK_TF_STDOUT="Error: something went wrong"
+run_step
+assert "Exit 1: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Exit 1: tf-plan-exitcode publishes raw '1'" \
+  test "$(get_output tf-plan-exitcode)" = "1"
+assert "Exit 1: failure log line present" \
+  grep -q "failed to plan" /tmp/test_output_plan.txt
+
+# ----------------------------------------------------------------------
+# Test: extra-global-args and extra-plan-args reach terraform invocation
+# in the expected order:
+#   <tf_bin> <global> plan -detailed-exitcode -input=false -no-color -out=<file> <plan>
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+export MOCK_TF_ARGV_FILE="${RUNNER_TEMP}/argv.log"
+export input_extra_global_args="-chdir=/tmp/fake"
+export input_extra_plan_args="-var foo=bar -var baz=qux"
+run_step
+argv_line="$(head -n1 "${MOCK_TF_ARGV_FILE}" 2>/dev/null || true)"
+assert "argv: global arg precedes 'plan'" \
+  bash -c "[[ '${argv_line}' == *'-chdir=/tmp/fake plan'* ]]"
+assert "argv: plan flags from script present" \
+  bash -c "[[ '${argv_line}' == *'-detailed-exitcode'* && '${argv_line}' == *'-input=false'* && '${argv_line}' == *'-no-color'* ]]"
+assert "argv: plan args appear after the -out flag" \
+  bash -c "[[ '${argv_line}' == *'-var foo=bar -var baz=qux' ]]"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}            step_plan.sh SUMMARY            ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/terraform-plan/run_tests_step_plan.sh
+++ b/terraform-plan/run_tests_step_plan.sh
@@ -106,6 +106,13 @@ assert() {
   fi
 }
 
+# Check that a value matches a regex.
+match_regex() {
+  local value="${1}"
+  local pattern="${2}"
+  [[ "${value}" =~ ${pattern} ]]
+}
+
 # --------------------------------------------------------------------------
 # Tests
 # --------------------------------------------------------------------------
@@ -114,6 +121,45 @@ echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}         TERRAFORM-PLAN STEP TESTS         ${NC}"
 echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# format-duration-mmss helper (helpers_additional.sh)
+# ----------------------------------------------------------------------
+# Source the helper directly so we can test it in isolation, independent
+# of the timing path in step_plan.sh.
+setup_workdir
+(
+  source "${_this_script_dir}/helpers.sh" >/dev/null 2>&1
+  printf '%s\n' \
+    "0=$(format-duration-mmss 0)" \
+    "1=$(format-duration-mmss 1)" \
+    "59=$(format-duration-mmss 59)" \
+    "60=$(format-duration-mmss 60)" \
+    "61=$(format-duration-mmss 61)" \
+    "125=$(format-duration-mmss 125)" \
+    "3599=$(format-duration-mmss 3599)" \
+    "7205=$(format-duration-mmss 7205)" \
+    "default=$(format-duration-mmss)"
+) >/tmp/test_output_plan.txt 2>&1
+
+assert "format-duration-mmss(0) = 0:00" \
+  grep -Fxq "0=0:00" /tmp/test_output_plan.txt
+assert "format-duration-mmss(1) = 0:01" \
+  grep -Fxq "1=0:01" /tmp/test_output_plan.txt
+assert "format-duration-mmss(59) = 0:59" \
+  grep -Fxq "59=0:59" /tmp/test_output_plan.txt
+assert "format-duration-mmss(60) = 1:00" \
+  grep -Fxq "60=1:00" /tmp/test_output_plan.txt
+assert "format-duration-mmss(61) = 1:01" \
+  grep -Fxq "61=1:01" /tmp/test_output_plan.txt
+assert "format-duration-mmss(125) = 2:05" \
+  grep -Fxq "125=2:05" /tmp/test_output_plan.txt
+assert "format-duration-mmss(3599) = 59:59" \
+  grep -Fxq "3599=59:59" /tmp/test_output_plan.txt
+assert "format-duration-mmss(7205) = 120:05" \
+  grep -Fxq "7205=120:05" /tmp/test_output_plan.txt
+assert "format-duration-mmss() defaults to 0:00" \
+  grep -Fxq "default=0:00" /tmp/test_output_plan.txt
 
 # ----------------------------------------------------------------------
 # Test: Happy path, no changes (terraform exit 0)
@@ -162,6 +208,50 @@ assert "Exit 1: tf-plan-exitcode publishes raw '1'" \
   test "$(get_output tf-plan-exitcode)" = "1"
 assert "Exit 1: failure log line present" \
   grep -q "failed to plan" /tmp/test_output_plan.txt
+
+# ----------------------------------------------------------------------
+# Test: plan-time on fast plan (sub-second / 1-2s jitter window)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+run_step
+pt_fast="$(get_output plan-time)"
+assert "Fast plan: plan-time published" test -n "${pt_fast}"
+assert "Fast plan: plan-time matches mm:ss format" \
+  match_regex "${pt_fast}" '^[0-9]+:[0-9]{2}$'
+# Accept 0:00, 0:01, 0:02 — accommodates clock-tick jitter.
+assert "Fast plan: plan-time is 0:00, 0:01, or 0:02" \
+  bash -c "case '${pt_fast}' in 0:0[0-2]) exit 0;; *) exit 1;; esac"
+
+# ----------------------------------------------------------------------
+# Test: plan-time reflects a few-seconds delay
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+export MOCK_TF_SLEEP=2
+run_step
+pt_slow="$(get_output plan-time)"
+assert "Slow plan: plan-time matches mm:ss format" \
+  match_regex "${pt_slow}" '^[0-9]+:[0-9]{2}$'
+# 2s sleep ± 1s jitter
+assert "Slow plan: plan-time is 0:02 or 0:03" \
+  bash -c "case '${pt_slow}' in 0:0[2-3]) exit 0;; *) exit 1;; esac"
+
+# ----------------------------------------------------------------------
+# Test: plan-time is emitted even when terraform fails
+# Regression guard — timing on failure is the whole point of showing
+# a "Plan time" row in the PR comment (slow + failing = bad signal).
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=1
+run_step
+pt_failed="$(get_output plan-time)"
+assert "Failed plan: plan-time still emitted" test -n "${pt_failed}"
+assert "Failed plan: plan-time matches mm:ss format" \
+  match_regex "${pt_failed}" '^[0-9]+:[0-9]{2}$'
 
 # ----------------------------------------------------------------------
 # Test: extra-global-args and extra-plan-args reach terraform invocation

--- a/terraform-plan/run_tests_step_plan_json.sh
+++ b/terraform-plan/run_tests_step_plan_json.sh
@@ -1,0 +1,121 @@
+#!/bin/env bash
+#
+# Tests for step_plan_json.sh
+#
+# 'terraform show -json <plan-file>' is mocked via TF_BIN — no real
+# terraform binary is invoked.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+  WORK_DIR="${RUNNER_TEMP}/work"
+  mkdir -p "${WORK_DIR}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_environment_name="testenv"
+  export input_plan_tf_output_file="${RUNNER_TEMP}/fake-plan.bin"
+
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT
+}
+
+install_stub_terraform() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/terraform" <<'STUB'
+#!/bin/env bash
+if [ -n "${MOCK_TF_STDOUT:-}" ]; then
+  printf '%s' "${MOCK_TF_STDOUT}"
+fi
+exit "${MOCK_TF_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/terraform"
+  export TF_BIN="${stub_dir}/terraform"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_plan_json.sh"
+  ) >/tmp/test_output_json.txt 2>&1
+  LAST_EXIT=$?
+}
+
+get_output() {
+  local key="${1}"
+  grep "^${key}=" "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat /tmp/test_output_json.txt 2>/dev/null || true
+    echo "--- /step output ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}       TERRAFORM-PLAN JSON STEP TESTS       ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Happy path: stub writes valid JSON → json file is produced verbatim.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+export MOCK_TF_STDOUT='{"format_version":"1.2","resource_changes":[]}'
+run_step
+
+json_file="$(get_output tf-plan-json-output-file)"
+assert "json output file path is published" test -n "${json_file}"
+assert "json output file path follows tf-plan-<env>.json convention" \
+  bash -c "[[ '${json_file}' == */tf-plan-testenv.json ]]"
+assert "json output file exists on disk" test -f "${json_file}"
+assert "json output file contains stub output verbatim" \
+  bash -c "[[ \"\$(cat '${json_file}')\" == '{\"format_version\":\"1.2\",\"resource_changes\":[]}' ]]"
+assert "json output is valid JSON" \
+  bash -c "python3 -c 'import json,sys; json.load(open(\"${json_file}\"))'"
+assert "step exits 0 on happy path" test "${LAST_EXIT}" -eq 0
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}         step_plan_json.sh SUMMARY          ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/terraform-plan/run_tests_step_plan_show.sh
+++ b/terraform-plan/run_tests_step_plan_show.sh
@@ -1,0 +1,140 @@
+#!/bin/env bash
+#
+# Tests for step_plan_show.sh
+#
+# 'terraform show <plan-file>' is mocked via TF_BIN — no real terraform
+# binary is invoked.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+  WORK_DIR="${RUNNER_TEMP}/work"
+  mkdir -p "${WORK_DIR}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_environment_name="testenv"
+  export input_plan_tf_output_file="${RUNNER_TEMP}/fake-plan.bin"
+
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT
+}
+
+install_stub_terraform() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/terraform" <<'STUB'
+#!/bin/env bash
+if [ -n "${MOCK_TF_STDOUT:-}" ]; then
+  printf '%s\n' "${MOCK_TF_STDOUT}"
+fi
+exit "${MOCK_TF_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/terraform"
+  export TF_BIN="${stub_dir}/terraform"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_plan_show.sh"
+  ) >/tmp/test_output_show.txt 2>&1
+  LAST_EXIT=$?
+}
+
+get_output() {
+  local key="${1}"
+  grep "^${key}=" "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat /tmp/test_output_show.txt 2>/dev/null || true
+    echo "--- /step output ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}       TERRAFORM-PLAN SHOW STEP TESTS       ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Happy path: stub prints predictable text → txt file is produced.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+export MOCK_TF_STDOUT="Plan rendered as text content"
+run_step
+
+txt_file="$(get_output tf-plan-txt-output-file)"
+assert "txt output file path is published" test -n "${txt_file}"
+assert "txt output file path is under GITHUB_WORKSPACE" \
+  bash -c "[[ '${txt_file}' == ${GITHUB_WORKSPACE}/* ]]"
+assert "txt output file path follows tf-plan-<env>.txt convention" \
+  bash -c "[[ '${txt_file}' == */tf-plan-testenv.txt ]]"
+assert "txt output file exists on disk" test -f "${txt_file}"
+assert "txt output file contains stub output" \
+  grep -q "Plan rendered as text content" "${txt_file}"
+assert "step exits 0 on happy path" test "${LAST_EXIT}" -eq 0
+
+# ----------------------------------------------------------------------
+# 'terraform show' failure: step still completes (continue-on-error in
+# action.yml). The script does not propagate the failure as exit code 1 —
+# matches the legacy behavior where this step was wrapped in
+# continue-on-error: true.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=1
+export MOCK_TF_STDOUT="Error rendering plan"
+run_step
+assert "Step still exits 0 when terraform show fails (continue-on-error semantics)" \
+  test "${LAST_EXIT}" -eq 0
+txt_file="$(get_output tf-plan-txt-output-file)"
+assert "txt output file path still published on failure" \
+  test -n "${txt_file}"
+assert "txt output file contains the error text from stub stdout" \
+  grep -q "Error rendering plan" "${txt_file}"
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}         step_plan_show.sh SUMMARY          ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/terraform-plan/step_plan.sh
+++ b/terraform-plan/step_plan.sh
@@ -1,0 +1,82 @@
+#!/bin/env bash
+#
+# Source for the terraform-plan main step.
+#
+# Runs 'terraform plan' in the working directory and captures the console
+# output.
+#
+# Outputs:
+#   tf-plan-console-output-file - Path of file with captured stdout/stderr.
+#   tf-plan-tf-output-file      - Path of the binary plan file.
+#   tf-plan-exitcode            - The raw exit code from 'terraform plan'.
+#                                 NOTE: terraform plan returns 2 on success
+#                                 when there are changes (with
+#                                 -detailed-exitcode); the raw code is
+#                                 published so downstream consumers can
+#                                 distinguish 'success-with-changes' from
+#                                 'success-no-changes'. The script itself
+#                                 still exits 0 in both cases.
+#                                 https://www.terraform.io/docs/commands/plan.html#detailed-exitcode
+#
+# Required environment variables:
+#   input_working_directory   - Where to invoke terraform.
+#   input_environment_name    - Used when naming the plan output files.
+#   input_extra_global_args   - Args before the 'plan' subcommand.
+#   input_extra_plan_args     - Args after the 'plan' subcommand.
+#
+# Optional environment variables:
+#   TF_BIN - Path to the terraform binary (defaults to 'terraform' on PATH).
+#            Used by tests to inject a stub.
+#
+
+set +o nounset
+
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tf_bin="${TF_BIN:-terraform}"
+
+  cd "${input_working_directory}"
+
+  local plan_console_out_file="${GITHUB_WORKSPACE}/tf-plan-console-output-${input_environment_name}.txt"
+  local plan_tf_out_file="${GITHUB_WORKSPACE}/tf-plan-${input_environment_name}.plan"
+  set-output 'tf-plan-console-output-file' "${plan_console_out_file}"
+  set-output 'tf-plan-tf-output-file' "${plan_tf_out_file}"
+
+  # Build the command. Quote-light to match the legacy action's behavior:
+  # extra-* args are space-delimited strings that the user injects verbatim.
+  local plan_cmd="${tf_bin} ${input_extra_global_args} plan -detailed-exitcode -input=false -no-color -out=${plan_tf_out_file} ${input_extra_plan_args}"
+  log-info "command string is '${plan_cmd}'"
+  start-group "'terraform plan' in '$(ws-path "$(pwd)")'"
+
+  # Needed to properly catch terraform's exit code through the pipe to tee.
+  set -o pipefail
+
+  # GitHub runner gets confused by set commands; make sure
+  # 'continue-on-error: true' still applies after 'set -o pipefail'.
+  set +e
+  ${plan_cmd} 2>&1 | tee "${plan_console_out_file}"
+  local plan_exit_code=${?}
+
+  set-output 'tf-plan-exitcode' "${plan_exit_code}"
+
+  # Normalize the local exit code so the action returns 0 on
+  # success-with-changes (terraform's exit 2 from -detailed-exitcode).
+  # The raw code is still published via tf-plan-exitcode above.
+  if [ "${plan_exit_code}" == "0" ]; then
+    log-info 'successfully planned Terraform configuration, no changes indicated.'
+  elif [ "${plan_exit_code}" == "2" ]; then
+    plan_exit_code=0
+    log-info 'successfully planned Terraform configuration, changes indicated!'
+  else
+    log-error "failed to plan Terraform configuration, exit code: ${plan_exit_code}"
+    plan_exit_code=-1
+  fi
+  end-group
+
+  return ${plan_exit_code}
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/terraform-plan/step_plan.sh
+++ b/terraform-plan/step_plan.sh
@@ -2,8 +2,8 @@
 #
 # Source for the terraform-plan main step.
 #
-# Runs 'terraform plan' in the working directory and captures the console
-# output.
+# Runs 'terraform plan' in the working directory, captures the console
+# output, and measures the wall-clock time the plan command took.
 #
 # Outputs:
 #   tf-plan-console-output-file - Path of file with captured stdout/stderr.
@@ -17,6 +17,11 @@
 #                                 'success-no-changes'. The script itself
 #                                 still exits 0 in both cases.
 #                                 https://www.terraform.io/docs/commands/plan.html#detailed-exitcode
+#   plan-time                   - Wall-clock duration of the plan command,
+#                                 formatted as 'mm:ss'. Always emitted —
+#                                 even on failure, so PR-comment tables can
+#                                 surface "this plan failed AND it took N
+#                                 minutes" in one glance.
 #
 # Required environment variables:
 #   input_working_directory   - Where to invoke terraform.
@@ -31,6 +36,7 @@
 
 set +o nounset
 
+# Load helpers (provides format-duration-mmss via helpers_additional.sh)
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
@@ -55,8 +61,19 @@ function main {
   # GitHub runner gets confused by set commands; make sure
   # 'continue-on-error: true' still applies after 'set -o pipefail'.
   set +e
+
+  # Capture elapsed seconds around the actual plan invocation. SECONDS is a
+  # bash builtin that increments once per real second; the delta is the
+  # wall-clock time spent inside terraform plan (plus the trivial overhead
+  # of the surrounding shell, which is below mm:ss granularity).
+  local plan_start=${SECONDS}
   ${plan_cmd} 2>&1 | tee "${plan_console_out_file}"
   local plan_exit_code=${?}
+  local plan_duration=$((SECONDS - plan_start))
+
+  # Emit plan-time before any return path so that even on parse/eval failure
+  # downstream, the PR comment still shows how long terraform actually ran.
+  set-output 'plan-time' "$(format-duration-mmss "${plan_duration}")"
 
   set-output 'tf-plan-exitcode' "${plan_exit_code}"
 

--- a/terraform-plan/step_plan_json.sh
+++ b/terraform-plan/step_plan_json.sh
@@ -1,0 +1,40 @@
+#!/bin/env bash
+#
+# Source for the plan-json step (post-plan).
+#
+# Renders the binary plan file as JSON via 'terraform show -json' and
+# exposes the path of the resulting file.
+#
+# Outputs:
+#   tf-plan-json-output-file - Path of the rendered .json file.
+#
+# Required environment variables:
+#   input_working_directory   - terraform working directory.
+#   input_environment_name    - used when naming the output file.
+#   input_plan_tf_output_file - the binary plan file produced by step_plan.sh.
+#
+# Optional environment variables:
+#   TF_BIN - Path to terraform binary (defaults to 'terraform' on PATH).
+#
+
+set +o nounset
+
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tf_bin="${TF_BIN:-terraform}"
+
+  cd "${input_working_directory}"
+
+  start-group "output the plan as json"
+  local plan_tf_out_file="${input_plan_tf_output_file}"
+  local plan_json_out_file="${GITHUB_WORKSPACE}/tf-plan-${input_environment_name}.json"
+  set-output 'tf-plan-json-output-file' "${plan_json_out_file}"
+  "${tf_bin}" show -json "${plan_tf_out_file}" >"${plan_json_out_file}" 2>&1
+  end-group
+  return 0
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/terraform-plan/step_plan_show.sh
+++ b/terraform-plan/step_plan_show.sh
@@ -1,0 +1,40 @@
+#!/bin/env bash
+#
+# Source for the plan-show step (post-plan).
+#
+# Renders the binary plan file as a human-readable text artifact via
+# 'terraform show' and exposes the path of the resulting file.
+#
+# Outputs:
+#   tf-plan-txt-output-file - Path of the rendered .txt file.
+#
+# Required environment variables:
+#   input_working_directory   - terraform working directory.
+#   input_environment_name    - used when naming the output file.
+#   input_plan_tf_output_file - the binary plan file produced by step_plan.sh.
+#
+# Optional environment variables:
+#   TF_BIN - Path to terraform binary (defaults to 'terraform' on PATH).
+#
+
+set +o nounset
+
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tf_bin="${TF_BIN:-terraform}"
+
+  cd "${input_working_directory}"
+
+  start-group "output the plan as txt"
+  local plan_tf_out_file="${input_plan_tf_output_file}"
+  local plan_txt_out_file="${GITHUB_WORKSPACE}/tf-plan-${input_environment_name}.txt"
+  set-output 'tf-plan-txt-output-file' "${plan_txt_out_file}"
+  "${tf_bin}" show -no-color "${plan_tf_out_file}" 2>&1 | tee "${plan_txt_out_file}"
+  end-group
+  return 0
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}


### PR DESCRIPTION
## Motivation

Reviewers can't tell from the PR comment whether a `terraform plan` was fast (refresh-heavy state) or slow (network/auth issues, large module trees) without clicking through to the job log. Surfacing the wall-clock duration in the validation summary makes "slow AND failing" or "slow but green" visible at a glance.

## Summary of changes

- **`terraform-plan/`** — converted from legacy inline-bash to the modern action layout per `docs/Action-implementation-guide.md`. The main plan step now wraps the `terraform plan` invocation with a `SECONDS` timer and publishes the duration as a new `plan-time` output (formatted `mm:ss`). The output is set *before* the script's exit path, so it's emitted even when plan fails. Comes with a per-step test harness that uses a PATH-shadowed mock `terraform` — tests never invoke the real binary.
- **`.github/workflows/terraform-ci-cd-default.yml`** — wires `steps.plan.outputs.plan-time` into `create-validation-summary@v0`.
- **`create-validation-summary/`** — new `plan-time` input (default `N/A`). Renders a trailing `| ⏱ | Plan time | <value> |` row in the ungrouped validation table. The value cell is wrapped in `<span title="mm:ss (minutes:seconds)">…</span>` so hovering on desktop surfaces the unit.
- **`aggregate-validation-summaries/`** — new `_extract_plan_time` / `_render_plan_time_cell` helpers. Reads `.steps.plan.outputs["plan-time"]` from each env's matrix metadata and emits the row between Plan details and Links in the per-group table. Missing values render as `—`. Same `<span title>` tooltip wraps both present and missing branches.
- **`docs/Workflow-pr-comments.md`** — both §3.1 (ungrouped) and §4 (grouped) examples updated; new §3.1 subsection "Plan time row" + new §4.5 "Plan time row" (renumbered §4.6 Links and §4.7 Reconcile algorithm).

Cell-empty conventions match each table's existing pattern: `N/A` in the ungrouped table (matches `plan-count-*` defaults), `—` in the grouped table (matches the existing "not applicable" status fallback).

## Preview — rendered tables

The same markdown a reviewer would see once this lands. Hover any Plan time cell on desktop to see the `mm:ss (minutes:seconds)` tooltip.

### Ungrouped per-env comment (one per environment)

> ### Terraform validation summary for environment: `dev`
>
> |  | Step | Result |
> |:---:|---|---|
> | ⚙️ | Initialization | `success` |
> | 🔒 | Lock file | `success` |
> | 🖌 | Format and Style | `success` |
> | ✔ | Validate | `success` |
> | 🧹 | TFLint | `success` |
> | 📖 | Plan | `success` |
> | 📊 | Plan Details | <span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span> |
> | ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |
>
> <details><summary>Plan: 1 changes ℹ️</summary>
>
> ```terraform
> …
> ```
>
> </details>
>
> [Job log](#)

### Grouped per-group comment (one per `pr-comment-group`)

> ### Terraform validation summary for group: `dev`
>
> |  | Step | sub-a-dev | sub-b-dev | sub-c-dev |
> |:---:|---|:---:|:---:|:---:|
> | <span title="Initialization">⚙️</span> | Initialization | <span title="success">✅</span> | <span title="success">✅</span> | <span title="failure">❌</span> |
> | <span title="Lock file">🔒</span> | Lock file | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
> | <span title="Format and Style">🖌</span> | Format and Style | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
> | <span title="Validate">✔</span> | Validate | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
> | <span title="TFLint">🧹</span> | TFLint | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
> | <span title="Plan">📖</span> | Plan | <span title="success">✅</span> | <span title="success">✅</span> | <span title="skipped">⏭️</span> |
> | <span title="Plan details">📊</span> | Plan details | <div align="left"><span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span></div> | <div align="left"><span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span><br><span title="Resources to be imported">`📥 2` import</span></div> | N/A |
> | <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`0:42`</span> | <span title="mm:ss (minutes:seconds)">`2:05`</span> | <span title="mm:ss (minutes:seconds)">—</span> |
> | <span title="Links">🔗</span> | Links | [log extract](#)<br>[job log](#) | [log extract](#)<br>[job log](#) | [job log](#) |
>
> [Job log](#)

The third env (`sub-c-dev`) above illustrates the missing-value case: its plan was skipped (init failed), so its Plan time cell renders the em-dash `—`. Hovering still shows the format tooltip.

## Test coverage

129 tests across the touched suites (terraform-plan 45, create-validation-summary 52, aggregate-validation-summaries 32). Existing golden-body assertions updated to include the new row + tooltip; new tests cover happy path, defaults, placement, grouped-mode omission, per-env values, and the em-dash branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
