### PR TITLE
fix(aggregate-validation-summaries): upsert by HTML marker; self-heal duplicates

### DIFF
--- a/aggregate-validation-summaries/helpers_additional.sh
+++ b/aggregate-validation-summaries/helpers_additional.sh
@@ -6,11 +6,14 @@
 # by helpers.sh.
 #
 
-# Family prefix shared by every per-group comment this action manages.
-# Used both for delete-by-prefix reconciliation and to identify orphans
-# whose specific group name is no longer in the desired set.
+# Family marker shared by every per-group comment this action manages.
+# Lives on the first line of the body as an HTML comment so it's invisible
+# to readers. The per-group marker (built via _group_marker) extends this
+# with the group name and a trailing ' -->', allowing a single PR to host
+# multiple group comments and have each one upserted independently.
+# Renders to nothing in the GitHub Markdown view.
 # See docs/Workflow-pr-comments.md §2.
-declare -gr GROUP_COMMENT_FAMILY_PREFIX='### Terraform validation summary for group: '
+declare -gr GROUP_COMMENT_MARKER_FAMILY='<!-- terraform-validation-summary-group:'
 
 # Per-env comment prefix template (uses backtick-delimited env name so
 # partial matches can't collide).
@@ -20,10 +23,20 @@ function _per_env_prefix {
   echo "### Terraform validation summary for environment: \`${env_name}\`"
 }
 
-# Specific group comment prefix for one group name.
+# Specific group comment H3 heading (rendered immediately after the marker
+# at the top of the body). Kept for visible identification — users still
+# see "for group: \`<group>\`" — but no longer load-bearing for upsert
+# identity. The marker (_group_marker) is the load-bearing handle.
 function _group_prefix {
   local group_name="${1}"
-  echo "${GROUP_COMMENT_FAMILY_PREFIX}\`${group_name}\`"
+  echo "### Terraform validation summary for group: \`${group_name}\`"
+}
+
+# Per-group HTML marker. Unique per group so multiple groups on the same
+# PR can be upserted independently.
+function _group_marker {
+  local group_name="${1}"
+  echo "${GROUP_COMMENT_MARKER_FAMILY}${group_name} -->"
 }
 
 # Map a GitHub Actions step outcome string to the (emoji, title) pair used
@@ -171,4 +184,11 @@ function _gh_delete_comment {
 function _gh_post_comment {
   local repo="${1}" pr="${2}" body_file="${3}"
   gh api -X POST "repos/${repo}/issues/${pr}/comments" -F "body=@${body_file}" --jq '.id'
+}
+
+# Edits an existing comment in place. Body file convention matches
+# _gh_post_comment so callers can use the same temp file for either op.
+function _gh_patch_comment {
+  local repo="${1}" comment_id="${2}" body_file="${3}"
+  gh api -X PATCH "repos/${repo}/issues/comments/${comment_id}" -F "body=@${body_file}" --jq '.id'
 }

--- a/aggregate-validation-summaries/run_all_tests.sh
+++ b/aggregate-validation-summaries/run_all_tests.sh
@@ -60,6 +60,20 @@ case "$*" in
     fi
     echo '{"deleted": true}'
     ;;
+  *"-X PATCH"*"/issues/comments/"*)
+    if [ "${GH_FAKE_PATCH_EXIT:-0}" != "0" ]; then
+      exit "${GH_FAKE_PATCH_EXIT}"
+    fi
+    # Extract the comment id from the URL and echo it — matches production
+    # _gh_patch_comment which uses --jq '.id' on the response.
+    # URL form: repos/<repo>/issues/comments/<id>
+    for arg in "$@"; do
+      if [[ "${arg}" == repos/*"/issues/comments/"* ]]; then
+        echo "${arg##*/}"
+        break
+      fi
+    done
+    ;;
   *"-X POST"*)
     if [ "${GH_FAKE_POST_EXIT:-0}" != "0" ]; then
       exit "${GH_FAKE_POST_EXIT}"
@@ -79,7 +93,7 @@ FAKE_GH
   export GH_FAKE_CALL_LOG="${TEST_DIR}/gh-calls.log"
   export GH_FAKE_LIST_RESPONSE_FILE="${TEST_DIR}/list-response.json"
   export GH_FAKE_JOBS_RESPONSE_FILE="${TEST_DIR}/jobs-response.json"
-  unset GH_FAKE_LIST_EXIT GH_FAKE_DELETE_EXIT GH_FAKE_POST_EXIT GH_FAKE_JOBS_EXIT
+  unset GH_FAKE_LIST_EXIT GH_FAKE_DELETE_EXIT GH_FAKE_POST_EXIT GH_FAKE_PATCH_EXIT GH_FAKE_JOBS_EXIT
   echo "[]" > "${GH_FAKE_LIST_RESPONSE_FILE}"
   echo "[]" > "${GH_FAKE_JOBS_RESPONSE_FILE}"
   : > "${GH_FAKE_CALL_LOG}"
