### PR TITLE
fix(ci-cd-default): unblock matrix on non-PR events when seed skips

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -463,6 +463,19 @@ jobs:
   terraform-ci-cd:
     name: "Terraform"
     needs: [create-matrix, seed-pr-comments]
+    # seed-pr-comments only fires on pull_request events. On push / dispatch /
+    # schedule it is correctly skipped — but GitHub Actions' implicit
+    # `if: success()` for a job with no explicit `if:` requires every `needs:`
+    # dep to be `success`, and a skipped dep doesn't satisfy that. Without
+    # this guard, push-to-main runs skip the entire matrix and everything
+    # downstream cascades to 'skipped'. Allow seed to be either success or
+    # skipped while still requiring create-matrix actually succeeded, and
+    # propagate cancellation explicitly via !cancelled() so a cancelled
+    # upstream still cancels this matrix.
+    if: |
+      !cancelled()
+      && needs.create-matrix.result == 'success'
+      && (needs.seed-pr-comments.result == 'success' || needs.seed-pr-comments.result == 'skipped')
     runs-on: ${{ matrix.vars.runs-on }}
     strategy:
       fail-fast: false # Allow jobs to continue even though one more env(s) fail


### PR DESCRIPTION
## Why

v0.26 (PR #42) introduced a new `seed-pr-comments` job between `create-matrix` and `terraform-ci-cd`. The seed job is guarded by `github.event_name == 'pull_request'`, so on push / workflow_dispatch / schedule events it correctly skips — there is no PR conversation to post into.

But `terraform-ci-cd` had `needs: [create-matrix, seed-pr-comments]` with **no explicit `if:`**. GitHub Actions applies an implicit `if: success()` to any job without one, which requires *every* `needs:` dep to have `result == 'success'`. A `skipped` dep doesn't satisfy that — so on non-PR events the matrix itself was skipped, and every downstream job cascaded.

**Symptom on calling repos:** a push to `main` runs the matrix-builder, skips everything else, and completes "successfully" without actually running terraform. Reproduced cleanly on `dsb-infra/azure-terraform-ikt-operations` [actions run 26403732430 attempt 3](https://github.com/dsb-infra/azure-terraform-ikt-operations/actions/runs/26403732430) (event=push, head_branch=main):

```
Create job matrix:        success
Seed PR comment heads:    skipped     ← correctly skipped on push events
Terraform:                skipped     ← BUG: needs seed-pr-comments, no `if:` to tolerate skip
PR comment aggregator:    skipped
PR auto merger:           skipped
Terraform conclusion:     success     ← runs anyway (has if: always())
```

## Fix

Add an explicit `if:` to `terraform-ci-cd` that:

- tolerates `seed-pr-comments` being either `success` (PR events) or `skipped` (everything else),
- still requires `create-matrix` to have actually succeeded,
- propagates upstream cancellation via `!cancelled()` so the matrix doesn't run when the parent run was cancelled.

```yaml
if: |
  !cancelled()
  && needs.create-matrix.result == 'success'
  && (needs.seed-pr-comments.result == 'success' || needs.seed-pr-comments.result == 'skipped')
```

## Impact

- **PR events:** no change. seed always runs and succeeds, so `needs.seed-pr-comments.result == 'success'` was already the path that ran. The new condition just extends "OK" to the skipped case.
- **push / dispatch / schedule events:** matrix now runs as it did in v0.25.

## Operational note

`v0` has been rolled back to the v0.25 commit (already done) so calling repos on `@v0` are unblocked. Once this PR merges, the plan is to cut **v0.27** with this fix and move `@v0` forward to the v0.27 commit — bringing back the v0.26 PR-commenting work plus this fix in one shot.

## Verification done locally

- `python3 -c "import yaml; yaml.safe_load(...)"` passes
- Diff is +13 lines, single-file, single-job

## Verification to do post-merge (pre-release)

Smoke-test on a calling repo via the v0.27 release flow — confirm both:
- push to main on a calling repo → matrix actually runs through terraform-init/plan/apply
- PR event on a calling repo → all PR-comment behavior from v0.26 still works as documented in [docs/Workflow-pr-comments.md](docs/Workflow-pr-comments.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)