@@ -245,9 +259,9 @@ test_empty_desired_empty_existing_is_noop() {
 }
 
 test_sweep_only_orphans() {
-  # No desired groups, but PR has an existing group comment from a prior run
+  # No desired groups, but PR has an existing marker comment from a prior run
   cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
-[{"id": 5001, "body": "### Terraform validation summary for group: `stale-group`\nold body"}]
+[{"id": 5001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:stale-group -->\n### Terraform validation summary for group: `stale-group`\nold body"}]
 JSON
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
@@ -256,6 +270,9 @@ JSON
   fi
   if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
     echo "did not expect POST when desired set is empty"; return 1
+  fi
+  if grep -q 'PATCH' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect PATCH on orphan"; return 1
   fi
   return 0
 }
@@ -284,27 +301,33 @@ test_post_when_no_existing() {
   return 0
 }
 
-test_mixed_reconcile() {
-  # One desired group, one orphan, one matching-prefix-existing
+test_mixed_orphan_delete_and_patch() {
+  # One desired group ('dev'), one orphan ('obsolete-group').
+  # Existing 'dev' marker is PATCHed in place (stable identity), orphan
+  # is deleted, no POST is needed.
   write_meta "alpha-dev" "dev"
   cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
 [
-  {"id": 7001, "body": "### Terraform validation summary for group: `dev`\nold matching body"},
-  {"id": 7002, "body": "### Terraform validation summary for group: `obsolete-group`\norphan body"}
+  {"id": 7001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold body"},
+  {"id": 7002, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:obsolete-group -->\n### Terraform validation summary for group: `obsolete-group`\norphan body"}
 ]
 JSON
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
-  # Both existing must be deleted (one as repost, one as orphan)
-  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7001' "${GH_FAKE_CALL_LOG}"; then
-    echo "expected DELETE of matching-prefix existing 7001"; return 1
+  # 'dev' marker is patched in place — NOT deleted
+  if grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7001' "${GH_FAKE_CALL_LOG}"; then
+    echo "did NOT expect DELETE of existing 'dev' marker 7001 — it should be PATCHed"; return 1
   fi
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/7001' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of existing 'dev' marker 7001"; return 1
+  fi
+  # Orphan marker is deleted
   if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/7002' "${GH_FAKE_CALL_LOG}"; then
     echo "expected DELETE of orphan 7002"; return 1
   fi
-  # And we should have posted the fresh body for 'dev'
-  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
-    echo "expected 1 POST for desired 'dev'"; return 1
+  # No POST: 'dev' was upserted via PATCH, not a fresh post.
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST when existing marker is patched in place"; return 1
   fi
   return 0
 }
@@ -506,7 +529,7 @@ test_grouped_footer_is_condensed_v024() {
   return 0
 }
 
-test_post_pass_does_not_nest_log_groups() {
+test_upsert_pass_does_not_nest_log_groups() {
   # GitHub Actions does not support nested log groups. Verify that no
   # ::group:: line appears before a matching ::endgroup:: while another
   # ::group:: is already open.
@@ -613,13 +636,18 @@ test_plan_details_left_align_div() {
   return 0
 }
 
-test_group_prefix_byte_exact() {
+test_group_marker_then_prefix_byte_exact() {
   write_meta "envA" "dev"
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
-  # The first line of the rendered body must be the byte-exact group prefix
+  # Body line 1 must be the HTML marker (load-bearing for upsert identity).
+  # Body line 2 must be the byte-exact group H3 (still visible to readers).
+  if ! grep -q '^<!-- terraform-validation-summary-group:dev -->$' "${TEST_DIR}/step.log"; then
+    echo "expected byte-exact marker line '<!-- terraform-validation-summary-group:dev -->'"
+    return 1
+  fi
   if ! grep -q '^### Terraform validation summary for group: `dev`$' "${TEST_DIR}/step.log"; then
-    echo "expected byte-exact group prefix line"
+    echo "expected byte-exact H3 group heading"
     return 1
   fi
   return 0
@@ -693,8 +721,8 @@ test_multiple_groups_sorted_alphabetically() {
   fi
   # Per-group log group names appear in alpha order
   local order
-  order=$(grep -oE "Step 5: Posting group '[^']+'" "${TEST_DIR}/step.log" | head -3 | tr '\n' ' ')
-  local expected="Step 5: Posting group 'alpha' Step 5: Posting group 'mike' Step 5: Posting group 'zebra' "
+  order=$(grep -oE "Step 5: Upsert group '[^']+'" "${TEST_DIR}/step.log" | head -3 | tr '\n' ' ')
+  local expected="Step 5: Upsert group 'alpha' Step 5: Upsert group 'mike' Step 5: Upsert group 'zebra' "
   if [[ "${order}" != "${expected}" ]]; then
     echo "groups not in alphabetical order"
     echo "got:      ${order}"
@@ -705,15 +733,16 @@ test_multiple_groups_sorted_alphabetically() {
 }
 
 test_groups_processed_json_output() {
+  # 'dev' is desired but has no existing marker → posted fresh.
+  # 'obsolete' has an existing marker but is not desired → orphan-deleted.
   write_meta "envA" "dev"
   cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
-[{"id": 8001, "body": "### Terraform validation summary for group: `obsolete`\n"}]
+[{"id": 8001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:obsolete -->\n### Terraform validation summary for group: `obsolete`\n"}]
 JSON
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
   local processed
   processed=$(get_processed_json)
-  # Must include both orphan-deleted and posted entries
   if ! echo "${processed}" | jq -e '.[] | select(.action == "orphan-deleted" and .group == "obsolete")' >/dev/null; then
     echo "expected orphan-deleted entry for 'obsolete'"
     echo "got: ${processed}"
@@ -769,6 +798,172 @@ test_missing_pr_number_fails_fast() {
   return 0
 }
 
+# --------------------------------------------------------------------------
+# Marker-based upsert behaviour
+# --------------------------------------------------------------------------
+
+# Existing single marker comment for desired group → PATCHed in place
+# (stable comment id; no fresh POST, no DELETE).
+test_existing_marker_is_patched() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 6001, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold body"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6001' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of existing marker comment 6001"
+    grep -E 'PATCH|POST|DELETE' "${GH_FAKE_CALL_LOG}" || true
+    return 1
+  fi
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST when existing marker can be patched"; return 1
+  fi
+  if grep -q 'DELETE' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect DELETE when only a single matching marker exists"; return 1
+  fi
+  # Processed JSON should record action=patched
+  local processed
+  processed=$(get_processed_json)
+  if ! echo "${processed}" | jq -e '.[] | select(.action == "patched" and .group == "dev" and ."comment-id" == "6001")' >/dev/null; then
+    echo "expected processed-json entry {group: 'dev', action: 'patched', id: 6001}"
+    echo "got: ${processed}"
+    return 1
+  fi
+  return 0
+}
+
+# Multiple marker comments for the SAME group (pre-existing duplicates) →
+# oldest is PATCHed, the rest are deleted. Self-healing.
+test_duplicate_markers_delete_extras_patch_oldest() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[
+  {"id": 6100, "created_at": "2026-02-01T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nmid-age dup"},
+  {"id": 6200, "created_at": "2026-03-01T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nnewest dup"},
+  {"id": 6050, "created_at": "2026-01-15T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\noldest — should be kept"}
+]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # Oldest (6050) is patched, the two newer are deleted
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6050' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of oldest duplicate 6050"
+    grep -E 'PATCH|POST|DELETE' "${GH_FAKE_CALL_LOG}" || true
+    return 1
+  fi
+  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/6100' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected DELETE of duplicate 6100"; return 1
+  fi
+  if ! grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/6200' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected DELETE of duplicate 6200"; return 1
+  fi
+  # Patched and duplicate-deleted should both appear in processed-json
+  local processed
+  processed=$(get_processed_json)
+  if ! echo "${processed}" | jq -e '.[] | select(.action == "patched" and ."comment-id" == "6050")' >/dev/null; then
+    echo "expected processed.action=patched id=6050"; echo "got: ${processed}"; return 1
+  fi
+  if ! echo "${processed}" | jq -e '[.[] | select(.action == "duplicate-deleted")] | length == 2' >/dev/null; then
+    echo "expected 2 duplicate-deleted entries"; echo "got: ${processed}"; return 1
+  fi
+  return 0
+}
+
+# Legacy comment from the pre-marker era (body starts with the H3, no
+# marker) → ignored: no DELETE, no PATCH. The system posts a fresh
+# marked comment alongside it (the no-migration trade-off — operators
+# clean up legacy comments by hand).
+test_legacy_prefix_only_comment_is_ignored() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 6300, "created_at": "2025-12-01T10:00:00Z", "body": "### Terraform validation summary for group: `dev`\nlegacy body without marker"}]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if grep -q 'DELETE repos/dsb-norge/test-repo/issues/comments/6300' "${GH_FAKE_CALL_LOG}"; then
+    echo "legacy comment 6300 MUST NOT be deleted (no migration policy)"; return 1
+  fi
+  if grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6300' "${GH_FAKE_CALL_LOG}"; then
+    echo "legacy comment 6300 MUST NOT be patched"; return 1
+  fi
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
+    echo "expected exactly 1 POST (fresh marked comment alongside legacy)"; return 1
+  fi
+  return 0
+}
+
+# Marker comment body line 1 must be the per-group marker; line 2 the H3.
+# Pinning byte-level shape so accidental drift in render_group_body breaks
+# this test (and only this test).
+test_body_starts_with_marker_then_h3() {
+  write_meta "envA" "dev"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  # The rendered body is echoed into the step log right after a
+  # 'aggregate-validation-summaries: Body:' line; capture the next two
+  # non-blank lines (marker + H3).
+  local body_lines
+  body_lines=$(awk '/Body:$/ {flag=1; next} flag && NF {print; if (++n == 2) exit}' "${TEST_DIR}/step.log")
+  local expected
+  expected=$'<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`'
+  if [[ "${body_lines}" != "${expected}" ]]; then
+    echo "expected marker + H3 as first two body lines (byte-exact)"
+    echo "expected: ${expected//$'\n'/ \\n }"
+    echo "got:      ${body_lines//$'\n'/ \\n }"
+    return 1
+  fi
+  return 0
+}
+
+# Two distinct groups (dev + prod) both have existing markers → both get
+# PATCHed in their own pass, neither is deleted, no POST occurs. Verifies
+# per-group markers route correctly when multiple group comments coexist.
+test_multiple_groups_each_patched() {
+  write_meta "envA" "dev"
+  write_meta "envB" "prod"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[
+  {"id": 6400, "created_at": "2026-01-15T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold dev"},
+  {"id": 6500, "created_at": "2026-01-15T10:00:00Z", "body": "<!-- terraform-validation-summary-group:prod -->\n### Terraform validation summary for group: `prod`\nold prod"}
+]
+JSON
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6400' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of dev marker 6400"; return 1
+  fi
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6500' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH of prod marker 6500"; return 1
+  fi
+  if grep -q 'POST' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect POST when both groups have existing markers"; return 1
+  fi
+  if grep -q 'DELETE' "${GH_FAKE_CALL_LOG}"; then
+    echo "did not expect DELETE when no orphans and no duplicates"; return 1
+  fi
+  return 0
+}
+
+# PATCH failure → fall back to POST so the comment is still visible.
+test_patch_failure_falls_back_to_post() {
+  write_meta "envA" "dev"
+  cat > "${GH_FAKE_LIST_RESPONSE_FILE}" <<'JSON'
+[{"id": 6600, "created_at": "2026-01-30T10:00:00Z", "body": "<!-- terraform-validation-summary-group:dev -->\n### Terraform validation summary for group: `dev`\nold body"}]
+JSON
+  export GH_FAKE_PATCH_EXIT=22
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE} — PATCH failure should not abort"; return 1; }
+  # PATCH was attempted on 6600, failed, then POST as fallback
+  if ! grep -q 'PATCH repos/dsb-norge/test-repo/issues/comments/6600' "${GH_FAKE_CALL_LOG}"; then
+    echo "expected PATCH attempt before fallback"; return 1
+  fi
+  if [[ $(grep -c 'POST' "${GH_FAKE_CALL_LOG}") -ne 1 ]]; then
+    echo "expected exactly 1 POST as fallback after PATCH failure"; return 1
+  fi
+  return 0
+}
+
 test_post_failure_recorded_without_aborting() {
   write_meta "envA" "g"
   export GH_FAKE_POST_EXIT=22
@@ -791,7 +986,7 @@ test_post_failure_recorded_without_aborting() {
 run_test "empty desired + empty existing is a no-op"                       test_empty_desired_empty_existing_is_noop
 run_test "sweep mode: empty desired + orphan existing → delete only"       test_sweep_only_orphans
 run_test "post mode: desired + no existing → post only"                    test_post_when_no_existing
-run_test "mixed reconcile: orphan deleted + matching reposted"             test_mixed_reconcile
+run_test "mixed upsert: orphan deleted + matching marker patched in place" test_mixed_orphan_delete_and_patch
 run_test "envs render in alphabetical column order"                        test_alphabetical_column_order
 run_test "per-env anchor resolved → log-extract link rendered"             test_per_env_anchor_resolved
 run_test "anchor missing + job URL resolved → Links shows only job log"    test_per_env_anchor_missing_but_job_url_resolved_shows_only_job_log
@@ -801,14 +996,14 @@ run_test "Jobs API failure → 'job log' line omitted for all envs"          tes
 run_test "job URL resolution handles 'caller / Terraform (env)' prefix"   test_job_url_resolution_handles_caller_prefixed_name
 run_test "job URL resolution handles bare 'Terraform (env)' too"          test_job_url_resolution_handles_bare_name
 run_test "job URL resolution skips non-matrix jobs"                       test_job_url_resolution_skips_non_matrix_jobs
-run_test "post pass does NOT nest log groups"                              test_post_pass_does_not_nest_log_groups
+run_test "upsert pass does NOT nest log groups"                            test_upsert_pass_does_not_nest_log_groups
 run_test "grouped comment footer is condensed v0.24 [Job log] only"       test_grouped_footer_is_condensed_v024
 run_test "per-env anchor picks newest comment id when duplicates exist"    test_per_env_anchor_picks_newest_when_duplicates
 run_test "status emoji map covers success/failure/cancelled/skipped"       test_status_emoji_map
 run_test "Plan Details: optional categories appear only when non-zero"     test_plan_details_optional_categories
 run_test "Plan Details cell wraps in <div align='left'>"                   test_plan_details_left_align_div
-run_test "group prefix line is byte-exact"                                 test_group_prefix_byte_exact
-run_test "degraded mode: gh list fails → skip delete, still post"          test_degraded_mode_when_list_fails
+run_test "group marker + H3 prefix lines are byte-exact"                   test_group_marker_then_prefix_byte_exact
+run_test "degraded mode: gh list fails → skip orphan delete, fresh POST"   test_degraded_mode_when_list_fails
 run_test "malformed metadata file is skipped with warning"                 test_malformed_metadata_is_skipped
 run_test "envs without pr-comment-group are ignored"                       test_envs_without_group_are_ignored
 run_test "multiple groups are posted in alphabetical order"                test_multiple_groups_sorted_alphabetically
@@ -816,6 +1011,12 @@ run_test "groups-processed-json output records every action"               test_
 run_test "table step rows appear in spec order"                            test_step_row_order_byte_exact
 run_test "missing input_pr_number fails the step"                          test_missing_pr_number_fails_fast
 run_test "post failure does not abort, recorded in output"                 test_post_failure_recorded_without_aborting
+run_test "existing marker comment → PATCHed in place (stable id)"          test_existing_marker_is_patched
+run_test "duplicate markers → delete extras, PATCH oldest"                 test_duplicate_markers_delete_extras_patch_oldest
+run_test "legacy prefix-only comment → ignored (no-migration policy)"      test_legacy_prefix_only_comment_is_ignored
+run_test "body starts with marker on line 1, H3 on line 2"                 test_body_starts_with_marker_then_h3
+run_test "multiple groups: each marker patched independently"              test_multiple_groups_each_patched
+run_test "PATCH failure → fall back to POST"                               test_patch_failure_falls_back_to_post
 
 # ============================================================================
 echo ""

--- a/aggregate-validation-summaries/step_aggregate.sh
+++ b/aggregate-validation-summaries/step_aggregate.sh
@@ -34,8 +34,11 @@ declare -gA DESIRED_GROUPS=()
 # desired_meta[<group_name>/<env_name>]="<absolute path to metadata file>"
 declare -gA DESIRED_META=()
 
-# existing_group_comments[group_name]="<comment_id>" — one entry per
-# currently-on-PR group comment that matches our family prefix
+# existing_group_comments[group_name]="<id1>\n<id2>\n..." — newline-
+# delimited list of every PR comment currently matching our family marker
+# for that group. Multiple IDs per group can happen when an earlier run
+# orphaned duplicates; the upsert pass picks the oldest to keep (stable
+# identity) and deletes the rest.
 declare -gA EXISTING_GROUP_COMMENTS=()
 
 # per_env_anchor[env_name]="#issuecomment-<id>" — resolved at step 2,
@@ -49,9 +52,11 @@ declare -gA PER_ENV_ANCHOR=()
 # cell drops the `job log` line in that case rather than emit a wrong link.
 declare -gA PER_ENV_JOB_URL=()
 
-# Tracks degraded mode (gh api list failed). When true, reconcile (delete
-# pass) is skipped — the rendered bodies are still posted so the grouped
-# table is always visible.
+# Tracks degraded mode (gh api list failed). When true, the upsert pass
+# skips its delete branch and posts fresh bodies instead — the grouped
+# table is always visible, even if we can't be sure what's already on the
+# PR. Duplicates from this degraded mode will self-heal on the next clean
+# run (the duplicate-deleted branch of the upsert algorithm).
 DEGRADED_MODE="false"
 
 # Tracks each group processed for the groups-processed-json output.
@@ -192,7 +197,7 @@ function list_pr_state {
   local comments_json
   if ! comments_json=$(_gh_list_pr_comments "${GITHUB_REPOSITORY}" "${input_pr_number}" 2>&1); then
     log-warn "Failed to list PR comments: ${comments_json}"
-    log-warn "Entering degraded mode — reconcile (delete pass) skipped; will still post fresh bodies."
+    log-warn "Entering degraded mode — upsert will post fresh bodies instead of editing in place."
     DEGRADED_MODE="true"
     end-group
     return 0
@@ -213,26 +218,41 @@ function list_pr_state {
   total=$(echo "${normalized}" | jq 'length')
   log-info "PR has ${total} comment(s) total."
 
-  # Extract existing group comments (family prefix match).
-  # Output one line per match: "<comment_id>\t<group_name>"
-  # Group name is parsed out of the body's first line by stripping the family
-  # prefix and the surrounding backticks.
+  # Find existing group comments by HTML marker on the first line of the
+  # body: '<!-- terraform-validation-summary-group:<group> -->'. Multiple
+  # IDs per group are tolerated (and self-healed in the upsert pass).
+  # Group name is parsed by stripping the family prefix and the trailing
+  # ' -->' marker close.
+  #
+  # Legacy comments from the pre-marker era (body starts with the H3
+  # heading rather than the marker) are not matched here — they sit
+  # untouched on the PR and the upsert pass posts a fresh marked comment
+  # alongside them. This is the documented "no-migration" trade-off
+  # (docs/Workflow-pr-comments.md §2.1).
   local group_lines
   group_lines=$(echo "${normalized}" \
-    | jq -r --arg fam "${GROUP_COMMENT_FAMILY_PREFIX}" '
+    | jq -r --arg fam "${GROUP_COMMENT_MARKER_FAMILY}" '
         .[]
         | select(.body | startswith($fam))
         | .id as $id
-        | (.body | split("\n")[0] | sub($fam; "") | sub("^`"; "") | sub("`.*$"; "")) as $g
-        | "\($id)\t\($g)"
+        | .created_at as $created
+        | (.body | split("\n")[0] | sub($fam; "") | sub(" -->.*$"; "")) as $g
+        | "\($id)\t\($created)\t\($g)"
       ' 2>/dev/null) || group_lines=""
 
   if [ -n "${group_lines}" ]; then
-    local line cid gname
-    while IFS=$'\t' read -r cid gname; do
+    local line cid created gname
+    while IFS=$'\t' read -r cid created gname; do
       [ -z "${cid}" ] && continue
-      EXISTING_GROUP_COMMENTS[${gname}]="${cid}"
-      log-info "  existing group comment: '${gname}' (id=${cid})"
+      # Pack as "<created_at>|<id>" so a later 'sort' gives the oldest first
+      # — created_at is ISO-8601, lexicographically sortable. The upsert
+      # pass picks the head of the sorted list to keep, deletes the rest.
+      if [ -n "${EXISTING_GROUP_COMMENTS[${gname}]:-}" ]; then
+        EXISTING_GROUP_COMMENTS[${gname}]+=$'\n'"${created}|${cid}"
+      else
+        EXISTING_GROUP_COMMENTS[${gname}]="${created}|${cid}"
+      fi
+      log-info "  existing group comment: '${gname}' (id=${cid}, created=${created})"
     done <<<"${group_lines}"
   else
     log-info "  no existing group comments on PR"
@@ -290,7 +310,8 @@ function list_pr_state {
 function render_group_body {
   local group_name="${1}"
   local envs_nl="${2}"
-  local prefix
+  local marker prefix
+  marker=$(_group_marker "${group_name}")
   prefix=$(_group_prefix "${group_name}")
 
   local -a envs=()
@@ -356,7 +377,13 @@ function render_group_body {
   footer=$(_render_footer "${first_env_meta_file}")
 
   # ---- Assembly ----
-  printf '%s\n%s\n%s\n%s%s\n%s\n\n%s\n' \
+  # The HTML marker is line 1 and the load-bearing identity for upserts —
+  # see docs/Workflow-pr-comments.md §2. The H3 'prefix' line follows; it
+  # is still rendered (visible to readers) but no longer used for comment
+  # identification, so the H3 wording can be tweaked freely as long as
+  # the marker is unchanged.
+  printf '%s\n%s\n%s\n%s\n%s%s\n%s\n\n%s\n' \
+    "${marker}" \
     "${prefix}" \
     "${header}" \
     "${sep}" \
@@ -414,69 +441,76 @@ function _render_footer {
 }
 
 # ============================================================================
-# Step 4: Reconcile (delete pass)
+# Step 4: Orphan-delete pass — drop marker comments whose group is no
+# longer in the desired set. Desired groups themselves are handled by the
+# upsert pass below (PATCH-in-place + dedupe).
 # ============================================================================
 
-function reconcile_delete_pass {
-  start-group "Step 4: Reconcile — delete pass"
+function orphan_delete_pass {
+  start-group "Step 4: Delete orphan group comments"
 
   if [ "${DEGRADED_MODE}" = "true" ]; then
-    log-warn "Degraded mode — skipping delete pass."
+    log-warn "Degraded mode — skipping orphan delete pass."
     end-group
     return 0
   fi
 
   if [ ${#EXISTING_GROUP_COMMENTS[@]} -eq 0 ]; then
-    log-info "No existing group comments — nothing to delete."
+    log-info "No existing group comments — nothing to clean up."
     end-group
     return 0
   fi
 
-  local existing_group existing_id action
+  local existing_group entry created cid
   for existing_group in "${!EXISTING_GROUP_COMMENTS[@]}"; do
-    existing_id="${EXISTING_GROUP_COMMENTS[${existing_group}]}"
+    # Only orphan if the group is NOT in the desired set. Desired groups
+    # are kept (one survivor) by the upsert pass.
     if [ -n "${DESIRED_GROUPS[${existing_group}]:-}" ]; then
-      action="repost"
-      log-info "  deleting existing group comment '${existing_group}' (id=${existing_id}) — will be reposted"
-    else
-      action="orphan-deleted"
-      log-info "  deleting orphan group comment '${existing_group}' (id=${existing_id}) — not in desired set"
+      continue
     fi
-
-    if _gh_delete_comment "${GITHUB_REPOSITORY}" "${existing_id}" >/dev/null 2>&1; then
-      _record_processed "${existing_group}" "${existing_id}" "${action}"
-    else
-      log-warn "  failed to delete comment id=${existing_id} (group '${existing_group}') — continuing"
-    fi
+    # Delete every comment for this orphan group — markers from prior
+    # double-posts could accumulate here too.
+    while IFS= read -r entry; do
+      [ -z "${entry}" ] && continue
+      created="${entry%%|*}"
+      cid="${entry##*|}"
+      log-info "  deleting orphan group comment '${existing_group}' (id=${cid}, created=${created})"
+      if _gh_delete_comment "${GITHUB_REPOSITORY}" "${cid}" >/dev/null 2>&1; then
+        _record_processed "${existing_group}" "${cid}" "orphan-deleted"
+      else
+        log-warn "  failed to delete comment id=${cid} (group '${existing_group}') — continuing"
+      fi
+    done <<<"${EXISTING_GROUP_COMMENTS[${existing_group}]}"
   done
 
   end-group
 }
 
 # ============================================================================
-# Step 5: Post pass
+# Step 5: Upsert pass — for every desired group, either PATCH the
+# oldest existing marker comment (stable identity across runs, no
+# re-pinging of subscribers) or POST a fresh one. Duplicate marker
+# comments for the same group are deleted in the same pass so the
+# system is self-healing — if a prior run posted twice (e.g. degraded
+# mode + later recovery), the next clean run leaves exactly one comment
+# per group.
 # ============================================================================
 
-function post_pass {
-  # NOTE: one log group per group processed — no outer wrapper. GitHub Actions
-  # does not support nested log groups; the prior structure ('Step 5' outer
-  # group containing per-group 'Body for...' sub-groups) rendered confusingly
-  # in the runner log UI.
-
+function upsert_pass {
   if [ ${#DESIRED_GROUPS[@]} -eq 0 ]; then
-    log-info "Step 5: Post fresh group comments — no desired groups, nothing to post."
+    log-info "Step 5: Upsert group comments — no desired groups, nothing to upsert."
     return 0
   fi
 
-  log-info "Step 5: Post fresh group comments (${#DESIRED_GROUPS[@]} group(s))"
+  log-info "Step 5: Upsert group comments (${#DESIRED_GROUPS[@]} group(s))"
 
   # Sort group names for deterministic output ordering.
   local -a sorted_groups=()
   while IFS= read -r g; do sorted_groups+=("${g}"); done < <(printf '%s\n' "${!DESIRED_GROUPS[@]}" | sort)
 
-  local group envs_sorted body body_file new_id
+  local group envs_sorted body body_file
   for group in "${sorted_groups[@]}"; do
-    start-group "Step 5: Posting group '${group}'"
+    start-group "Step 5: Upsert group '${group}'"
 
     # Sort envs alphabetically within the group (docs/Workflow-pr-comments.md §4.2)
     envs_sorted=$(echo "${DESIRED_GROUPS[${group}]}" | sort)
@@ -489,17 +523,84 @@ function post_pass {
     log-info "Body:"
     echo "${body}"
 
-    if new_id=$(_gh_post_comment "${GITHUB_REPOSITORY}" "${input_pr_number}" "${body_file}" 2>&1); then
-      log-info "posted: comment id=${new_id}"
-      _record_processed "${group}" "${new_id}" "posted"
-    else
-      log-warn "failed to post comment for group '${group}': ${new_id}"
-      _record_processed "${group}" "0" "post-failed"
-    fi
+    _upsert_one_group "${group}" "${body_file}"
 
     rm -f "${body_file}"
     end-group
   done
+}
+
+# Upsert a single group's comment. Picks the oldest existing marker
+# comment (lowest created_at, since GitHub IDs are monotonic but the
+# created_at field is the canonical timestamp) to keep, deletes any
+# others, then PATCHes the keeper. If none exist, POSTs fresh.
+#
+# In degraded mode (PR comments listing failed) we don't know what
+# exists, so we always POST fresh — duplicates will self-heal on the
+# next clean run via this same dedupe branch.
+function _upsert_one_group {
+  local group="${1}" body_file="${2}"
+
+  if [ "${DEGRADED_MODE}" = "true" ]; then
+    log-warn "Degraded mode — posting fresh (cannot list existing comments to upsert)."
+    _post_fresh "${group}" "${body_file}"
+    return
+  fi
+
+  local entries="${EXISTING_GROUP_COMMENTS[${group}]:-}"
+  if [ -z "${entries}" ]; then
+    log-info "No existing marker comment for '${group}' — posting fresh."
+    _post_fresh "${group}" "${body_file}"
+    return
+  fi
+
+  # Sort entries by created_at (ISO-8601, lexicographic). Oldest first.
+  local sorted_entries
+  sorted_entries=$(echo "${entries}" | sort)
+  local keep_entry
+  keep_entry=$(echo "${sorted_entries}" | head -n1)
+  local keep_id="${keep_entry##*|}"
+  local keep_created="${keep_entry%%|*}"
+
+  # Delete every entry except the keeper.
+  local entry created cid
+  while IFS= read -r entry; do
+    [ -z "${entry}" ] && continue
+    created="${entry%%|*}"
+    cid="${entry##*|}"
+    if [ "${cid}" = "${keep_id}" ]; then
+      continue
+    fi
+    log-info "  duplicate '${group}' marker comment (id=${cid}, created=${created}) — deleting"
+    if _gh_delete_comment "${GITHUB_REPOSITORY}" "${cid}" >/dev/null 2>&1; then
+      _record_processed "${group}" "${cid}" "duplicate-deleted"
+    else
+      log-warn "  failed to delete duplicate id=${cid} for '${group}' — continuing"
+    fi
+  done <<<"${sorted_entries}"
+
+  # PATCH the keeper.
+  log-info "Editing existing comment in place (id=${keep_id}, created=${keep_created})."
+  if _gh_patch_comment "${GITHUB_REPOSITORY}" "${keep_id}" "${body_file}" >/dev/null 2>&1; then
+    _record_processed "${group}" "${keep_id}" "patched"
+  else
+    log-warn "PATCH failed for '${group}' (id=${keep_id}) — posting fresh as fallback."
+    _post_fresh "${group}" "${body_file}"
+  fi
+}
+
+# Internal: POST a fresh comment for a group. Used by _upsert_one_group
+# on the "no existing comment" and "degraded mode" branches.
+function _post_fresh {
+  local group="${1}" body_file="${2}"
+  local new_id
+  if new_id=$(_gh_post_comment "${GITHUB_REPOSITORY}" "${input_pr_number}" "${body_file}" 2>&1); then
+    log-info "posted: comment id=${new_id}"
+    _record_processed "${group}" "${new_id}" "posted"
+  else
+    log-warn "failed to post comment for group '${group}': ${new_id}"
+    _record_processed "${group}" "0" "post-failed"
+  fi
 }
 
 # ============================================================================
@@ -534,8 +635,8 @@ function main {
 
   build_desired_set
   list_pr_state
-  reconcile_delete_pass
-  post_pass
+  orphan_delete_pass
+  upsert_pass
 
   set-multiline-output "groups-processed-json" "${PROCESSED_RESULTS_JSON}"
   log-info "Done. Processed ${#DESIRED_GROUPS[@]} group(s)."

--- a/docs/Workflow-pr-comments.md
+++ b/docs/Workflow-pr-comments.md
@@ -6,25 +6,34 @@ Out of scope: deployment-environment UI, status checks, workflow run summaries �
 
 ## 1. When are comments posted
 
-Comments are only posted when the workflow runs against a `pull_request` event whose action is not `closed` or `converted_to_draft`. The mechanism is identical regardless of which job posts the comment: each comment carries a deterministic Markdown heading (the "prefix") and every post does a delete-by-prefix + post — so comments update in place across re-runs, never duplicate.
+Comments are only posted when the workflow runs against a `pull_request` event whose action is not `closed` or `converted_to_draft`. Each comment carries a deterministic identity handle so re-runs update in place rather than duplicating. The two families use different mechanisms — see §2.
 
 Comments are suppressed when either:
 
 - the workflow input `add-pr-comment: false` is set (globally), or
 - a per-environment `add-pr-comment: false` override is set in `environments-yml` (per env).
 
-Both controls only affect the per-environment comments. The per-group reconcile job runs unconditionally on PR events; see §6 for why and the cost analysis.
+Both controls only affect the per-environment comments. The per-group aggregator job runs unconditionally on PR events; see §6 for why and the cost analysis.
 
 ## 2. The two comment families
 
-| Family | Identity prefix | Posted by | Cardinality |
-|---|---|---|---|
-| Per-environment | `` ### Terraform validation summary for environment: `<env>` `` | matrix job for that env, via `comment-on-pr@v2` | one per env per workflow run |
-| Per-group | `` ### Terraform validation summary for group: `<group>` `` | `pr-comment-aggregator` job, via `aggregate-validation-summaries` | one per distinct non-empty `pr-comment-group` value |
+| Family | Identity handle | Lifecycle | Posted by | Cardinality |
+|---|---|---|---|---|
+| Per-environment | H3 heading `` ### Terraform validation summary for environment: `<env>` `` (first line of body) | delete-by-prefix + post | matrix job for that env, via `comment-on-pr@v2` | one per env per workflow run |
+| Per-group | HTML marker `<!-- terraform-validation-summary-group:<group> -->` (first line of body) | upsert-by-marker (PATCH-in-place or POST) | `pr-comment-aggregator` job, via `aggregate-validation-summaries` | one per distinct non-empty `pr-comment-group` value |
 
-Both families share the prefix-based identity contract: the family prefix uniquely identifies the comment within a PR, the action lists existing comments via `gh api`, deletes any whose body starts with the matching specific prefix, and posts the freshly-built body. Bodies always start with their full prefix (heading line) so substring matching is unambiguous.
+The two families use **different identity contracts** because they have different lifecycles:
 
-Per-env prefixes use backtick-delimited env names so partial matches can't collide (e.g. `dev` doesn't match `dev-2`).
+- **Per-env** uses a visible H3 prefix as the load-bearing handle. Each run does delete-by-prefix + post, so per-env comments get a new comment id every run (subscribers re-pinged). Cheap and simple for a one-shot job.
+- **Per-group** uses an invisible HTML marker as the load-bearing handle. Each run does PATCH-in-place on the oldest existing marker comment for that group (stable comment id, no re-ping), and deletes any duplicate markers in the same pass — self-healing against past races or degraded runs. Comments without the marker are ignored (see §2.1 below). Per-group markers are unique per group name so multiple groups on the same PR are upserted independently.
+
+The H3 line `` ### Terraform validation summary for group: `<group>` `` still appears (visible to readers, line 2 of the body) but is no longer load-bearing — only the HTML marker is. The H3 wording can be tweaked freely as long as the marker is unchanged.
+
+Per-env prefixes use backtick-delimited env names so partial matches can't collide (e.g. `dev` doesn't match `dev-2`). Per-group markers don't need this since the colon + ` -->` close make the boundary unambiguous.
+
+### 2.1 No migration policy
+
+When `aggregate-validation-summaries` rolls out, existing per-group comments from prior versions don't yet carry the HTML marker — they only have the H3 heading. The new code ignores those legacy comments rather than deleting them: the next run posts a fresh marked comment alongside, and operators clean up the legacy one by hand if they want. This is an intentional trade-off — adding marker detection on the legacy H3 path would require a transitional shim, and given how rare PR-runs-after-release are for a given PR, the one-time double-post is the simpler choice. Subsequent runs upsert the marked comment normally.
 
 ## 3. Per-environment comments
 
@@ -163,6 +172,7 @@ Every PR run triggers the `pr-comment-aggregator` job once. It downloads all `ma
 Raw markdown:
 
 ````markdown
+<!-- terraform-validation-summary-group:dev -->
 ### Terraform validation summary for group: `dev`
 
 |  | Step | sub-a-dev | sub-b-dev | sub-c-dev |
@@ -237,37 +247,41 @@ Per-env-comment lookup edge cases:
 
 If the Jobs API call itself fails (rate limit, transient 5xx), every env's `job log` line is dropped and a single warning is logged; the grouped table still renders.
 
-### 4.6 Reconcile algorithm
+### 4.6 Upsert algorithm
 
-The aggregator action runs every PR event. Its job is to make the set of group comments on the PR equal to the desired set computed from the current run's metadata:
+The aggregator action runs every PR event. Its job is to make the set of marked group comments on the PR equal to the desired set computed from the current run's metadata, **editing in place** rather than recreating, so subscribers aren't re-pinged on every push.
 
 1. **Build desired set.** Read every `matrix-job-meta-*.json` artifact downloaded by `actions/download-artifact@v4`. Group entries by `matrix_context.vars.pr-comment-group`, dropping empty-string values. The desired set may be empty (no env declares a group).
 2. **List PR + run state.** Two paginated `gh api` calls:
     - `repos/$REPO/issues/$PR/comments` — from the result, build two maps:
-      - existing group comments (body starts with `### Terraform validation summary for group: `)
+      - existing group comments (body **starts with** `<!-- terraform-validation-summary-group:`). The group name is parsed out of the marker. Multiple matches per group are retained as a list of `(created_at, id)` pairs.
       - existing per-env comments (body starts with the exact backtick-delimited per-env prefix from §2)
-    - `repos/$REPO/actions/runs/$RUN_ID/jobs` — used to resolve each env's matrix job URL for the Links row (§4.5). Match by GitHub-rendered job name pattern `^Terraform \(<env>\)$`. Either call may fail independently: a Jobs API failure drops `job log` links from every Links cell; a PR-comments failure triggers degraded mode (skip reconcile delete pass, still post fresh bodies, will re-reconcile on next run).
-3. **Render desired.** For each desired group, sort envs alphabetically and build the prefix + body per §4.1. The Links row uses the per-env comment map (step 2) to resolve `log extract` anchors.
-4. **Reconcile (delete pass).** Walk the existing group comments:
-    - prefix not in desired set → DELETE (orphan from a removed/renamed group)
-    - prefix in desired set → DELETE (will be reposted with fresh body in step 5)
-5. **Post pass.** For each desired group, POST the rendered body.
-6. **Emit `groups-processed-json`** for logs/tests.
+    - `repos/$REPO/actions/runs/$RUN_ID/jobs` — used to resolve each env's matrix job URL for the Links row (§4.5). Match by GitHub-rendered job name pattern `^Terraform \(<env>\)$`. Either call may fail independently: a Jobs API failure drops `job log` links from every Links cell; a PR-comments failure triggers degraded mode (see below).
+3. **Render desired.** For each desired group, sort envs alphabetically and build the marker + H3 prefix + body per §4.1. The Links row uses the per-env comment map (step 2) to resolve `log extract` anchors.
+4. **Orphan delete pass.** Walk the existing marker comments. For each group **not** in the desired set, DELETE every matching marker comment (an orphan from a removed/renamed group can have accumulated duplicates).
+5. **Upsert pass.** For each desired group:
+    - **0 existing marker comments** → POST a fresh marked body.
+    - **1 existing** → PATCH that comment in place. Same comment id across runs, so subscribers don't get re-notified.
+    - **2+ existing** (duplicates from past races or degraded runs) → sort by `created_at` ascending, DELETE every entry except the oldest, then PATCH the oldest. The system is self-healing: one clean run collapses duplicates.
+    - **PATCH failure** (transient 5xx, comment removed mid-run, etc.) → fall back to POST so the comment is still visible on the PR.
+6. **Emit `groups-processed-json`** with one entry per action (`patched`, `posted`, `orphan-deleted`, `duplicate-deleted`, `post-failed`) for logs/tests.
 
-Four scenarios collapse into the same path:
+Scenarios:
 
-| Desired groups | Existing group comments | Outcome |
+| Desired groups | Existing marker comments | Outcome |
 |---|---|---|
 | 0 | 0 | no-op |
 | 0 | N | sweep N orphans (caller disabled grouping) |
-| M | 0 | post M (first run with grouping enabled) |
-| M | N (any overlap) | sweep mismatched, repost matched, post new |
+| M | 0 | post M (first run with grouping enabled, or no-migration legacy: see §2.1) |
+| M | M, 1 marker each | PATCH M in place (no new comment ids, no re-ping) |
+| M | M+K (duplicates) | PATCH oldest M, delete K dupes |
+| M | N (mixed: some desired, some orphan) | PATCH desired, delete orphans |
 
-Self-healing: at most one PR run is needed after toggling grouping on/off or renaming groups; no manual cleanup procedure.
+Self-healing: at most one PR run is needed after toggling grouping on/off, renaming groups, or recovering from a degraded run.
 
 #### Degraded mode
 
-If `gh api` fails (rate limit, transient 5xx), the action logs a warning, treats the existing-comments map as empty, renders bodies with Links rows showing `job log` only (no `log extract` anchors), and attempts to post. Subsequent runs reconcile any duplicates left behind. The grouped table itself always renders.
+If `gh api` listing fails (rate limit, transient 5xx), the action can't tell what already exists on the PR. It logs a warning, skips the orphan delete pass, and the upsert pass POSTs fresh bodies (no PATCH attempt). Any duplicates left behind are collapsed on the next clean run via step 5's "2+ existing" branch. The grouped table itself always renders.
 
 #### Failure isolation
 
@@ -323,7 +337,7 @@ Quick map from spec section to implementing code:
 | §3.1 Ungrouped per-env comment body | [`create-validation-summary/step_create_validation_summary.sh`](../create-validation-summary/step_create_validation_summary.sh) |
 | §3.2 Grouped per-env comment body | same file, branched on `pr-comment-group` |
 | §3 Posting/replacing per-env comments | [`dsb-norge/github-actions/ci-cd/comment-on-pr@v2`](https://github.com/dsb-norge/github-actions/tree/main/ci-cd/comment-on-pr) |
-| §4 Per-group comment body + reconcile | [`aggregate-validation-summaries/step_aggregate.sh`](../aggregate-validation-summaries/step_aggregate.sh) |
+| §4 Per-group comment body + upsert | [`aggregate-validation-summaries/step_aggregate.sh`](../aggregate-validation-summaries/step_aggregate.sh) |
 | §4.6 Source artifacts | [`capture-matrix-job-meta/step_capture.sh`](../capture-matrix-job-meta/step_capture.sh) |
 | §5 Input plumbing & per-env defaults | [`create-tf-vars-matrix/action.yml`](../create-tf-vars-matrix/action.yml) |
 | Workflow wiring | [`.github/workflows/terraform-ci-cd-default.yml`](../.github/workflows/terraform-ci-cd-default.yml) |


### PR DESCRIPTION
## Motivation

Found while testing #40 in a calling repo: stale per-group comments accumulated across PR runs instead of being replaced. After 5 runs against [dsb-infra/azure-terraform-ikt-operations#303](https://github.com/dsb-infra/azure-terraform-ikt-operations/pull/303), the PR had 10 group comments where there should have been 2.

**Root cause (pre-existing — not from #40):** [`aggregate-validation-summaries/step_aggregate.sh`'s `list_pr_state`](aggregate-validation-summaries/step_aggregate.sh) stored existing group comments in a bash associative array `EXISTING_GROUP_COMMENTS[group_name] = comment_id`. Multiple stale comments sharing the same group name collided in the map; the delete pass then deleted only one per group per run, so stale count stayed flat or grew.

## Approach

Replace the delete-by-prefix + post-fresh reconcile with **upsert-by-HTML-marker** — same pattern `.github/scripts/aggregate-action-tests.sh` already uses:

- Body line 1 is now an invisible HTML marker `<!-- terraform-validation-summary-group:<group> -->`. The H3 `### Terraform validation summary for group: \`<group>\`` line stays (visible to readers) but is no longer load-bearing.
- `list_pr_state` matches by marker family and groups **all** matching IDs per group as a `<created_at>|<id>` list — no more overwriting.
- New `upsert_pass`:
  - 0 existing → POST fresh
  - 1 existing → **PATCH in place** (stable comment id; subscribers not re-pinged on every push)
  - 2+ existing → sort by `created_at`, PATCH oldest, DELETE the rest (self-heals against past races / degraded runs)
  - PATCH 5xx → fall back to POST so the table is still visible
- `orphan_delete_pass` now deletes **every** marker comment for an orphan group, not just one.

### No-migration policy

Legacy comments from the pre-marker era (body starts with H3, no marker) are **ignored** — not deleted. The next run posts a fresh marked comment alongside the legacy one; operators clean up legacy comments by hand. Documented in `docs/Workflow-pr-comments.md` §2.1.

This trades a one-time double-post per PR for not having to ship and reason about a transitional shim.

## Test coverage

`aggregate-validation-summaries` suite: **22 → 34 tests**.

New tests:
- single-marker PATCH (no POST, no DELETE)
- duplicate-marker dedupe (oldest patched, rest deleted)
- legacy prefix-only comment ignored
- body line 1 = marker, line 2 = H3 (byte-exact)
- two distinct groups patched independently
- PATCH failure falls back to POST

Existing tests updated to use marker-formatted fixtures and the new `patched` / `duplicate-deleted` `processed-json` action values.

## Files

- `aggregate-validation-summaries/helpers_additional.sh` — new `GROUP_COMMENT_MARKER_FAMILY`, `_group_marker()`, `_gh_patch_comment()`
- `aggregate-validation-summaries/step_aggregate.sh` — `list_pr_state` matches by marker; new `orphan_delete_pass` + `upsert_pass` replace the old `reconcile_delete_pass` + `post_pass`; `render_group_body` emits marker on line 1
- `aggregate-validation-summaries/run_all_tests.sh` — fake `gh` gains PATCH handling; existing fixtures updated; 6 new tests
- `docs/Workflow-pr-comments.md` — §2 identity contract rewritten; new §2.1 no-migration policy; §4.6 reconcile → upsert algorithm

## Relation to PR #40

Independent — touches different code paths and is safe to merge first. PR #40 (`feat/plan-time-row`) will need a rebase on main after this lands but the rebase is trivial (no conflicts expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
