### PR TITLE
feat: surface terraform plan/init/validate warnings on PRs

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -568,6 +568,7 @@ jobs:
         uses: dsb-norge/github-actions-terraform/terraform-init@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
+          environment-name: ${{ matrix.vars.github-environment }}
           additional-dirs-json: ${{ toJSON(matrix.vars.terraform-init-additional-dirs) }}
           plugin-cache-directory: ${{ steps.setup-terraform-cache.outputs.plugin-cache-directory }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -605,6 +606,7 @@ jobs:
         uses: dsb-norge/github-actions-terraform/terraform-validate@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
+          environment-name: ${{ matrix.vars.github-environment }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: 🧹 Lint with TFLint
@@ -631,6 +633,83 @@ jobs:
         with:
           plan-console-file: ${{ steps.plan.outputs.console-output-file }}
         continue-on-error: true # allow job to continue, step outcome is ignored
+
+      # Warning extraction — one parse-terraform-warnings invocation per step
+      # whose console output got captured. Three invocations rather than one
+      # consolidated scan so each gets its own 10-annotation GHA budget;
+      # consolidating would mean a noisy init crowds out plan-warning
+      # annotations. Each emits one ::warning per detected block (with
+      # file=/line= when source context is present) and writes a markdown
+      # body file for embedding in the PR plan-tag comment.
+      # See docs/Plan-warnings.md.
+      - name: "⚠️ Parse init warnings"
+        id: parse-init-warnings
+        if: always() && steps.init.outputs.console-output-file != ''
+        uses: dsb-norge/github-actions-terraform/parse-terraform-warnings@v0
+        with:
+          console-output-file: ${{ steps.init.outputs.console-output-file }}
+          step-label: init
+          environment-name: ${{ matrix.vars.github-environment }}
+        continue-on-error: true # allow job to continue, step outcome is ignored
+
+      - name: "⚠️ Parse validate warnings"
+        id: parse-validate-warnings
+        if: always() && steps.validate.outputs.console-output-file != ''
+        uses: dsb-norge/github-actions-terraform/parse-terraform-warnings@v0
+        with:
+          console-output-file: ${{ steps.validate.outputs.console-output-file }}
+          step-label: validate
+          environment-name: ${{ matrix.vars.github-environment }}
+        continue-on-error: true
+
+      - name: "⚠️ Parse plan warnings"
+        id: parse-plan-warnings
+        if: always() && steps.plan.outputs.console-output-file != ''
+        uses: dsb-norge/github-actions-terraform/parse-terraform-warnings@v0
+        with:
+          console-output-file: ${{ steps.plan.outputs.console-output-file }}
+          step-label: plan
+          environment-name: ${{ matrix.vars.github-environment }}
+        continue-on-error: true
+
+      # Aggregate the three per-step parse-terraform-warnings outputs into
+      # a single markdown file (init → validate → plan order) plus a single
+      # warning-count integer that's the sum across all three steps.
+      # Done as one shell step because GHA workflow expressions don't
+      # support arithmetic — '+' between fromJSON() calls is rejected by
+      # the expression parser. Empty / missing per-step files are skipped
+      # so the concatenation also works when an upstream step didn't run
+      # (e.g. plan skipped because init failed).
+      - name: "⚠️ Aggregate warnings (concat + sum)"
+        id: concat-warnings-md
+        if: always()
+        shell: bash
+        env:
+          init_md: ${{ steps.parse-init-warnings.outputs.warnings-markdown-file }}
+          validate_md: ${{ steps.parse-validate-warnings.outputs.warnings-markdown-file }}
+          plan_md: ${{ steps.parse-plan-warnings.outputs.warnings-markdown-file }}
+          init_count: ${{ steps.parse-init-warnings.outputs.warning-count }}
+          validate_count: ${{ steps.parse-validate-warnings.outputs.warning-count }}
+          plan_count: ${{ steps.parse-plan-warnings.outputs.warning-count }}
+          env_name: ${{ matrix.vars.github-environment }}
+        run: |
+          out="${GITHUB_WORKSPACE}/tf-warnings-${env_name}.md"
+          : > "${out}"
+          for f in "${init_md}" "${validate_md}" "${plan_md}"; do
+            if [ -n "${f}" ] && [ -s "${f}" ]; then
+              cat "${f}" >> "${out}"
+            fi
+          done
+          # Sum the per-step counts. Treat empty/non-numeric values as 0
+          # so a missing step output never breaks the arithmetic.
+          total=0
+          for c in "${init_count}" "${validate_count}" "${plan_count}"; do
+            if [[ "${c}" =~ ^[0-9]+$ ]]; then
+              total=$((total + c))
+            fi
+          done
+          echo "warnings-markdown-file=${out}" >> "${GITHUB_OUTPUT}"
+          echo "warning-count=${total}" >> "${GITHUB_OUTPUT}"
 
       - name: 📝 Create validation summary
         id: create-validation-summary
@@ -679,6 +758,14 @@ jobs:
           # Plan time row in the PR comment surfaces "slow + failing" at a
           # glance instead of forcing a click into the job log.
           plan-time: ${{ steps.plan.outputs.plan-time }}
+          # Warning surfaces — see docs/Plan-warnings.md. warning-count is the
+          # sum across init+validate+plan (each parse-terraform-warnings
+          # invocation emits its own count). The markdown file holds the
+          # rendered warning bodies; create-validation-summary appends them
+          # as a <details> collapser inside the plan-tag comment, with
+          # warnings taking priority over plan-extract in the 65k budget.
+          warning-count: ${{ steps.concat-warnings-md.outputs.warning-count }}
+          warnings-markdown-file: ${{ steps.concat-warnings-md.outputs.warnings-markdown-file }}
         continue-on-error: true # allow job to continue, step outcome is ignored
 
       - name: 📋 Post per-env plan-extract tag
@@ -743,6 +830,12 @@ jobs:
           plan-count-total: ${{ steps.parse-plan.outputs.count-total }}
           plan-has-output-only-changes: ${{ steps.parse-plan.outputs.has-output-only-changes }}
           plan-time: ${{ steps.plan.outputs.plan-time }}
+          # Mirror the warning inputs from the first invocation so the
+          # re-rendered head also carries the ⚠️ Warnings row. Without this
+          # the second render would drop the warnings row from the head
+          # body that ultimately PATCHes the per-env head.
+          warning-count: ${{ steps.concat-warnings-md.outputs.warning-count }}
+          warnings-markdown-file: ${{ steps.concat-warnings-md.outputs.warnings-markdown-file }}
           # The single input that differs from the first call. Triggers the
           # Links row branch in render_head_summary.
           plan-tag-comment-id: ${{ steps.post-plan-tag.outputs.comment-id }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,17 @@ run: |
   source "${{ github.action_path }}/step_<name>.sh"
 ```
 
+### Watch for ARG_MAX in step scripts
+
+Under `set -o allexport`, any shell variable holding large data (file contents, `gh api` responses, plan extracts) gets exported to envp; once envp crosses Linux's `ARG_MAX` (~2 MB total) or `MAX_ARG_STRLEN` (128 KB per string), the next `fork+execve` — typically `jq`, `bash -c`, or another helper — fails with exit 126 "Argument list too long". The bug correlates with PR/data size so it stays silent in tests and only surfaces in production on a calling repo with a big-enough plan or comment thread.
+
+**Rule:** never assign large captured data to a shell variable while allexport is in scope. Route through `mktemp` files (or read straight from disk) and pass via stdin / `-f` / `-F body=@file` / `jq --slurpfile`. Four in-tree reference patterns to copy from when authoring or reviewing a step script:
+
+- File tails — `tail -c 65000 "<path>"` directly into the capture, never via an intermediate var (`create-validation-summary/step_create_validation_summary.sh`).
+- `gh api` responses — write the response to `mktemp`, then `jq` reads it (`aggregate-validation-summaries/step_aggregate.sh`, both `_resolve_per_env_job_urls` and `list_pr_state`).
+- Large JSON merge — `jq --slurpfile` (not `--argjson`, which puts the JSON on argv) and dereference with `[0]` (`capture-matrix-job-meta/step_capture.sh`).
+- Large gh CLI inputs — heredoc the body into a tempfile, post via `gh api -F body=@<tempfile>` (`pr-comment/action.yml`).
+
 ### PRs are gated by per-action test suites
 
 `.github/workflows/action-tests.yml` runs every action's `run_all_tests.sh` in parallel on each PR and exposes a single `tests-conclusion` check (intended to be required by branch protection). Result is reported as a PR comment, run-page annotations, and a `$GITHUB_STEP_SUMMARY` block — all three driven by the result-JSON artifacts each matrix job uploads.

--- a/aggregate-validation-summaries/helpers_additional.sh
+++ b/aggregate-validation-summaries/helpers_additional.sh
@@ -118,6 +118,22 @@ function _render_plan_details_cell {
   echo "${cell}"
 }
 
+# Render the Warnings cell for a single env in the grouped table.
+# Empty input (no parse-warnings data) → "—" (matches the not-applicable
+# fallback used by _render_plan_time_cell and _status_emoji_and_title's
+# default branch). 0 → "—" too, since "no warnings" is not interesting.
+# Non-zero numeric → "⚠️ N" inside a tooltip-bearing span so the row
+# stays scannable in the grouped table.
+function _render_warning_count_cell {
+  local v="${1:-}"
+  local title='Warnings from init+validate+plan'
+  if [ -z "${v}" ] || [ "${v}" = "0" ]; then
+    echo "<span title=\"${title}\">—</span>"
+    return
+  fi
+  echo "<span title=\"${title}\">⚠️ ${v}</span>"
+}
+
 # Render the Plan time cell for a single env in the grouped table.
 # Empty input → "—" (matches the existing 'not applicable' fallback from
 # _status_emoji_and_title for missing data). Non-empty values are wrapped

--- a/aggregate-validation-summaries/run_all_tests.sh
+++ b/aggregate-validation-summaries/run_all_tests.sh
@@ -130,12 +130,24 @@ teardown() {
 # Empty / unset preserves the pre-plan-time fixture shape so older tests
 # stay backwards-compatible.
 write_meta() {
-  local env="${1}" group="${2:-}" fmt_outcome="${3:-success}" counts="${4:-}" plan_time="${5:-}"
+  local env="${1}" group="${2:-}" fmt_outcome="${3:-success}" counts="${4:-}" plan_time="${5:-}" warnings="${6:-}"
   local counts_default='{"count-add":"0","count-change":"0","count-destroy":"0","count-import":"0","count-move":"0","count-remove":"0"}'
   local counts_use="${counts:-${counts_default}}"
   local plan_outputs='{}'
   if [ -n "${plan_time}" ]; then
     plan_outputs="{\"plan-time\": \"${plan_time}\"}"
+  fi
+  # parse-*-warnings step entries are emitted only when the caller passed
+  # a non-empty warnings spec. Format: "<init>:<validate>:<plan>" where each
+  # field is either a number or empty (empty = step entry omitted entirely
+  # so we can test the "step did not run" branch of _extract_warning_count).
+  local parse_warnings_json=""
+  if [ -n "${warnings}" ]; then
+    local w_init w_validate w_plan
+    IFS=':' read -r w_init w_validate w_plan <<< "${warnings}"
+    [ -n "${w_init}" ]     && parse_warnings_json+=",\"parse-init-warnings\":     {\"outcome\":\"success\",\"conclusion\":\"success\",\"outputs\":{\"warning-count\":\"${w_init}\"}}"
+    [ -n "${w_validate}" ] && parse_warnings_json+=",\"parse-validate-warnings\": {\"outcome\":\"success\",\"conclusion\":\"success\",\"outputs\":{\"warning-count\":\"${w_validate}\"}}"
+    [ -n "${w_plan}" ]     && parse_warnings_json+=",\"parse-plan-warnings\":     {\"outcome\":\"success\",\"conclusion\":\"success\",\"outputs\":{\"warning-count\":\"${w_plan}\"}}"
   fi
   cat > "${TEST_DIR}/matrix-job-meta-${env}.json" <<JSON
 {
@@ -153,7 +165,7 @@ write_meta() {
     "validate":    {"outcome": "success", "conclusion": "success", "outputs": {}},
     "lint":        {"outcome": "success", "conclusion": "success", "outputs": {}},
     "plan":        {"outcome": "success", "conclusion": "success", "outputs": ${plan_outputs}},
-    "parse-plan":  {"outcome": "success", "conclusion": "success", "outputs": ${counts_use}}
+    "parse-plan":  {"outcome": "success", "conclusion": "success", "outputs": ${counts_use}}${parse_warnings_json}
   }
 }
 JSON
@@ -664,6 +676,120 @@ test_plan_details_left_align_div() {
   return 0
 }
 
+# Warnings row in the grouped table. Sums warning-count outputs from
+# parse-init-warnings + parse-validate-warnings + parse-plan-warnings step
+# entries in each env's meta file. See docs/Plan-warnings.md §6.
+
+test_warnings_row_renders_sum_across_three_steps() {
+  # 1 init + 2 validate + 3 plan = 6 warnings for envA
+  write_meta "envA" "g" "success" "" "" "1:2:3"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  if ! grep -q '<span title="Warnings">⚠️</span> | Warnings' "${log}"; then
+    echo "expected Warnings row in the grouped table"
+    return 1
+  fi
+  if ! grep -q '⚠️ 6</span>' "${log}"; then
+    echo "expected cell '⚠️ 6' (sum of 1+2+3)"
+    return 1
+  fi
+  return 0
+}
+
+test_warnings_row_renders_em_dash_when_zero() {
+  write_meta "envA" "g" "success" "" "" "0:0:0"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  # Row must still appear (consistent shape across envs) but cell shows "—".
+  if ! grep -q '<span title="Warnings">⚠️</span> | Warnings' "${log}"; then
+    echo "expected Warnings row even when all zero"
+    return 1
+  fi
+  # Find the warnings row specifically and verify the env cell shows the em-dash
+  local row
+  row=$(grep '| Warnings |' "${log}" | head -n1)
+  if [[ "${row}" != *'—</span>'* ]]; then
+    echo "expected cell '—' on the Warnings row when all-zero, got: ${row}"
+    return 1
+  fi
+  return 0
+}
+
+test_warnings_row_renders_em_dash_when_steps_missing() {
+  # No 6th arg → no parse-*-warnings step entries written at all. This is
+  # the back-compat path: meta files captured before this feature shipped
+  # should still render correctly.
+  write_meta "envA" "g"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  if ! grep -q '<span title="Warnings">⚠️</span> | Warnings' "${log}"; then
+    echo "expected Warnings row even when parse-*-warnings step entries absent"
+    return 1
+  fi
+  local row
+  row=$(grep '| Warnings |' "${log}" | head -n1)
+  if [[ "${row}" != *'—</span>'* ]]; then
+    echo "expected cell '—' on the Warnings row when parse-warnings steps absent, got: ${row}"
+    return 1
+  fi
+  return 0
+}
+
+test_warnings_row_sums_when_some_steps_missing() {
+  # Only init + plan ran (validate didn't emit a parse-warnings step).
+  # Sum should be 2 + 5 = 7.
+  write_meta "envA" "g" "success" "" "" "2::5"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  if ! grep -q '⚠️ 7</span>' "${log}"; then
+    echo "expected '⚠️ 7' (sum across present steps; missing step counts as 0)"
+    return 1
+  fi
+  return 0
+}
+
+test_warnings_row_mixed_envs() {
+  # Multi-env group: env-a has warnings, env-b has none. Both cells must
+  # render correctly side-by-side.
+  write_meta "env-a" "g" "success" "" "" "1:0:2"
+  write_meta "env-b" "g"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  local row
+  row=$(grep '| Warnings |' "${log}" | head -n1)
+  # env-a is alphabetically first → cell 1 = "⚠️ 3", cell 2 = "—".
+  if [[ "${row}" != *'⚠️ 3</span>'*'—</span>'* ]]; then
+    echo "expected envA cell '⚠️ 3' and envB cell '—' in the Warnings row, got: ${row}"
+    return 1
+  fi
+  return 0
+}
+
+test_warnings_row_position_between_plan_and_plan_details() {
+  write_meta "envA" "g" "success" "" "" "1:0:0"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  local plan_line warn_line details_line
+  plan_line=$(grep -n '<span title="Plan">'         "${log}" | head -n1 | cut -d: -f1)
+  warn_line=$(grep -n '<span title="Warnings">'     "${log}" | head -n1 | cut -d: -f1)
+  details_line=$(grep -n '<span title="Plan details">' "${log}" | head -n1 | cut -d: -f1)
+  if [ -z "${plan_line}" ] || [ -z "${warn_line}" ] || [ -z "${details_line}" ]; then
+    echo "missing one or more rows (plan=${plan_line:-?}, warn=${warn_line:-?}, details=${details_line:-?})"
+    return 1
+  fi
+  if [ "${warn_line}" -le "${plan_line}" ] || [ "${warn_line}" -ge "${details_line}" ]; then
+    echo "Warnings row (line ${warn_line}) must sit between Plan (${plan_line}) and Plan details (${details_line})"
+    return 1
+  fi
+  return 0
+}
+
 test_group_marker_then_prefix_byte_exact() {
   write_meta "envA" "dev"
   run_step
@@ -791,13 +917,14 @@ test_step_row_order_byte_exact() {
   local log="${TEST_DIR}/step.log"
   # Extract just the table body rows in order
   local lines
-  lines=$(grep -oE '^\| <span title="[^"]+">' "${log}" | head -9)
+  lines=$(grep -oE '^\| <span title="[^"]+">' "${log}" | head -10)
   local expected='| <span title="Initialization">
 | <span title="Lock file">
 | <span title="Format and Style">
 | <span title="Validate">
 | <span title="TFLint">
 | <span title="Plan">
+| <span title="Warnings">
 | <span title="Plan details">
 | <span title="Plan time">
 | <span title="Links">'
@@ -1117,6 +1244,12 @@ run_test "per-env anchor picks newest comment id across multiple attempts" test_
 run_test "status emoji map covers success/failure/cancelled/skipped"       test_status_emoji_map
 run_test "Plan Details: optional categories appear only when non-zero"     test_plan_details_optional_categories
 run_test "Plan Details cell wraps in <div align='left'>"                   test_plan_details_left_align_div
+run_test "Warnings row sums across init+validate+plan step outputs"        test_warnings_row_renders_sum_across_three_steps
+run_test "Warnings row renders em-dash when all three counts are 0"        test_warnings_row_renders_em_dash_when_zero
+run_test "Warnings row renders em-dash when parse-warnings steps missing"  test_warnings_row_renders_em_dash_when_steps_missing
+run_test "Warnings row sums correctly when some parse-warnings steps absent" test_warnings_row_sums_when_some_steps_missing
+run_test "Warnings row renders mixed envs (some with warnings, some without)" test_warnings_row_mixed_envs
+run_test "Warnings row sits between Plan and Plan details in grouped table" test_warnings_row_position_between_plan_and_plan_details
 run_test "group marker + H3 prefix lines are byte-exact"                   test_group_marker_then_prefix_byte_exact
 run_test "degraded mode: gh list fails → skip orphan delete, fresh POST"   test_degraded_mode_when_list_fails
 run_test "malformed metadata file is skipped with warning"                 test_malformed_metadata_is_skipped

--- a/aggregate-validation-summaries/run_all_tests.sh
+++ b/aggregate-validation-summaries/run_all_tests.sh
@@ -676,6 +676,27 @@ test_plan_details_left_align_div() {
   return 0
 }
 
+# Plan details row is omitted when no env in the group has plan data
+# (parse-plan didn't run anywhere), mirroring the per-env head's
+# include-plan-details gate. Empty parse-plan outputs ('{}') stand in for
+# "plan didn't run" — _extract_plan_count then returns "" for every count.
+test_plan_details_row_absent_when_no_plan_data() {
+  write_meta "envA" "g" "success" "{}"
+  run_step
+  [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
+  local log="${TEST_DIR}/step.log"
+  if grep -q '| Plan details |' "${log}"; then
+    echo "Plan details row must be omitted when no env has plan data"
+    return 1
+  fi
+  # Plan time + Links still render (table didn't collapse).
+  if ! grep -q '| Plan time |' "${log}" || ! grep -q '| Links |' "${log}"; then
+    echo "Plan time / Links rows must still render"
+    return 1
+  fi
+  return 0
+}
+
 # Warnings row in the grouped table. Sums warning-count outputs from
 # parse-init-warnings + parse-validate-warnings + parse-plan-warnings step
 # entries in each env's meta file. See docs/Plan-warnings.md §6.
@@ -697,42 +718,34 @@ test_warnings_row_renders_sum_across_three_steps() {
   return 0
 }
 
-test_warnings_row_renders_em_dash_when_zero() {
+test_warnings_row_absent_when_all_zero() {
   write_meta "envA" "g" "success" "" "" "0:0:0"
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
   local log="${TEST_DIR}/step.log"
-  # Row must still appear (consistent shape across envs) but cell shows "—".
-  if ! grep -q '<span title="Warnings">⚠️</span> | Warnings' "${log}"; then
-    echo "expected Warnings row even when all zero"
+  # Whole row omitted when no env has warnings — ⚠️ stays a signal.
+  if grep -q '| Warnings |' "${log}"; then
+    echo "Warnings row must be omitted when all counts are 0"
     return 1
   fi
-  # Find the warnings row specifically and verify the env cell shows the em-dash
-  local row
-  row=$(grep '| Warnings |' "${log}" | head -n1)
-  if [[ "${row}" != *'—</span>'* ]]; then
-    echo "expected cell '—' on the Warnings row when all-zero, got: ${row}"
+  # The rest of the table must still render (didn't collapse).
+  if ! grep -q '| Plan details |' "${log}" || ! grep -q '| Plan time |' "${log}"; then
+    echo "Plan details / Plan time rows must still render"
     return 1
   fi
   return 0
 }
 
-test_warnings_row_renders_em_dash_when_steps_missing() {
+test_warnings_row_absent_when_steps_missing() {
   # No 6th arg → no parse-*-warnings step entries written at all. This is
   # the back-compat path: meta files captured before this feature shipped
-  # should still render correctly.
+  # have no warnings, so the row is correctly absent.
   write_meta "envA" "g"
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
   local log="${TEST_DIR}/step.log"
-  if ! grep -q '<span title="Warnings">⚠️</span> | Warnings' "${log}"; then
-    echo "expected Warnings row even when parse-*-warnings step entries absent"
-    return 1
-  fi
-  local row
-  row=$(grep '| Warnings |' "${log}" | head -n1)
-  if [[ "${row}" != *'—</span>'* ]]; then
-    echo "expected cell '—' on the Warnings row when parse-warnings steps absent, got: ${row}"
+  if grep -q '| Warnings |' "${log}"; then
+    echo "Warnings row must be omitted when parse-*-warnings step entries are absent"
     return 1
   fi
   return 0
@@ -911,7 +924,10 @@ JSON
 }
 
 test_step_row_order_byte_exact() {
-  write_meta "envA" "g"
+  # Give the env a warning AND plan data so the optional Warnings and Plan
+  # details rows both render — this test locks the full canonical row order
+  # (both rows are conditional now; their order only matters when present).
+  write_meta "envA" "g" "success" "" "" "1:0:0"
   run_step
   [[ ${STEP_EXIT_CODE} -eq 0 ]] || { echo "step exit ${STEP_EXIT_CODE}"; return 1; }
   local log="${TEST_DIR}/step.log"
@@ -1244,9 +1260,10 @@ run_test "per-env anchor picks newest comment id across multiple attempts" test_
 run_test "status emoji map covers success/failure/cancelled/skipped"       test_status_emoji_map
 run_test "Plan Details: optional categories appear only when non-zero"     test_plan_details_optional_categories
 run_test "Plan Details cell wraps in <div align='left'>"                   test_plan_details_left_align_div
+run_test "Plan details row omitted when no env has plan data"              test_plan_details_row_absent_when_no_plan_data
 run_test "Warnings row sums across init+validate+plan step outputs"        test_warnings_row_renders_sum_across_three_steps
-run_test "Warnings row renders em-dash when all three counts are 0"        test_warnings_row_renders_em_dash_when_zero
-run_test "Warnings row renders em-dash when parse-warnings steps missing"  test_warnings_row_renders_em_dash_when_steps_missing
+run_test "Warnings row omitted when all three counts are 0"                test_warnings_row_absent_when_all_zero
+run_test "Warnings row omitted when parse-warnings steps missing"          test_warnings_row_absent_when_steps_missing
 run_test "Warnings row sums correctly when some parse-warnings steps absent" test_warnings_row_sums_when_some_steps_missing
 run_test "Warnings row renders mixed envs (some with warnings, some without)" test_warnings_row_mixed_envs
 run_test "Warnings row sits between Plan and Plan details in grouped table" test_warnings_row_position_between_plan_and_plan_details

--- a/aggregate-validation-summaries/step_aggregate.sh
+++ b/aggregate-validation-summaries/step_aggregate.sh
@@ -326,6 +326,15 @@ function list_pr_state {
 # `<!-- comment-hash:<sha> -->` line via _render_full_body before
 # POSTing/PATCHing, so re-runs with unchanged content hash-short-circuit
 # the PATCH and don't re-ping subscribers.
+#
+# Kept in sync with the per-env head (create-validation-summary's
+# render_head_summary): same row set, labels, col-1 icon tooltips, and
+# Plan-details / Plan-time / Warnings cell conventions and row-presence
+# rules. Two differences are intentional, not drift: (1) step-status cells
+# use emoji here vs text (`success` / <kbd>) in the per-env head — a
+# column-width adaptation (many narrow env columns vs one wide Result
+# column); (2) the header shape and footer scope differ. See
+# docs/Workflow-pr-comments.md §5.1/§5.3.
 # Args:
 #   $1  - group name
 #   $2  - newline-delimited list of envs (already alphabetically sorted)
@@ -370,19 +379,30 @@ function render_group_body {
   # ---- Warnings row ----
   # Positioned between step rows and Plan details so reviewers scan
   # top-to-bottom: "did each step pass" → "any warnings" → "what changes
-  # are planned". Cell shape is "⚠️ N" (or "—" for zero/missing); the
-  # warning bodies themselves live in the per-env plan-tag comment via
-  # create-validation-summary. See docs/Plan-warnings.md §6.
+  # are planned". Cell shape is "⚠️ N" (or "—" for clean envs); the warning
+  # bodies themselves live in the per-env plan-tag comment via
+  # create-validation-summary. The whole row is omitted when no env in the
+  # group has warnings (see the mid_rows assembly below) — keeps ⚠️ a signal
+  # rather than a permanent fixture, matching the per-env head which also
+  # suppresses at zero. See docs/Plan-warnings.md §6.
   local warnings_row="| $(_render_step_icon_cell "⚠️" "Warnings") | Warnings |"
+  local group_warning_total=0
   for env in "${envs[@]}"; do
     local meta_file="${DESIRED_META[${group_name}/${env}]:-}"
     local wc
     wc=$(_extract_warning_count "${meta_file}")
     warnings_row+=" $(_render_warning_count_cell "${wc}") |"
+    [[ "${wc}" =~ ^[0-9]+$ ]] && group_warning_total=$((group_warning_total + wc))
   done
 
   # ---- Plan Details row ----
+  # Omitted entirely when no env in the group has plan data (parse-plan
+  # didn't run anywhere), mirroring the per-env head's include-plan-details
+  # gate and the Warnings row above. When shown, data-less envs render N/A.
+  # An env "has data" when at least one of add/change/destroy is non-empty
+  # — i.e. _render_plan_details_cell would not short-circuit to "N/A".
   local plan_details_row="| $(_render_step_icon_cell "📊" "Plan details") | Plan details |"
+  local group_has_plan_data=false
   for env in "${envs[@]}"; do
     local meta_file="${DESIRED_META[${group_name}/${env}]:-}"
     local c_add c_change c_destroy c_import c_move c_remove
@@ -393,6 +413,9 @@ function render_group_body {
     c_move=$(_extract_plan_count "${meta_file}" "count-move")
     c_remove=$(_extract_plan_count "${meta_file}" "count-remove")
     plan_details_row+=" $(_render_plan_details_cell "${c_add}" "${c_change}" "${c_destroy}" "${c_import}" "${c_move}" "${c_remove}") |"
+    if [ -n "${c_add}" ] || [ -n "${c_change}" ] || [ -n "${c_destroy}" ]; then
+      group_has_plan_data=true
+    fi
   done
 
   # ---- Plan time row ----
@@ -427,17 +450,25 @@ function render_group_body {
   # marker (load-bearing for upsert identity, see Workflow-pr-comments.md
   # §2) and the inline comment-hash line are prepended by _render_full_body
   # in _upsert_one_group / _post_fresh.
-  # 'rows' ends with a trailing newline; the rest are plain rows with no
-  # trailing newline, so the format string supplies the line breaks.
-  printf '%s\n%s\n%s\n%s%s\n%s\n%s\n%s\n\n%s\n' \
+  #
+  # Optional rows (Warnings, Plan details) are assembled into mid_rows and
+  # omitted from the string entirely when their group-wide condition is
+  # unmet — an empty printf arg would still emit a blank table line, so the
+  # row must be dropped from the string, not blanked. Plan time and Links
+  # always render. 'rows' ends with a trailing newline; mid_rows has none,
+  # so the '\n\n' before the footer yields exactly one blank line.
+  local mid_rows=""
+  [ "${group_warning_total}" -gt 0 ] && mid_rows+="${warnings_row}"$'\n'
+  [ "${group_has_plan_data}" = true ] && mid_rows+="${plan_details_row}"$'\n'
+  mid_rows+="${plan_time_row}"$'\n'
+  mid_rows+="${links_row}"
+
+  printf '%s\n%s\n%s\n%s%s\n\n%s\n' \
     "${prefix}" \
     "${header}" \
     "${sep}" \
     "${rows}" \
-    "${warnings_row}" \
-    "${plan_details_row}" \
-    "${plan_time_row}" \
-    "${links_row}" \
+    "${mid_rows}" \
     "${footer}"
 }
 

--- a/aggregate-validation-summaries/step_aggregate.sh
+++ b/aggregate-validation-summaries/step_aggregate.sh
@@ -367,6 +367,20 @@ function render_group_body {
     rows+="${row}"$'\n'
   done
 
+  # ---- Warnings row ----
+  # Positioned between step rows and Plan details so reviewers scan
+  # top-to-bottom: "did each step pass" → "any warnings" → "what changes
+  # are planned". Cell shape is "⚠️ N" (or "—" for zero/missing); the
+  # warning bodies themselves live in the per-env plan-tag comment via
+  # create-validation-summary. See docs/Plan-warnings.md §6.
+  local warnings_row="| $(_render_step_icon_cell "⚠️" "Warnings") | Warnings |"
+  for env in "${envs[@]}"; do
+    local meta_file="${DESIRED_META[${group_name}/${env}]:-}"
+    local wc
+    wc=$(_extract_warning_count "${meta_file}")
+    warnings_row+=" $(_render_warning_count_cell "${wc}") |"
+  done
+
   # ---- Plan Details row ----
   local plan_details_row="| $(_render_step_icon_cell "📊" "Plan details") | Plan details |"
   for env in "${envs[@]}"; do
@@ -415,11 +429,12 @@ function render_group_body {
   # in _upsert_one_group / _post_fresh.
   # 'rows' ends with a trailing newline; the rest are plain rows with no
   # trailing newline, so the format string supplies the line breaks.
-  printf '%s\n%s\n%s\n%s%s\n%s\n%s\n\n%s\n' \
+  printf '%s\n%s\n%s\n%s%s\n%s\n%s\n%s\n\n%s\n' \
     "${prefix}" \
     "${header}" \
     "${sep}" \
     "${rows}" \
+    "${warnings_row}" \
     "${plan_details_row}" \
     "${plan_time_row}" \
     "${links_row}" \
@@ -447,6 +462,25 @@ function _extract_plan_count {
   val=$(jq -r --arg k "${key}" '.steps["parse-plan"].outputs[$k] // ""' "${file}" 2>/dev/null || echo "")
   [ "${val}" = "null" ] && val=""
   echo "${val}"
+}
+
+# Extract the total warning count across all three parse-terraform-warnings
+# invocations (init / validate / plan) from a matrix-job-meta file. Returns
+# the sum as a string. Missing step outputs are treated as 0. Returns "0"
+# when the meta file is missing entirely or none of the steps ran — the
+# rendering helper (_render_warning_count_cell) then displays "—".
+#
+# Step IDs are 'parse-init-warnings', 'parse-validate-warnings',
+# 'parse-plan-warnings' — must match the IDs set in
+# .github/workflows/terraform-ci-cd-default.yml.
+function _extract_warning_count {
+  local file="${1}"
+  [ -z "${file}" ] || [ ! -f "${file}" ] && { echo "0"; return; }
+  jq -r '
+    (.steps["parse-init-warnings"].outputs["warning-count"] // "0" | tonumber? // 0) +
+    (.steps["parse-validate-warnings"].outputs["warning-count"] // "0" | tonumber? // 0) +
+    (.steps["parse-plan-warnings"].outputs["warning-count"] // "0" | tonumber? // 0)
+  ' "${file}" 2>/dev/null || echo "0"
 }
 
 # Extract the plan-time (mm:ss) emitted by terraform-plan from the metadata

--- a/auto-merge-pr/action.yml
+++ b/auto-merge-pr/action.yml
@@ -70,13 +70,19 @@ runs:
         input_repo_ref: ${{ github.repository }}
         input_pr_number: ${{ github.event.number }}
       run: |
-        # JSON inputs require special handling (heredocs)
+        # Heredoc capture (special chars in github.event JSON survive verbatim).
+        # Intentionally NOT exported — step_auto_merge_pr.sh is sourced from
+        # this same shell and reads ${input_github_event_context_json} as a
+        # shell-local, so it never needs to be in envp. github.event for PR
+        # events can be 30-100+ KB (long descriptions, large reviewer lists,
+        # labels). Exporting that pushed every subsequent gh / jq fork past
+        # MAX_ARG_STRLEN (128 KB per envp string on Ubuntu); see
+        # docs/Action-implementation-guide.md §"Anti-pattern: exporting
+        # heredoc-captured JSON".
         input_github_event_context_json=$(cat <<'EOF'
         ${{ inputs.github-event-context-json }}
         EOF
         )
-
-        export input_github_event_context_json
 
         source "${GITHUB_ACTION_PATH}/step_auto_merge_pr.sh"
         exit_code=$?

--- a/create-validation-summary/action.yml
+++ b/create-validation-summary/action.yml
@@ -97,6 +97,28 @@ inputs:
       when not provided — matches the convention used by `plan-count-*`.
     required: false
     default: "N/A"
+  warning-count:
+    description: |
+      Total terraform warning count across init+validate+plan (typically
+      summed in the caller workflow from three parse-terraform-warnings
+      invocations). When numeric and > 0, the per-env head-summary table
+      gets a "⚠️ Warnings" row between the "📖 Plan" and "📊 Plan Details"
+      rows. When 0 / unset / '?', the row is omitted. See
+      docs/Plan-warnings.md.
+    required: false
+    default: "0"
+  warnings-markdown-file:
+    description: |
+      Absolute path to a markdown file containing rendered warning bodies
+      (typically the concatenation of the three parse-terraform-warnings
+      output files for init+validate+plan). When non-empty and the file
+      has content, a `<details>⚠️ N warnings</summary>…</details>`
+      collapser is appended to the plan-extract output AFTER the existing
+      plan-block. Warnings have priority over the plan extract in the 65k
+      char budget — when both can't fit, plan extract is trimmed first.
+      See docs/Plan-warnings.md §5 for the budgeting algorithm.
+    required: false
+    default: ""
   plan-tag-comment-id:
     description: |
       GitHub comment id of the per-env plan-extract tag for this run, used
@@ -173,6 +195,8 @@ runs:
         input_plan_count_total: ${{ inputs.plan-count-total }}
         input_plan_has_output_only_changes: ${{ inputs.plan-has-output-only-changes }}
         input_plan_time: ${{ inputs.plan-time }}
+        input_warning_count: ${{ inputs.warning-count }}
+        input_warnings_markdown_file: ${{ inputs.warnings-markdown-file }}
         input_plan_tag_comment_id: ${{ inputs.plan-tag-comment-id }}
         input_job_check_run_id: ${{ job.check_run_id }}
       run: |

--- a/create-validation-summary/helpers_additional.sh
+++ b/create-validation-summary/helpers_additional.sh
@@ -7,6 +7,13 @@
 
 # Format a step status for the markdown summary table.
 # Successful statuses are shown in backticks, failures in <kbd> tags.
+#
+# NOTE: this text representation (`success` / <kbd>failure</kbd>) is an
+# intentional divergence from the grouped head, which uses emoji
+# (✅/❌/…). The per-env head has one wide "Result" column where text reads
+# well; the grouped head has many narrow per-env columns where emoji stay
+# compact. Keep them different — see docs/Workflow-pr-comments.md §5.1/§5.3.
+#
 # Arguments:
 #   $1 - status string (e.g., "success", "failure", "skipped")
 # Output:
@@ -18,4 +25,14 @@ function format-status {
   else
     echo "<kbd>${status}</kbd>"
   fi
+}
+
+# Render the column-1 step-icon cell with a hover tooltip (the label is the
+# step name). Kept byte-identical to the grouped head's helper of the same
+# name (aggregate-validation-summaries/helpers_additional.sh) so the two
+# validation tables render col-1 the same way.
+function _render_step_icon_cell {
+  local emoji="${1}"
+  local label="${2}"
+  echo "<span title=\"${label}\">${emoji}</span>"
 }

--- a/create-validation-summary/run_all_tests.sh
+++ b/create-validation-summary/run_all_tests.sh
@@ -227,9 +227,9 @@ assert_plan_details_basic() {
   local summary="${2}"
   local fails=""
 
-  # Should contain the Plan Details row
-  if [[ "${summary}" != *"Plan Details"* ]]; then
-    fails+="  summary: expected to contain 'Plan Details'\n"
+  # Should contain the Plan details row
+  if [[ "${summary}" != *"Plan details"* ]]; then
+    fails+="  summary: expected to contain 'Plan details'\n"
   fi
 
   # Should contain add/change/destroy counts
@@ -293,9 +293,9 @@ assert_no_plan_details() {
   local summary="${2}"
   local fails=""
 
-  # Should NOT contain the Plan Details row
-  if [[ "${summary}" == *"Plan Details"* ]]; then
-    fails+="  summary: should not contain 'Plan Details' when disabled\n"
+  # Should NOT contain the Plan details row
+  if [[ "${summary}" == *"Plan details"* ]]; then
+    fails+="  summary: should not contain 'Plan details' when disabled\n"
   fi
 
   if [[ -n "${fails}" ]]; then
@@ -522,7 +522,7 @@ assert_lock_row_success() {
   local prefix="${1}"
   local summary="${2}"
   local fails=""
-  if [[ "${summary}" != *"| 🔒 | Lock file | \`success\` |"* ]]; then
+  if [[ "${summary}" != *'| <span title="Lock file">🔒</span> | Lock file | `success` |'* ]]; then
     fails+="  summary: expected lock file row with success status\n"
   fi
   if [[ -n "${fails}" ]]; then
@@ -539,7 +539,7 @@ assert_lock_row_failure() {
   local prefix="${1}"
   local summary="${2}"
   local fails=""
-  if [[ "${summary}" != *"| 🔒 | Lock file | <kbd>failure</kbd> |"* ]]; then
+  if [[ "${summary}" != *'| <span title="Lock file">🔒</span> | Lock file | <kbd>failure</kbd> |'* ]]; then
     fails+="  summary: expected lock file row with <kbd>failure</kbd>\n"
   fi
   if [[ -n "${fails}" ]]; then
@@ -590,13 +590,13 @@ assert_full_body_golden_all_success_no_plan() {
 ### Terraform validation summary for environment: `dev`
 |  | Step | Result |
 |:---:|---|---|
-| ⚙️ | Initialization | `success` |
-| 🔒 | Lock file | `success` |
-| 🖌 | Format and Style | `success` |
-| ✔ | Validate | `success` |
-| 🧹 | TFLint | `success` |
-| 📖 | Plan | `success` |
-| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`N/A`</span> |
+| <span title="Initialization">⚙️</span> | Initialization | `success` |
+| <span title="Lock file">🔒</span> | Lock file | `success` |
+| <span title="Format and Style">🖌</span> | Format and Style | `success` |
+| <span title="Validate">✔</span> | Validate | `success` |
+| <span title="TFLint">🧹</span> | TFLint | `success` |
+| <span title="Plan">📖</span> | Plan | `success` |
+| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">—</span> |
 
 [Job log](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs)
 EOF
@@ -628,13 +628,13 @@ assert_all_row_labels_byte_exact() {
   local summary="${2}"
   local fails=""
   local rows=(
-    "| ⚙️ | Initialization | "
-    "| 🔒 | Lock file | "
-    "| 🖌 | Format and Style | "
-    "| ✔ | Validate | "
-    "| 🧹 | TFLint | "
-    "| 📖 | Plan | "
-    "| ⏱ | Plan time | "
+    '| <span title="Initialization">⚙️</span> | Initialization | '
+    '| <span title="Lock file">🔒</span> | Lock file | '
+    '| <span title="Format and Style">🖌</span> | Format and Style | '
+    '| <span title="Validate">✔</span> | Validate | '
+    '| <span title="TFLint">🧹</span> | TFLint | '
+    '| <span title="Plan">📖</span> | Plan | '
+    '| <span title="Plan time">⏱</span> | Plan time | '
   )
   for row in "${rows[@]}"; do
     if [[ "${summary}" != *"${row}"* ]]; then
@@ -672,9 +672,9 @@ assert_plan_details_row_byte_exact() {
   local prefix="${1}"
   local summary="${2}"
   local fails=""
-  local expected='| 📊 | Plan Details | <span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span> |'
+  local expected='| <span title="Plan details">📊</span> | Plan details | <div align="left"><span title="Resources to be added">`💫 0` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span></div> |'
   if [[ "${summary}" != *"${expected}"* ]]; then
-    fails+="  summary: Plan Details row not byte-exact\n"
+    fails+="  summary: Plan details row not byte-exact\n"
     fails+="    expected substring: ${expected}\n"
   fi
   if [[ -n "${fails}" ]]; then
@@ -941,12 +941,12 @@ assert_grouped_table_omitted() {
   local fails=""
   # No standard row labels should appear
   local forbidden_rows=(
-    "| ⚙️ | Initialization |"
-    "| 🔒 | Lock file |"
-    "| 🖌 | Format and Style |"
-    "| ✔ | Validate |"
-    "| 🧹 | TFLint |"
-    "| 📖 | Plan |"
+    '| <span title="Initialization">⚙️</span> | Initialization |'
+    '| <span title="Lock file">🔒</span> | Lock file |'
+    '| <span title="Format and Style">🖌</span> | Format and Style |'
+    '| <span title="Validate">✔</span> | Validate |'
+    '| <span title="TFLint">🧹</span> | TFLint |'
+    '| <span title="Plan">📖</span> | Plan |'
     "|  | Step | Result |"
     "|:---:|---|---|"
   )
@@ -1074,8 +1074,8 @@ run_test "Grouped mode: footer is byte-exact (same as ungrouped)" assert_grouped
 assert_grouped_plan_details_row_omitted() {
   local prefix="${1}"
   local summary="${2}"
-  if [[ "${summary}" == *"Plan Details"* ]]; then
-    echo "  summary: grouped mode must NOT render the Plan Details row even when include-plan-details=true"
+  if [[ "${summary}" == *"Plan details"* ]]; then
+    echo "  summary: grouped mode must NOT render the Plan details row even when include-plan-details=true"
     return 1
   fi
   return 0
@@ -1131,7 +1131,7 @@ assert_empty_group_acts_ungrouped() {
   local summary="${2}"
   local fails=""
   # Must contain the full table (ungrouped shape)
-  if [[ "${summary}" != *"| ⚙️ | Initialization |"* ]]; then
+  if [[ "${summary}" != *'| <span title="Initialization">⚙️</span> | Initialization |'* ]]; then
     fails+="  summary: empty pr-comment-group must render full validation table (got grouped shape?)\n"
   fi
   # Must NOT contain the grouped "Part of group" note
@@ -1248,7 +1248,7 @@ assert_grouped_no_changes_short_circuit() {
     return 1
   fi
   # And still no validation table (it's in the per-group comment)
-  if [[ "${summary}" == *'| ⚙️ | Initialization'* ]]; then
+  if [[ "${summary}" == *'| <span title="Initialization">⚙️</span> | Initialization'* ]]; then
     echo "  summary: grouped mode must still omit validation table"
     return 1
   fi
@@ -1293,13 +1293,13 @@ assert_golden_no_changes_body() {
 ### Terraform validation summary for environment: `dev`
 |  | Step | Result |
 |:---:|---|---|
-| ⚙️ | Initialization | `success` |
-| 🔒 | Lock file | `success` |
-| 🖌 | Format and Style | `success` |
-| ✔ | Validate | `success` |
-| 🧹 | TFLint | `success` |
-| 📖 | Plan | `success` |
-| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`N/A`</span> |
+| <span title="Initialization">⚙️</span> | Initialization | `success` |
+| <span title="Lock file">🔒</span> | Lock file | `success` |
+| <span title="Format and Style">🖌</span> | Format and Style | `success` |
+| <span title="Validate">✔</span> | Validate | `success` |
+| <span title="TFLint">🧹</span> | TFLint | `success` |
+| <span title="Plan">📖</span> | Plan | `success` |
+| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">—</span> |
 
 [Job log](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs)
 EOF
@@ -1409,7 +1409,7 @@ assert_grouped_output_only_keeps_details() {
     return 1
   fi
   # No validation table (group mode invariant)
-  if [[ "${summary}" == *'| ⚙️ | Initialization'* ]]; then
+  if [[ "${summary}" == *'| <span title="Initialization">⚙️</span> | Initialization'* ]]; then
     echo "  summary: grouped mode must still omit the validation table"
     return 1
   fi
@@ -1436,7 +1436,7 @@ rm -f "${_plan_file}"
 assert_plan_time_row_with_value() {
   local prefix="${1}"
   local summary="${2}"
-  if [[ "${summary}" != *'| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |'* ]]; then
+  if [[ "${summary}" != *'| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |'* ]]; then
     echo "  summary: expected backtick-wrapped value cell with format tooltip"
     return 1
   fi
@@ -1446,21 +1446,22 @@ reset_defaults
 export input_plan_time="1:23"
 run_test "Plan time row renders backtick-wrapped mm:ss value with tooltip" assert_plan_time_row_with_value
 
-# Plan time row: defaults to N/A when caller passes nothing (matches
-# the create-validation-summary input default and plan-count-* convention).
-# Tooltip wrapper applies to the N/A branch too so hover-discovery works
-# even when there's no timing recorded.
+# Plan time row: defaults to the em-dash '—' (not backtick-wrapped) when
+# caller passes nothing — matching the grouped head's _render_plan_time_cell.
+# The action.yml input default is the literal 'N/A', which the renderer maps
+# to '—'. Tooltip wrapper applies to the em-dash branch too so hover-
+# discovery works even when there's no timing recorded.
 assert_plan_time_row_default_na() {
   local prefix="${1}"
   local summary="${2}"
-  if [[ "${summary}" != *'| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`N/A`</span> |'* ]]; then
-    echo "  summary: expected default N/A cell with format tooltip"
+  if [[ "${summary}" != *'| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">—</span> |'* ]]; then
+    echo "  summary: expected default em-dash cell with format tooltip"
     return 1
   fi
   return 0
 }
 reset_defaults
-run_test "Plan time row defaults to 'N/A' with tooltip when input not supplied" assert_plan_time_row_default_na
+run_test "Plan time row defaults to em-dash with tooltip when input not supplied" assert_plan_time_row_default_na
 
 # Plan time row: rendered even when Plan Details is off (Plan time row is
 # always emitted in ungrouped mode; Plan Details row is conditional).
@@ -1468,11 +1469,11 @@ assert_plan_time_without_plan_details() {
   local prefix="${1}"
   local summary="${2}"
   local fails=""
-  if [[ "${summary}" != *'| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`0:45`</span> |'* ]]; then
-    fails+="  summary: expected Plan time row (with tooltip) to render without Plan Details\n"
+  if [[ "${summary}" != *'| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`0:45`</span> |'* ]]; then
+    fails+="  summary: expected Plan time row (with tooltip) to render without Plan details\n"
   fi
-  if [[ "${summary}" == *"Plan Details"* ]]; then
-    fails+="  summary: Plan Details row should NOT appear when include-plan-details=false\n"
+  if [[ "${summary}" == *"Plan details"* ]]; then
+    fails+="  summary: Plan details row should NOT appear when include-plan-details=false\n"
   fi
   if [[ -n "${fails}" ]]; then
     echo -e "${fails}"
@@ -1509,14 +1510,14 @@ assert_plan_time_after_plan_details() {
   # Extract the bit between Plan Details opener and the blank line that
   # closes the table. Plan time row must be after Plan Details in that span.
   local pd_pos pt_pos
-  pd_pos=$(echo "${summary}" | grep -n '| 📊 | Plan Details |' | head -n1 | cut -d: -f1)
-  pt_pos=$(echo "${summary}" | grep -n '| ⏱ | Plan time |'   | head -n1 | cut -d: -f1)
+  pd_pos=$(echo "${summary}" | grep -n '| Plan details |' | head -n1 | cut -d: -f1)
+  pt_pos=$(echo "${summary}" | grep -n '| Plan time |'   | head -n1 | cut -d: -f1)
   if [ -z "${pd_pos}" ] || [ -z "${pt_pos}" ]; then
-    echo "  summary: expected both Plan Details and Plan time rows present (pd=${pd_pos}, pt=${pt_pos})"
+    echo "  summary: expected both Plan details and Plan time rows present (pd=${pd_pos}, pt=${pt_pos})"
     return 1
   fi
   if [ "${pt_pos}" -le "${pd_pos}" ]; then
-    echo "  summary: Plan time row (line ${pt_pos}) must appear AFTER Plan Details (line ${pd_pos})"
+    echo "  summary: Plan time row (line ${pt_pos}) must appear AFTER Plan details (line ${pd_pos})"
     return 1
   fi
   return 0
@@ -1541,7 +1542,7 @@ assert_links_row_rendered_ungrouped() {
   local prefix="${1}"
   local summary="${2}"
   local head="${3}"
-  local expected_cell='| 🔗 | Links | [log extract](#issuecomment-99887766)<br>[job log](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs) |'
+  local expected_cell='| <span title="Links">🔗</span> | Links | [log extract](#issuecomment-99887766)<br>[job log](https://github.com/dsb-norge/github-actions-terraform/actions/runs/12345678/job/87654321#logs) |'
   if [[ "${head}" != *"${expected_cell}"* ]]; then
     echo "  head-summary: expected Links row with anchor + job log:"
     echo "    expected substring: ${expected_cell}"
@@ -1577,7 +1578,7 @@ assert_links_row_omitted_when_no_id() {
   local prefix="${1}"
   local summary="${2}"
   local head="${3}"
-  if [[ "${head}" == *'| 🔗 | Links |'* ]]; then
+  if [[ "${head}" == *'| <span title="Links">🔗</span> | Links |'* ]]; then
     echo "  head-summary: Links row must NOT be rendered when plan-tag-comment-id is empty"
     return 1
   fi
@@ -1600,7 +1601,7 @@ assert_links_row_omitted_in_grouped_mode() {
   # row has no table to live in. Caller supplies the id anyway (matrix
   # passes it uniformly) — action must ignore it for grouped envs and
   # keep the legacy minimal grouped-mode body (H3 + footer).
-  if [[ "${head}" == *'| 🔗 | Links |'* ]]; then
+  if [[ "${head}" == *'| <span title="Links">🔗</span> | Links |'* ]]; then
     echo "  head-summary: Links row must NOT appear in grouped mode"
     return 1
   fi
@@ -1620,8 +1621,8 @@ assert_links_row_appears_after_plan_time() {
   local summary="${2}"
   local head="${3}"
   local pt_pos lk_pos
-  pt_pos=$(echo "${head}" | grep -n '| ⏱ | Plan time |' | head -n1 | cut -d: -f1)
-  lk_pos=$(echo "${head}" | grep -n '| 🔗 | Links |'   | head -n1 | cut -d: -f1)
+  pt_pos=$(echo "${head}" | grep -n '| Plan time |' | head -n1 | cut -d: -f1)
+  lk_pos=$(echo "${head}" | grep -n '| Links |'   | head -n1 | cut -d: -f1)
   if [ -z "${pt_pos}" ] || [ -z "${lk_pos}" ]; then
     echo "  expected both Plan time and Links rows present (pt=${pt_pos}, lk=${lk_pos})"
     return 1
@@ -1705,7 +1706,7 @@ assert_warnings_row_present_when_count_positive() {
   local prefix="${1}"
   local summary="${2}"
   local head="${3}"
-  if [[ "${head}" != *'| ⚠️ | Warnings |'* ]]; then
+  if [[ "${head}" != *'| <span title="Warnings">⚠️</span> | Warnings |'* ]]; then
     echo "  head-summary: expected '⚠️ Warnings' row to be present"
     return 1
   fi
@@ -1724,7 +1725,7 @@ assert_warnings_row_absent_when_count_zero() {
   local prefix="${1}"
   local summary="${2}"
   local head="${3}"
-  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+  if [[ "${head}" == *'| <span title="Warnings">⚠️</span> | Warnings |'* ]]; then
     echo "  head-summary: warnings row must be absent when count is 0"
     return 1
   fi
@@ -1739,7 +1740,7 @@ assert_warnings_row_absent_when_count_unset() {
   local prefix="${1}"
   local summary="${2}"
   local head="${3}"
-  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+  if [[ "${head}" == *'| <span title="Warnings">⚠️</span> | Warnings |'* ]]; then
     echo "  head-summary: warnings row must be absent when count is unset"
     return 1
   fi
@@ -1754,7 +1755,7 @@ assert_warnings_row_absent_when_count_question_mark() {
   local prefix="${1}"
   local summary="${2}"
   local head="${3}"
-  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+  if [[ "${head}" == *'| <span title="Warnings">⚠️</span> | Warnings |'* ]]; then
     echo "  head-summary: warnings row must be absent when count is '?'"
     return 1
   fi
@@ -1771,7 +1772,7 @@ assert_warnings_row_omitted_in_grouped_mode() {
   # Grouped mode skips the entire validation table; the warnings row sits
   # inside that table so it must be absent. The warnings collapser still
   # appears in plan-extract though — checked separately below.
-  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+  if [[ "${head}" == *'| <span title="Warnings">⚠️</span> | Warnings |'* ]]; then
     echo "  head-summary: warnings row must NOT appear in grouped mode"
     return 1
   fi

--- a/create-validation-summary/run_all_tests.sh
+++ b/create-validation-summary/run_all_tests.sh
@@ -1638,6 +1638,343 @@ export input_plan_time="0:45"
 run_test "Links row sits after Plan time row" assert_links_row_appears_after_plan_time
 
 # --------------------------------------------------
+# Warnings row in head + warnings <details> collapser in plan-extract.
+# See docs/Plan-warnings.md §6 for the rendered shape.
+# --------------------------------------------------
+
+# Helper that writes the same canned warnings markdown to a temp file and
+# returns the path, suitable for input_warnings_markdown_file.
+make_warnings_md() {
+  local content="${1:-default}"
+  local tmp
+  tmp=$(mktemp)
+  case "${content}" in
+    default)
+      cat >"${tmp}" <<'MD'
+### From terraform plan
+
+**Warning: Deprecated attribute**
+- source: `.terraform/modules/foo/main.tf:176`
+
+> The attribute is deprecated.
+
+---
+
+MD
+      ;;
+    multi)
+      cat >"${tmp}" <<'MD'
+### From terraform init
+
+**Warning: Provider deprecation**
+
+> The provider is deprecated.
+
+---
+
+### From terraform plan
+
+**Warning: Deprecated attribute**
+- source: `main.tf:42`
+
+> Body.
+
+---
+
+MD
+      ;;
+    huge)
+      # >60k of dummy warning blocks to exercise the WARN_CAP truncation
+      # (WARN_CAP = 60000; each block here is ~95 chars, 1000 blocks ≈ 95k).
+      local i
+      {
+        printf '### From terraform plan\n\n'
+        for i in $(seq 1 1000); do
+          printf '**Warning: deprecated attribute number %d**\n\n> body line one of warning %d\n> body line two of warning %d\n\n---\n\n' "${i}" "${i}" "${i}"
+        done
+      } >"${tmp}"
+      ;;
+  esac
+  echo "${tmp}"
+}
+
+# Per-test cleanup: created markdown / plan files left in tmp space, fine
+# under CI.
+
+assert_warnings_row_present_when_count_positive() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  if [[ "${head}" != *'| ⚠️ | Warnings |'* ]]; then
+    echo "  head-summary: expected '⚠️ Warnings' row to be present"
+    return 1
+  fi
+  if [[ "${head}" != *'⚠️ 3</span>'* ]]; then
+    echo "  head-summary: expected count badge '⚠️ 3'"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_warning_count="3"
+export input_warnings_markdown_file=$(make_warnings_md default)
+run_test "Warnings row rendered in ungrouped head when warning-count > 0" assert_warnings_row_present_when_count_positive
+
+assert_warnings_row_absent_when_count_zero() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+    echo "  head-summary: warnings row must be absent when count is 0"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_warning_count="0"
+export input_warnings_markdown_file=""
+run_test "Warnings row absent when warning-count is 0" assert_warnings_row_absent_when_count_zero
+
+assert_warnings_row_absent_when_count_unset() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+    echo "  head-summary: warnings row must be absent when count is unset"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+unset input_warning_count
+unset input_warnings_markdown_file
+run_test "Warnings row absent when warning-count is unset" assert_warnings_row_absent_when_count_unset
+
+assert_warnings_row_absent_when_count_question_mark() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+    echo "  head-summary: warnings row must be absent when count is '?'"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_warning_count="?"
+run_test "Warnings row absent when warning-count is '?'" assert_warnings_row_absent_when_count_question_mark
+
+assert_warnings_row_omitted_in_grouped_mode() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  # Grouped mode skips the entire validation table; the warnings row sits
+  # inside that table so it must be absent. The warnings collapser still
+  # appears in plan-extract though — checked separately below.
+  if [[ "${head}" == *'| ⚠️ | Warnings |'* ]]; then
+    echo "  head-summary: warnings row must NOT appear in grouped mode"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+export input_warning_count="3"
+export input_warnings_markdown_file=$(make_warnings_md default)
+run_test "Warnings row omitted in grouped mode" assert_warnings_row_omitted_in_grouped_mode
+
+assert_warnings_collapser_in_plan_extract() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  local plan="${4}"
+  if [[ "${plan}" != *'<details><summary>⚠️ 3 warnings</summary>'* ]]; then
+    echo "  plan-extract: expected '<details><summary>⚠️ 3 warnings</summary>'"
+    return 1
+  fi
+  if [[ "${plan}" != *'From terraform plan'* ]]; then
+    echo "  plan-extract: warning body content missing"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_warning_count="3"
+export input_warnings_markdown_file=$(make_warnings_md default)
+run_test "Warnings collapser appended to plan-extract" assert_warnings_collapser_in_plan_extract
+
+assert_warnings_collapser_absent_when_file_empty() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  local plan="${4}"
+  if [[ "${plan}" == *'⚠️'*' warnings</summary>'* ]]; then
+    echo "  plan-extract: warnings collapser must be absent when markdown file is empty"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_warning_count="0"
+export input_warnings_markdown_file=$(mktemp)  # empty file
+run_test "Warnings collapser absent when markdown file empty" assert_warnings_collapser_absent_when_file_empty
+
+assert_warnings_collapser_rendered_in_grouped_mode() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  local plan="${4}"
+  # Per docs/Workflow-pr-comments.md §5.2 the plan-extract is still posted
+  # for grouped envs — only the per-env head's validation table is dropped.
+  # Warnings collapser must still appear inside plan-extract.
+  if [[ "${plan}" != *'⚠️ 2 warnings</summary>'* ]]; then
+    echo "  plan-extract: warnings collapser must still appear in grouped mode"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_pr_comment_group="dev-group"
+export input_warning_count="2"
+export input_warnings_markdown_file=$(make_warnings_md multi)
+run_test "Warnings collapser appears in plan-extract even in grouped mode" assert_warnings_collapser_rendered_in_grouped_mode
+
+assert_combined_body_under_65k_with_huge_warnings() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  local plan="${4}"
+  # When warnings exceed WARN_CAP they must be truncated with a clear
+  # marker. plan-extract size (the largest of the two outputs) must
+  # stay under 65000.
+  local plan_size
+  plan_size=$(printf '%s' "${plan}" | wc -c)
+  if [ "${plan_size}" -gt 65000 ]; then
+    echo "  plan-extract size ${plan_size} > 65000 (hard limit)"
+    return 1
+  fi
+  if [[ "${plan}" != *'truncated, warnings exceed'* ]]; then
+    echo "  plan-extract: expected truncation marker '_(truncated, warnings exceed …)'"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_warning_count="700"
+export input_warnings_markdown_file=$(make_warnings_md huge)
+run_test "Combined body stays under 65k even with huge warnings (warnings truncated)" assert_combined_body_under_65k_with_huge_warnings
+
+assert_plan_trimmed_when_warnings_present() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  local plan="${4}"
+  # Construct a 50k plan extract + ~5k warnings. Combined raw would be
+  # 55k+. Budgeting must shrink the plan-extract to fit; warnings stay
+  # intact.
+  local plan_size
+  plan_size=$(printf '%s' "${plan}" | wc -c)
+  if [ "${plan_size}" -gt 65000 ]; then
+    echo "  plan-extract size ${plan_size} > 65000"
+    return 1
+  fi
+  # The warnings markdown ("Deprecated attribute") must be intact.
+  if [[ "${plan}" != *'Deprecated attribute'* ]]; then
+    echo "  warnings markdown should survive budgeting"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+# Build a ~50k plan extract
+_huge_plan_file=$(mktemp)
+{
+  echo "Terraform used the selected providers to generate the following execution plan"
+  yes "  + foo_resource.bar = \"some value here that pads each line to a comfortable width\"" | head -n 1000
+  echo "Plan: 1 to add, 0 to change, 0 to destroy."
+} >"${_huge_plan_file}"
+export input_plan_txt_output_file="${_huge_plan_file}"
+export input_plan_count_total="1"
+export input_warning_count="3"
+export input_warnings_markdown_file=$(make_warnings_md default)
+run_test "Plan extract trimmed first when warnings + plan together exceed budget" assert_plan_trimmed_when_warnings_present
+
+assert_warnings_collapser_after_plan_block() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  local plan="${4}"
+  # Warnings collapser is a SIBLING of the plan-block, positioned AFTER.
+  # Find both positions in plan-extract output.
+  local plan_block_pos warnings_pos
+  plan_block_pos=$(printf '%s' "${plan}" | grep -n 'Plan: no changes ✅' | head -n1 | cut -d: -f1)
+  warnings_pos=$(printf '%s' "${plan}" | grep -n '⚠️ 1 warnings</summary>' | head -n1 | cut -d: -f1)
+  if [ -z "${plan_block_pos}" ] || [ -z "${warnings_pos}" ]; then
+    echo "  expected both plan-block ('Plan: no changes ✅' line ${plan_block_pos:-?}) and warnings collapser (line ${warnings_pos:-?})"
+    return 1
+  fi
+  if [ "${warnings_pos}" -le "${plan_block_pos}" ]; then
+    echo "  warnings collapser (line ${warnings_pos}) must appear AFTER plan-block (line ${plan_block_pos})"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+# 'No changes' plan-block (count-total=0, no output-only). The shape is
+# only produced when plan_out is non-empty AND count-total=0 — supply a
+# minimal plan file so render_plan_extract doesn't fall back to
+# "Plan not available 🤷‍♀️".
+_no_changes_plan_file=$(mktemp)
+echo "No changes. Your infrastructure matches the configuration." >"${_no_changes_plan_file}"
+export input_plan_txt_output_file="${_no_changes_plan_file}"
+export input_plan_count_total="0"
+export input_warning_count="1"
+export input_warnings_markdown_file=$(make_warnings_md default)
+run_test "Warnings collapser sits AFTER plan-block in plan-extract" assert_warnings_collapser_after_plan_block
+
+assert_warnings_included_in_legacy_summary() {
+  local prefix="${1}"
+  local summary="${2}"
+  if [[ "${summary}" != *'⚠️ 2 warnings</summary>'* ]]; then
+    echo "  legacy 'summary' output must include the warnings collapser"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+export input_warning_count="2"
+export input_warnings_markdown_file=$(make_warnings_md multi)
+run_test "Legacy 'summary' output includes warnings collapser" assert_warnings_included_in_legacy_summary
+
+assert_utf8_preserved_at_truncation_boundary() {
+  local prefix="${1}"
+  local summary="${2}"
+  local head="${3}"
+  local plan="${4}"
+  # The plan extract must contain valid UTF-8 throughout. If the tail-cut
+  # lands mid-codepoint without the line-anchored fix, iconv would fail.
+  if ! printf '%s' "${plan}" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+    echo "  plan-extract is not valid UTF-8 (truncation likely cut mid-codepoint)"
+    return 1
+  fi
+  return 0
+}
+reset_defaults
+# A plan file padded with em-dashes (3 bytes each in UTF-8) so a naive
+# tail -c is overwhelmingly likely to cut mid-codepoint.
+_utf8_plan_file=$(mktemp)
+{
+  echo "Terraform used the selected providers to generate the following execution plan"
+  yes "— — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — —" | head -n 1500
+  echo "Plan: 1 to add, 0 to change, 0 to destroy."
+} >"${_utf8_plan_file}"
+export input_plan_txt_output_file="${_utf8_plan_file}"
+export input_plan_count_total="1"
+export input_warning_count="3"
+export input_warnings_markdown_file=$(make_warnings_md default)
+run_test "UTF-8 preserved at truncation boundary" assert_utf8_preserved_at_truncation_boundary
+
+# --------------------------------------------------
 # Summary
 # --------------------------------------------------
 echo ""

--- a/create-validation-summary/step_create_validation_summary.sh
+++ b/create-validation-summary/step_create_validation_summary.sh
@@ -31,6 +31,8 @@
 #   input_plan_count_total     - Sum across categories ('' or '?' = not available; ≥0 numeric otherwise)
 #   input_plan_has_output_only_changes - 'true' when plan changes outputs only (no resource changes)
 #   input_plan_time            - Wall-clock duration of 'terraform plan' formatted as mm:ss (defaults to 'N/A')
+#   input_warning_count        - Total warning count across init+validate+plan (numeric; 0/missing/'?' suppresses the row + collapser)
+#   input_warnings_markdown_file - Path to rendered warnings markdown; appended as a sibling <details> after the plan-block when non-empty
 #   input_job_check_run_id     - The check run ID for the current job
 #
 # Standard GitHub environment variables used:
@@ -81,6 +83,16 @@ function render_head_summary {
 | ✔ | Validate | $(format-status "${input_status_validate}") |
 | 🧹 | TFLint | $(format-status "${input_status_lint}") |
 | 📖 | Plan | $(format-status "${input_status_plan}") |"
+
+    # Warnings row — between Plan and Plan Details. Only when count is a
+    # positive integer; 0 / unset / '?' suppress it (matches the
+    # 'absent when uninteresting' convention used for the per-env head's
+    # plan-details vs plan-time rows). The bodies live in the plan-tag
+    # comment via render_plan_extract; the head only carries the count.
+    if [[ "${input_warning_count:-0}" =~ ^[0-9]+$ ]] && [ "${input_warning_count}" -gt 0 ]; then
+      head="${head}
+| ⚠️ | Warnings | <span title=\"Warnings from init+validate+plan\">⚠️ ${input_warning_count}</span> |"
+    fi
 
     if [ "${input_include_plan_details}" == 'true' ]; then
 
@@ -149,19 +161,99 @@ function render_head_summary {
 #   4. plan-count-total missing/'?'                   → '<details>Show Plan (last 65k characters)…'
 # When plan output is entirely absent, render 'Plan not available 🤷‍♀️'.
 
+# --- helpers used by render_plan_extract ---
+
+# Byte-budgeted tail that always lands on a line boundary. Two motivations:
+#  (a) UTF-8 safety: 'tail -c <N>' can cut mid-codepoint when the file
+#      contains multi-byte chars; the resulting partial-codepoint at the
+#      start of the slice corrupts the rendered comment.
+#  (b) Readability: cutting mid-line leaves a dangling fragment at the
+#      top of the plan block; reviewers see ' ... whatever_var = '.
+# Strategy: 'tail -c <budget>' is byte-safe wrt the total length; piping
+# through 'sed 1d' discards the first (possibly-partial) line, which is
+# always whole bytes since a newline is a single ASCII byte. The result
+# is guaranteed to be line-aligned, slightly under the byte budget.
+# Files smaller than the budget pass through unchanged.
+function line_anchored_tail {
+  local file="$1"
+  local budget="$2"
+  [ "${budget}" -le 0 ] && return 0
+  [ -z "${file}" ] && return 0
+  [ ! -f "${file}" ] && return 0
+  local file_size
+  file_size=$(wc -c <"${file}")
+  if [ "${file_size}" -le "${budget}" ]; then
+    cat "${file}"
+    return
+  fi
+  tail -c "${budget}" "${file}" | sed '1d'
+}
+
+# Reads the warnings markdown file, capping its size at WARN_CAP. Block
+# boundary in our rendered markdown is "\n---\n" between every warning,
+# so we cut at a newline boundary (same UTF-8 trick as line_anchored_tail)
+# and append a clear "(truncated)" footer so reviewers know to look at
+# the job log for the full list. Empty / missing file returns empty.
+function load_warnings_md {
+  local file="$1"
+  local cap="$2"
+  [ -z "${file}" ] && return 0
+  [ ! -s "${file}" ] && return 0
+  local file_size
+  file_size=$(wc -c <"${file}")
+  if [ "${file_size}" -le "${cap}" ]; then
+    cat "${file}"
+    return
+  fi
+  local truncated
+  truncated=$(head -c "${cap}" "${file}")
+  # Strip the partial trailing line (cut may land mid-line).
+  if [[ "${truncated}" == *$'\n'* ]]; then
+    truncated="${truncated%$'\n'*}"
+    truncated="${truncated}"$'\n'
+  fi
+  printf '%s\n_(truncated, warnings exceed %d bytes — see job log)_\n' \
+    "${truncated}" "${cap}"
+}
+
 function render_plan_extract {
   local plan="### Terraform plan for environment: \`${input_environment_name}\`"
 
-  # Cap at 65k characters to fit within GitHub's 65536-byte comment limit
-  # — and, as a side benefit, to keep the value a comfortable distance
-  # under Linux's per-string execve limit (MAX_ARG_STRLEN, 128k on Ubuntu)
-  # in case this variable ever ends up in envp. tail/sed read directly
-  # from disk so the full file is never materialised in shell memory.
+  # GitHub's comment-body limit is 65536; we cap at 65000 to leave headroom
+  # under that AND under Linux's per-string execve limit (MAX_ARG_STRLEN,
+  # 128k on Ubuntu) in case this output ever ends up in envp.
+  # Budget model: warnings have priority over plan extract — when both
+  # can't fit, plan extract is trimmed first. See docs/Plan-warnings.md §5.
+  local HARD_LIMIT=65000
+  local OVERHEAD=500   # headers, <details> wrappers, blank-line separators
+  local WARN_CAP=60000 # warnings get most-but-not-all of the budget
+
+  local warnings_md=""
+  warnings_md=$(load_warnings_md "${input_warnings_markdown_file:-}" "${WARN_CAP}")
+  local warnings_size
+  warnings_size=$(printf '%s' "${warnings_md}" | wc -c)
+
+  local plan_budget=$((HARD_LIMIT - OVERHEAD - warnings_size))
+  [ "${plan_budget}" -lt 0 ] && plan_budget=0
+
+  # Pick the source file for plan output. txt-output-file is the post-
+  # 'terraform show' rendering (cleanest); console file is the raw tee.
+  # For the console file, slice out everything below the "Terraform used
+  # the selected providers…" header so we drop init/refresh noise above.
+  local source_file=""
+  local sliced_console=""
+  if [ -f "${input_plan_txt_output_file:-}" ]; then
+    source_file="${input_plan_txt_output_file}"
+  elif [ -f "${input_plan_console_file:-}" ]; then
+    sliced_console="${RUNNER_TEMP:-/tmp}/plan-sliced-$$.txt"
+    sed -n '/Terraform used the selected providers to generate the following execution/,$p' \
+      "${input_plan_console_file}" >"${sliced_console}"
+    source_file="${sliced_console}"
+  fi
+
   local plan_out=""
-  if [ -f "${input_plan_txt_output_file}" ]; then
-    plan_out=$(tail -c 65000 "${input_plan_txt_output_file}")
-  elif [ -f "${input_plan_console_file}" ]; then
-    plan_out=$(sed -n '/Terraform used the selected providers to generate the following execution/,$p' "${input_plan_console_file}" | tail -c 65000)
+  if [ -n "${source_file}" ] && [ -s "${source_file}" ]; then
+    plan_out=$(line_anchored_tail "${source_file}" "${plan_budget}")
   fi
 
   local total="${input_plan_count_total:-}"
@@ -206,6 +298,24 @@ ${plan_out}
 \`\`\`
 </details>"
   fi
+
+  # Warnings collapser — sibling of the plan-block, appended after it.
+  # Rendered regardless of plan-block shape, including 'no changes ✅' —
+  # warnings are interesting even when the plan itself is.
+  if [ -n "${warnings_md}" ]; then
+    local warning_count="${input_warning_count:-0}"
+    [[ "${warning_count}" =~ ^[0-9]+$ ]] || warning_count=0
+    # don't touch the indenting here
+    plan="${plan}
+
+<details><summary>⚠️ ${warning_count} warnings</summary>
+
+${warnings_md}
+</details>"
+  fi
+
+  # Clean up the per-call temp slice if we made one.
+  [ -n "${sliced_console}" ] && [ -f "${sliced_console}" ] && rm -f "${sliced_console}"
 
   printf '%s' "${plan}"
 }

--- a/create-validation-summary/step_create_validation_summary.sh
+++ b/create-validation-summary/step_create_validation_summary.sh
@@ -59,6 +59,15 @@ source "${GITHUB_ACTION_PATH}/helpers.sh"
 # In grouped mode (input_pr_comment_group non-empty), the validation table
 # is omitted — it lives on the per-group head posted by
 # aggregate-validation-summaries.
+#
+# Kept in sync with the grouped head (aggregate-validation-summaries'
+# render_group_body): same row set, labels, col-1 icon tooltips (via
+# _render_step_icon_cell), and Plan-details / Plan-time / Warnings cell
+# conventions and row-presence rules. Two differences are intentional, not
+# drift: (1) step-status cells here use text (`success` / <kbd>failure</kbd>
+# via format-status) vs emoji in the grouped head — a column-width
+# adaptation; (2) the header shape and footer scope differ. See
+# docs/Workflow-pr-comments.md §5.1/§5.3.
 
 function render_head_summary {
   local job_url="${1}"
@@ -77,28 +86,34 @@ function render_head_summary {
     head="${head}
 |  | Step | Result |
 |:---:|---|---|
-| ⚙️ | Initialization | $(format-status "${input_status_init}") |
-| 🔒 | Lock file | $(format-status "${input_status_verify_lock}") |
-| 🖌 | Format and Style | $(format-status "${input_status_fmt}") |
-| ✔ | Validate | $(format-status "${input_status_validate}") |
-| 🧹 | TFLint | $(format-status "${input_status_lint}") |
-| 📖 | Plan | $(format-status "${input_status_plan}") |"
+| $(_render_step_icon_cell "⚙️" "Initialization") | Initialization | $(format-status "${input_status_init}") |
+| $(_render_step_icon_cell "🔒" "Lock file") | Lock file | $(format-status "${input_status_verify_lock}") |
+| $(_render_step_icon_cell "🖌" "Format and Style") | Format and Style | $(format-status "${input_status_fmt}") |
+| $(_render_step_icon_cell "✔" "Validate") | Validate | $(format-status "${input_status_validate}") |
+| $(_render_step_icon_cell "🧹" "TFLint") | TFLint | $(format-status "${input_status_lint}") |
+| $(_render_step_icon_cell "📖" "Plan") | Plan | $(format-status "${input_status_plan}") |"
 
-    # Warnings row — between Plan and Plan Details. Only when count is a
+    # Warnings row — between Plan and Plan details. Only when count is a
     # positive integer; 0 / unset / '?' suppress it (matches the
     # 'absent when uninteresting' convention used for the per-env head's
-    # plan-details vs plan-time rows). The bodies live in the plan-tag
-    # comment via render_plan_extract; the head only carries the count.
+    # plan-details vs plan-time rows, and the grouped head's Warnings row).
+    # The bodies live in the plan-tag comment via render_plan_extract; the
+    # head only carries the count.
     if [[ "${input_warning_count:-0}" =~ ^[0-9]+$ ]] && [ "${input_warning_count}" -gt 0 ]; then
       head="${head}
-| ⚠️ | Warnings | <span title=\"Warnings from init+validate+plan\">⚠️ ${input_warning_count}</span> |"
+| $(_render_step_icon_cell "⚠️" "Warnings") | Warnings | <span title=\"Warnings from init+validate+plan\">⚠️ ${input_warning_count}</span> |"
     fi
 
     if [ "${input_include_plan_details}" == 'true' ]; then
 
+      # Cell wrapped in <div align="left"> to match the grouped head's
+      # Plan-details cell byte-for-byte (the grouped table's columns are
+      # center-aligned and need the div to anchor the badge stack left; the
+      # per-env Result column is already left-aligned so it's a visual
+      # no-op, but kept identical for sync).
       # don't touch the indenting here
       head="${head}
-| 📊 | Plan Details | <span title=\"Resources to be added\">\`💫 ${input_plan_count_add}\` add</span><br><span title=\"Resources to be changed\">\`🛠️ ${input_plan_count_change}\` change</span><br><span title=\"Resources to be destroyed\">\`💥 ${input_plan_count_destroy}\` destroy</span>"
+| $(_render_step_icon_cell "📊" "Plan details") | Plan details | <div align=\"left\"><span title=\"Resources to be added\">\`💫 ${input_plan_count_add}\` add</span><br><span title=\"Resources to be changed\">\`🛠️ ${input_plan_count_change}\` change</span><br><span title=\"Resources to be destroyed\">\`💥 ${input_plan_count_destroy}\` destroy</span>"
 
       if [ "${input_plan_count_move}" != '0' ]; then
         head="${head}<br><span title=\"Resources to be moved\">\`🔀 ${input_plan_count_move}\` move</span>"
@@ -110,13 +125,23 @@ function render_head_summary {
         head="${head}<br><span title=\"Resources to be removed\">\`⛓️‍💥 ${input_plan_count_remove}\` remove</span>"
       fi
 
-      head="${head} |"
+      head="${head}</div> |"
     fi
 
-    # Plan time row — same shape as before.
+    # Plan time row. Default is the em-dash '—' (not backtick-wrapped),
+    # matching the grouped head's _render_plan_time_cell: a real duration is
+    # backtick-wrapped, an absent/N-A one renders as '—'. The action.yml
+    # input default is the literal 'N/A', so treat both empty and 'N/A' as
+    # absent here.
     # don't touch the indenting here
+    local plan_time_cell
+    if [ -z "${input_plan_time:-}" ] || [ "${input_plan_time}" = 'N/A' ]; then
+      plan_time_cell="<span title=\"mm:ss (minutes:seconds)\">—</span>"
+    else
+      plan_time_cell="<span title=\"mm:ss (minutes:seconds)\">\`${input_plan_time}\`</span>"
+    fi
     head="${head}
-| ⏱ | Plan time | <span title=\"mm:ss (minutes:seconds)\">\`${input_plan_time:-N/A}\`</span> |"
+| $(_render_step_icon_cell "⏱" "Plan time") | Plan time | ${plan_time_cell} |"
 
     # Links row — only rendered when the caller supplied
     # plan-tag-comment-id (typically the id of this run's per-env plan tag,
@@ -128,7 +153,7 @@ function render_head_summary {
     if [ -n "${input_plan_tag_comment_id:-}" ]; then
       # don't touch the indenting here
       head="${head}
-| 🔗 | Links | [log extract](#issuecomment-${input_plan_tag_comment_id})<br>[job log](${job_url}) |"
+| $(_render_step_icon_cell "🔗" "Links") | Links | [log extract](#issuecomment-${input_plan_tag_comment_id})<br>[job log](${job_url}) |"
     fi
   fi
 

--- a/docs/Action-implementation-guide.md
+++ b/docs/Action-implementation-guide.md
@@ -195,7 +195,7 @@ For inputs that are simple strings, pass them as environment variables. Use `set
 
 ### Step shim pattern — JSON inputs
 
-JSON values passed from GitHub Actions expressions can contain special characters that break normal variable assignment. Use heredocs. The `set -o allexport` pattern still applies:
+JSON values passed from GitHub Actions expressions can contain special characters that break normal variable assignment. Use heredocs. **Do NOT `export` the heredoc-captured variable** — the step script is `source`d in the same shell and reads it as a shell-local, so it never needs to be in envp. Exporting it would push the JSON into envp for every subsequent fork and risk an ARG_MAX crash on big inputs — see [Anti-pattern: exporting heredoc-captured JSON](#anti-pattern-exporting-heredoc-captured-json) below for the full rationale.
 
 ```yaml
 - id: my-step
@@ -203,17 +203,18 @@ JSON values passed from GitHub Actions expressions can contain special character
   env:
     input_simple_var: ${{ inputs.simple-var }}
   run: |
-    # JSON inputs require special handling (heredocs)
+    # Heredoc capture (special chars survive verbatim). Intentionally NOT
+    # exported — step_my_step.sh reads it as a shell-local via `source`.
     input_json_data=$(cat <<'EOF'
     ${{ inputs.json-data }}
     EOF
     )
 
-    export input_json_data
-
     set -o allexport
     source "${{ github.action_path }}/step_my_step.sh"
 ```
+
+> Note the order: the heredoc capture happens **before** `set -o allexport`. That keeps `input_json_data` from being auto-exported. Variables set later by the step script (under allexport) still get the export attribute, which is what allexport is there for.
 
 ### Naming convention for step IDs
 
@@ -556,6 +557,70 @@ main
 _main_exit_code=$?
 exit ${_main_exit_code}
 ```
+
+---
+
+## Anti-pattern: exporting heredoc-captured JSON
+
+**Don't do this:**
+
+```yaml
+run: |
+  input_json_data=$(cat <<'EOF'
+  ${{ inputs.json-data }}
+  EOF
+  )
+  export input_json_data           # ← anti-pattern
+  source "${{ github.action_path }}/step_my_step.sh"
+```
+
+Equally bad — capturing under allexport:
+
+```yaml
+run: |
+  set -o allexport
+  input_json_data=$(cat <<'EOF'    # ← variables created under allexport are auto-exported
+  ${{ inputs.json-data }}
+  EOF
+  )
+  source "${{ github.action_path }}/step_my_step.sh"
+```
+
+### Why it breaks
+
+Under either form, `input_json_data` is in the shell's exported-variable set. At the next `fork+execve` — any time the step calls `jq`, `gh`, `terraform`, or any other external command — bash builds `envp` from the exported set. Linux enforces two limits on `envp`:
+
+- `ARG_MAX` (~2 MB total across argv + envp), and
+- `MAX_ARG_STRLEN` (128 KB per individual string on Ubuntu).
+
+The 128 KB per-string limit is the closer one in practice — a single big JSON input (a long PR body in `github.event`, a 65 KB plan extract, the full `toJSON(steps)` for a busy matrix job) trips it. The fork fails with exit 126 "Argument list too long". The original step looks like it succeeded; whatever it forks dies. The bug is **size-dependent**, so it doesn't appear in tests and only surfaces in production on a calling repo with a big-enough input.
+
+### Why it bites repeatedly
+
+The pattern looks reasonable: the script is sourced from the shim, so why wouldn't you "make sure" the variable is visible by exporting it? But sourcing a script means it runs in the **same shell** — the script already sees the caller's variable table without `export`. The `export` only changes what reaches forked subprocesses, which is exactly where the danger lives. Once you internalize "source sees locals" the temptation to `export` evaporates.
+
+This repo has been bitten by this exact bug multiple times: `capture-matrix-job-meta` (steps context with embedded plan extracts), `aggregate-validation-summaries` (paginated `gh api` responses), `pr-comment` (user-supplied comment body), `auto-merge-pr` (`github.event` JSON on PRs with long descriptions). Each fix was a one-line removal of the `export` (plus, in the more sophisticated cases, an internal switch from `--argjson` to `--slurpfile` for jq). Reference implementations are in the corresponding action directories.
+
+### The safe pattern (recap)
+
+```yaml
+run: |
+  # Heredoc capture, NOT exported.
+  input_json_data=$(cat <<'EOF'
+  ${{ inputs.json-data }}
+  EOF
+  )
+
+  # set -o allexport AFTER the heredoc so this variable isn't auto-exported.
+  set -o allexport
+  source "${{ github.action_path }}/step_my_step.sh"
+```
+
+Inside the step script: read `${input_json_data}` directly, or — if it might be very large and needs to be passed to a forked tool — write it to a tempfile and pass the path (`jq --slurpfile`, `gh api -F body=@<file>`, etc). See [CLAUDE.md → "Watch for ARG_MAX in step scripts"](../CLAUDE.md) for the in-tree reference patterns.
+
+### When to actually export
+
+`export FOO=value` is correct when you need an external command (e.g., `terraform`) to see `FOO` via the environment. In that case the data is bounded (a directory path, a flag, a token) and won't trip ARG_MAX. The anti-pattern is specifically about exporting **large user-supplied content** that the step only reads.
 
 ---
 

--- a/docs/Plan-warnings.md
+++ b/docs/Plan-warnings.md
@@ -198,13 +198,13 @@ The collapser is absent when warning-count is 0 — no empty `<details>`.
 
 ### Per-group head (§5.3)
 
-A new `⚠️ Warnings` row is added to the grouped table, positioned between the step rows and the `📊 Plan details` row:
+A `⚠️ Warnings` row is added to the grouped table, positioned between the step rows and the `📊 Plan details` row:
 
 ```markdown
 | <span title="Warnings">⚠️</span> | Warnings | ⚠️ 3 | — | ⚠️ 1 |
 ```
 
-Cell content: `⚠️ N` when `N > 0`, em-dash `—` when 0 or empty. Mirrors `Plan time`'s empty-state convention rather than `Plan details`' "always render" convention — warnings absence is "not interesting" not "not applicable".
+The whole row is **omitted** when no env in the group has warnings — keeping ⚠️ a signal rather than a permanent fixture, and matching the per-env head which also suppresses the row at zero. When the row *is* shown (at least one env has warnings), each cell is `⚠️ N` for envs with warnings and em-dash `—` for the clean envs. Both warning surfaces (per-env head row + per-env plan-tag collapser) were already conditional; this aligns the grouped table with them.
 
 ## 7. Test scenarios
 
@@ -235,8 +235,9 @@ Per-action test suites (under `<action>/run_all_tests.sh`) cover:
 `aggregate-validation-summaries/` test additions:
 
 - Per-env meta files with varying warning counts render grouped table cells correctly.
-- Mixed envs (some with warnings, some without).
-- All-zero row still rendered with `—` cells (consistent shape).
+- Mixed envs (some with warnings, some without) — row shown, clean envs render `—`.
+- All-zero group → whole Warnings row omitted (and likewise when no parse-warnings step entries are present at all).
+- Plan details row omitted when no env in the group has plan data.
 - Sum across init/validate/plan step ids when some are missing/zero in meta.
 
 ## 8. ARG_MAX caveat

--- a/docs/Plan-warnings.md
+++ b/docs/Plan-warnings.md
@@ -1,0 +1,252 @@
+# Plan warnings on PRs
+
+Authoritative spec for how `terraform` `Warning:` diagnostics flow from `init` / `validate` / `plan` to the PR conversation and the GitHub run-page UI.
+
+Out of scope: errors (the existing `🧐 Validation outcome` steps already surface them), `tflint` warnings (separate tool, separate shape), force-unlock remediation hints (attached to `Error:` blocks, not `Warning:`).
+
+## 1. Why
+
+Terraform's `Warning:` diagnostics — deprecation notices, soft state-drift warnings, provider-level advisories — appear today only in the raw job log. Reviewers reading the PR conversation never see them, and nothing draws the eye in the GitHub UI. Deprecations harden into errors months later when the provider does a major release; the moment to act was when the warning first fired.
+
+Goal: warnings are first-class on the PR. They're counted in the summary table, listed in a collapsible block under the plan extract, and emitted as `::warning` annotations so they appear inline in the Files-changed view next to the offending source line where context is available.
+
+## 2. Data flow
+
+```text
+                         ┌─────────────────────────────────────┐
+                         │  terraform-init                     │
+                         │   tees stdout/stderr →              │
+   each step             │   tf-init-console-output-<env>.txt  │
+   captures its          └────────────┬────────────────────────┘
+   own console                        │
+                         ┌─────────────────────────────────────┐
+                         │  terraform-validate                 │
+                         │   tees → tf-validate-console-…txt   │
+                         └────────────┬────────────────────────┘
+                                      │
+                         ┌─────────────────────────────────────┐
+                         │  terraform-plan                     │
+                         │   tees → tf-plan-console-output…txt │
+                         └────────────┬────────────────────────┘
+                                      │
+                  ┌───────────────────▼─────────────────────────┐
+                  │  parse-terraform-warnings (×3 per env)      │
+   one call per   │   inputs: console-output-file, step-label   │
+   step gets its  │   outputs: warning-count                    │
+   own annotation │            warnings-markdown-file           │
+   budget         │   side effect: emit ::warning::…            │
+                  └───────────────────┬─────────────────────────┘
+                                      │
+                  ┌───────────────────▼──────────┐
+                  │  concat-warnings-md          │
+                  │   inline step concatenates   │
+                  │   the three .md files in     │
+                  │   init→validate→plan order   │
+                  └───────────────────┬──────────┘
+                                      │
+            ┌─────────────────────────┴──────────────────┐
+            ▼                                            ▼
+┌──────────────────────────┐               ┌────────────────────────────┐
+│ create-validation-summary│               │  capture-matrix-job-meta   │
+│  inputs: warning-count,  │               │   (no code change — picks  │
+│   warnings-markdown-file │               │   up new step outputs via  │
+│  renders ⚠️ Warnings row │               │   toJSON(steps) automatically) │
+│  + warnings collapser    │               └─────────────┬──────────────┘
+└──────────────────────────┘                             │
+                                                         ▼
+                                       ┌─────────────────────────────────┐
+                                       │  aggregate-validation-summaries │
+                                       │   sums per-env warning counts   │
+                                       │   across three step ids,        │
+                                       │   renders grouped-table ⚠️ row  │
+                                       └─────────────────────────────────┘
+```
+
+## 3. Warning-block grammar
+
+What `parse-terraform-warnings` recognises as a warning:
+
+```
+^Warning: <title>\n
+\n
+  on <file> line <N>, in <resource>:\n            ← optional context block
+   <line>: <code-excerpt>\n
+\n
+<message body — one or more wrapped lines>\n
+\n
+(and N more similar warnings elsewhere)\n         ← optional aggregator suffix
+```
+
+The parser uses a state machine:
+
+- **Outside-block** → **Inside-block** on a line matching `^Warning: ` (note trailing space; `Warning:Foo` is not a diagnostic header in terraform's output).
+- **Inside-block** → **Outside-block** on EOF, on the next `^Warning: ` / `^Error: ` / `^Plan: ` line, or on a blank line followed by a non-indented non-empty line that isn't itself a `(and N more …)` suffix.
+
+For each block extract:
+
+| Field | Source |
+|---|---|
+| `title` | text after `Warning: ` on the header line |
+| `source_file`, `source_line` | first `^\s*on (?P<file>.+) line (?P<line>\d+)` line in the block; absent when terraform's warning isn't anchored to a file (e.g. provider-level deprecation) |
+| `message` | remaining non-context body lines, leading/trailing whitespace trimmed, internal blank lines collapsed |
+| `suppressed_count` | `N` from `(and (?P<n>\d+) more similar warnings elsewhere)` if present |
+
+**`warning-count`** is the sum of `(1 + suppressed_count)` across all blocks — so when terraform shows one block with `(and 2 more)`, the count is `3`. This matches what reviewers expect ("there are N warnings in this plan").
+
+Annotations are emitted once per block (terraform only prints file/line for the shown example; the suppressed N have no available context).
+
+## 4. Annotation format
+
+GitHub workflow-command shape:
+
+```
+::warning file=<rel-path>,line=<n>,title=<title>::<message>
+```
+
+With fallback when source context is missing:
+
+```
+::warning title=<title>::<message>
+```
+
+Escaping rules ([GitHub docs — workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)):
+
+- `%` → `%25`
+- `\r` → `%0D`
+- `\n` → `%0A`
+- `:` → `%3A` (in title/file attribute values only)
+- `,` → `%2C` (in title/file attribute values only)
+
+Paths are kept as-printed by terraform (relative to the terraform working directory). GitHub resolves them against the repo root for inline-annotation placement; when the working directory isn't the repo root the annotation still appears in the right-side run panel but doesn't anchor inline. Acceptable — anchoring is a bonus, not the contract.
+
+GitHub silently dedupes identical annotations and caps each step at 10 warning annotations. Per-step extraction (one call after init, validate, plan) gives each its own 10 budget, so a noisy init no longer crowds out plan warnings.
+
+## 5. 65k budgeting algorithm
+
+The PR-comment body limit is 65536 chars. Warnings have priority over plan output: if the budget is tight, the plan extract gets trimmed first.
+
+```
+OVERHEAD     = 500          # H3 headers + <details> wrappers + blank lines
+HARD_LIMIT   = 65000        # leave 536 chars headroom under 65536
+WARN_CAP     = 60000        # warnings get most-but-not-all of the budget
+
+warnings_md  = read warnings file (empty string if missing or 0 warnings)
+
+if size(warnings_md) > WARN_CAP:
+  # Drop trailing complete '---'-separated blocks until size <= WARN_CAP.
+  # Block-level truncation keeps the visible warnings readable; we never
+  # show a half-rendered diagnostic.
+  warnings_md = drop_trailing_blocks(warnings_md, until=WARN_CAP)
+  warnings_md += "\n\n_(truncated, N more warnings — see job log)_"
+
+plan_budget  = max(0, HARD_LIMIT - OVERHEAD - size(warnings_md))
+plan_extract = line_anchored_tail(plan_file, plan_budget)
+```
+
+`line_anchored_tail` is **not** `tail -c <budget>` — that cut can land mid-UTF-8 and corrupt the comment. Implementation: read the file, accumulate lines from the end while `size(buf) + size(next_line) + 1 ≤ budget`, then emit in order. This also fixes a latent UTF-8 truncation in `create-validation-summary/step_create_validation_summary.sh:162` that pre-dates this feature.
+
+Edge cases:
+
+- **`warnings_md` empty**: warnings collapser not rendered at all. The combined body is plan-block-only, identical to today's output.
+- **`plan_budget` floors to 0**: plan-extract renders as an empty code fence inside the existing collapser; the warnings collapser carries the full diagnostic.
+- **Both empty**: existing `Plan not available 🤷‍♀️` fallback in `render_plan_extract`.
+
+## 6. Comment-shape integration
+
+This feature extends [Workflow-pr-comments.md §5.1 and §5.2](Workflow-pr-comments.md#51-per-env-head) — it does not replace any existing shape.
+
+### Per-env head (§5.1)
+
+A new `⚠️ Warnings` row is inserted **between** the `📖 Plan` row and the `📊 Plan Details` row, rendered only when `warning-count > 0`:
+
+```markdown
+| ⚠️ | Warnings | <span title="Warnings from init+validate+plan">⚠️ 3</span> |
+```
+
+The row is absent when count is 0, missing, or `?` — consistent with the existing "absent when not interesting" convention for the Plan Details row.
+
+### Per-env plan tag (§5.2)
+
+A new `<details>` collapser is appended **after** the existing plan-block. It is not a sixth `<plan-block>` shape — the plan-block and warnings-block are siblings:
+
+```markdown
+### Terraform plan for environment: `<env>`
+
+<plan-block>             ← existing five shapes, unchanged
+
+<details><summary>⚠️ 3 warnings</summary>
+
+### From terraform init
+**Warning: Deprecated attribute**
+- source: `.terraform/modules/foo/main.tf:176`
+
+> The attribute "vm_agent_platform_updates_enabled" is deprecated. Refer to the
+> provider documentation for details.
+
+---
+
+### From terraform plan
+**Warning: Argument is deprecated**
+- (and 2 more similar warnings elsewhere)
+
+> This property has been renamed to `rbac_authorization_enabled`...
+
+</details>
+```
+
+The collapser is absent when warning-count is 0 — no empty `<details>`.
+
+### Per-group head (§5.3)
+
+A new `⚠️ Warnings` row is added to the grouped table, positioned between the step rows and the `📊 Plan details` row:
+
+```markdown
+| <span title="Warnings">⚠️</span> | Warnings | ⚠️ 3 | — | ⚠️ 1 |
+```
+
+Cell content: `⚠️ N` when `N > 0`, em-dash `—` when 0 or empty. Mirrors `Plan time`'s empty-state convention rather than `Plan details`' "always render" convention — warnings absence is "not interesting" not "not applicable".
+
+## 7. Test scenarios
+
+Per-action test suites (under `<action>/run_all_tests.sh`) cover:
+
+`parse-terraform-warnings/`:
+
+| Fixture | Expectation |
+|---|---|
+| `t01_no_warnings.log` | clean plan output; `warning-count=0`; markdown file empty (or absent) |
+| `t02_single_warning_with_context.log` | one block with `on <file> line <N>`; 1 annotation with `file=`/`line=`; count=1 |
+| `t03_single_warning_no_context.log` | one block without source context; 1 fallback annotation (no `file=`/`line=`); count=1 |
+| `t04_aggregator_suppression.log` | block with `(and 2 more similar warnings elsewhere)`; count=3; 1 annotation |
+| `t05_multiple_blocks.log` | three distinct categories; 3 annotations; correct sum |
+| `t06_warning_then_error.log` | `Warning:` followed by `Error:`; error doesn't bleed into warning body |
+| `t07_non_ascii_message.log` | UTF-8 in body; markdown is valid UTF-8; annotation message round-trips |
+| `t08_empty_file.log` | empty file; count=0; no crash |
+| `t09_init_provider_deprecation.log` | real-shape init log with provider warning at top level |
+
+`create-validation-summary/` test additions:
+
+- Warnings row appears with count > 0; absent with count = 0 / unset / `?`.
+- Warnings collapser appended after plan-block; absent when warnings markdown file empty.
+- Combined body stays under 65000 bytes for: small warnings + huge plan; huge warnings + small plan; both huge (warnings preserved, plan trimmed).
+- UTF-8 boundary preserved (warning body with multi-byte char near the cut point).
+- Legacy `summary` output includes warnings collapser.
+
+`aggregate-validation-summaries/` test additions:
+
+- Per-env meta files with varying warning counts render grouped table cells correctly.
+- Mixed envs (some with warnings, some without).
+- All-zero row still rendered with `—` cells (consistent shape).
+- Sum across init/validate/plan step ids when some are missing/zero in meta.
+
+## 8. ARG_MAX caveat
+
+`capture-matrix-job-meta` captures every step's outputs via `toJSON(steps)` ([capture-matrix-job-meta/action.yml:64-71](../capture-matrix-job-meta/action.yml)). A prior incident documented in that file: when `plan-extract` (~65k) was exported into the environment, the next fork's envp blew past `ARG_MAX` and the metadata-capture step died with `E2BIG`.
+
+Constraint for this feature: **never expose warnings-markdown *content* as a step output.** Only paths and small integers go through step outputs. The warnings markdown lives in `${GITHUB_WORKSPACE}/tf-warnings-<env>-<step>.md` and is referenced by path; `create-validation-summary` reads the file from disk, never from env.
+
+## 9. Out of scope / follow-ups
+
+- Force-unlock remediation hints. They attach to `Error:` blocks (and look like multi-line shell snippets, not `Warning:` diagnostics) — would need a separate parser.
+- Warnings from `tflint` and other non-terraform-CLI tools. Their output formats differ; if surfacing them is wanted later, add per-tool parsers and one more `parse-*-warnings` invocation per env.
+- Audit the rest of the codebase for `tail -c` cuts that could land mid-UTF-8. This feature fixes only the one site it touches.

--- a/docs/Plan-warnings.md
+++ b/docs/Plan-warnings.md
@@ -12,54 +12,20 @@ Goal: warnings are first-class on the PR. They're counted in the summary table, 
 
 ## 2. Data flow
 
-```text
-                         ┌─────────────────────────────────────┐
-                         │  terraform-init                     │
-                         │   tees stdout/stderr →              │
-   each step             │   tf-init-console-output-<env>.txt  │
-   captures its          └────────────┬────────────────────────┘
-   own console                        │
-                         ┌─────────────────────────────────────┐
-                         │  terraform-validate                 │
-                         │   tees → tf-validate-console-…txt   │
-                         └────────────┬────────────────────────┘
-                                      │
-                         ┌─────────────────────────────────────┐
-                         │  terraform-plan                     │
-                         │   tees → tf-plan-console-output…txt │
-                         └────────────┬────────────────────────┘
-                                      │
-                  ┌───────────────────▼─────────────────────────┐
-                  │  parse-terraform-warnings (×3 per env)      │
-   one call per   │   inputs: console-output-file, step-label   │
-   step gets its  │   outputs: warning-count                    │
-   own annotation │            warnings-markdown-file           │
-   budget         │   side effect: emit ::warning::…            │
-                  └───────────────────┬─────────────────────────┘
-                                      │
-                  ┌───────────────────▼──────────┐
-                  │  concat-warnings-md          │
-                  │   inline step concatenates   │
-                  │   the three .md files in     │
-                  │   init→validate→plan order   │
-                  └───────────────────┬──────────┘
-                                      │
-            ┌─────────────────────────┴──────────────────┐
-            ▼                                            ▼
-┌──────────────────────────┐               ┌────────────────────────────┐
-│ create-validation-summary│               │  capture-matrix-job-meta   │
-│  inputs: warning-count,  │               │   (no code change — picks  │
-│   warnings-markdown-file │               │   up new step outputs via  │
-│  renders ⚠️ Warnings row │               │   toJSON(steps) automatically) │
-│  + warnings collapser    │               └─────────────┬──────────────┘
-└──────────────────────────┘                             │
-                                                         ▼
-                                       ┌─────────────────────────────────┐
-                                       │  aggregate-validation-summaries │
-                                       │   sums per-env warning counts   │
-                                       │   across three step ids,        │
-                                       │   renders grouped-table ⚠️ row  │
-                                       └─────────────────────────────────┘
+```mermaid
+flowchart TD
+    init["terraform-init<br>tees stdout/stderr to<br>tf-init-console-output-ENV.txt"]
+    validate["terraform-validate<br>tees to tf-validate-console-...txt"]
+    plan["terraform-plan<br>tees to tf-plan-console-output...txt"]
+    parse["parse-terraform-warnings (x3 per env)<br>inputs - console-output-file, step-label<br>outputs - warning-count, warnings-markdown-file<br>side effect - emits ::warning:: annotations"]
+    concat["concat-warnings-md<br>inline step concatenates the three .md files<br>in init then validate then plan order"]
+    summary["create-validation-summary<br>inputs - warning-count, warnings-markdown-file<br>renders Warnings row plus warnings collapser"]
+    capture["capture-matrix-job-meta<br>no code change - picks up new step outputs<br>via toJSON of steps automatically"]
+    aggregate["aggregate-validation-summaries<br>sums per-env warning counts across three step ids<br>renders grouped-table Warnings row"]
+
+    init --> validate --> plan --> parse --> concat
+    concat --> summary
+    concat --> capture --> aggregate
 ```
 
 ## 3. Warning-block grammar

--- a/docs/Testing-in-ci.md
+++ b/docs/Testing-in-ci.md
@@ -25,9 +25,11 @@ Out of scope: the test suites themselves (their layout is described in [Action-i
 
 Four jobs, in this order:
 
-```text
-discover  ─►  test (matrix, fan-out)  ─►  summary  ─►  tests-conclusion
-                                          (PR comment)   (required check)
+```mermaid
+flowchart LR
+    discover --> test["test - matrix fan-out"]
+    test --> summary["summary - PR comment"]
+    summary --> conclusion["tests-conclusion - required check"]
 ```
 
 ### 2.1 `discover`

--- a/docs/Workflow-pr-comments.md
+++ b/docs/Workflow-pr-comments.md
@@ -131,6 +131,8 @@ Status cells: `` `success` `` for successful steps, `<kbd>failure</kbd>` / `<kbd
 
 Plan time row is always emitted in ungrouped mode. Renders the upstream `terraform-plan@v0` `plan-time` output as `` `mm:ss` `` inside `<span title="mm:ss (minutes:seconds)">`; the tooltip surfaces the unit on desktop hover. Defaults to `N/A` when the upstream action didn't supply a value.
 
+Warnings row is rendered between `📖 Plan` and `📊 Plan Details` when `warning-count > 0`. Shape: `| ⚠️ | Warnings | <span title="Warnings from init+validate+plan">⚠️ N</span> |`. Absent when count is 0, missing, or `?`. The warning bodies live in the plan-tag comment (§5.2), not the head. See [Plan-warnings.md](Plan-warnings.md).
+
 Plan Details row is rendered only when `include-plan-details=true`. Shape:
 
 ```markdown
@@ -161,6 +163,8 @@ When `pr-comment-group` is non-empty, the env has **no per-env head at all** —
 
 All `<details>` shapes wrap the plan text in a `` ```terraform `` code fence. The plan text is capped at 65000 characters (tail-trimmed) to stay under GitHub's 65536-char comment limit.
 
+When `warning-count > 0`, a sibling `<details><summary>⚠️ N warnings</summary>…</details>` collapser is appended after the `<plan-block>` inside the same plan-tag comment. The two collapsers are siblings, not nested; the warnings collapser is **not** a sixth `<plan-block>` shape. See [Plan-warnings.md §5–§6](Plan-warnings.md) for the budgeting algorithm (warnings have priority over plan output when the combined body would exceed 65000 chars) and the rendered shape.
+
 ### 5.3 Per-group head
 
 The rolled-up grouped table aggregates every env in the group (alphabetical column order):
@@ -185,6 +189,8 @@ The rolled-up grouped table aggregates every env in the group (alphabetical colu
 Status cells map outcomes to emoji + tooltip: ✅ / ❌ / 🚫 / ⏭️ / — (empty outcome).
 
 Plan Details cells stack the count badges in a `<div align="left">` so they anchor left in the otherwise center-aligned column. The badges (`💫 N add`, `🛠️ N change`, `💥 N destroy`) always render; `🔀 move`, `📥 import`, `⛓️‍💥 remove` are appended only when non-zero.
+
+Warnings row is rendered between the step rows and `📊 Plan details`. Cell: `⚠️ N` when `N > 0`, em-dash `—` when 0 or empty. Mirrors Plan time's empty-state convention rather than Plan details' "always render" — warnings absence is "not interesting" not "not applicable". See [Plan-warnings.md](Plan-warnings.md).
 
 Plan time cells: backtick-wrapped `mm:ss` when present, em-dash `—` when missing. Both wrapped in `<span title="mm:ss (minutes:seconds)">` so desktop hover surfaces the unit.
 

--- a/docs/Workflow-pr-comments.md
+++ b/docs/Workflow-pr-comments.md
@@ -32,31 +32,14 @@ Markers are treated as opaque substrings by the underlying actions: matching is 
 
 ## 3. Lifecycle of a single workflow run
 
-```text
-                          ┌──────────────────────────────────────────────┐
-                          │  Seed phase (top of workflow, before matrix) │
-                          │                                              │
-   create-matrix ───────► │  seed-pr-comments job:                       │
-                          │   - reconcile heads (POST/PATCH per marker)  │
-                          │   - (heads only; plan-tag GC lives in the    │
-                          │      matrix, see §3.2)                       │
-                          └─────────────────┬────────────────────────────┘
-                                            │
-                          ┌─────────────────▼────────────────────────────┐
-                          │  Matrix jobs (parallel, one per env)         │
-                          │                                              │
-                          │   - DELETE prior `tf:tag:plan:<env>:*`       │
-                          │   - PATCH `tf:head:env:<env>` with results   │
-                          │   - POST `tf:tag:plan:<env>:run-id-<id>:`    │
-                          │     `attempt-<n>` with fresh plan-extract    │
-                          └─────────────────┬────────────────────────────┘
-                                            │
-                          ┌─────────────────▼────────────────────────────┐
-                          │  Aggregator job (after matrix)               │
-                          │                                              │
-                          │   - PATCH each `tf:head:group:<group>` head  │
-                          │     with the rolled-up grouped table         │
-                          └──────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    cm["create-matrix"]
+    seed["Seed phase - top of workflow, before matrix<br>seed-pr-comments job<br>- reconcile heads, POST or PATCH per marker<br>- heads only; plan-tag GC lives in the matrix, see section 3.2"]
+    matrix["Matrix jobs - parallel, one per env<br>- DELETE prior tf-tag-plan-ENV-star<br>- PATCH tf-head-env-ENV with results<br>- POST tf-tag-plan-ENV-run-id-ID-attempt-N with fresh plan-extract"]
+    agg["Aggregator job - after matrix<br>- PATCH each tf-head-group-GROUP head with the rolled-up grouped table"]
+
+    cm --> seed --> matrix --> agg
 ```
 
 ### 3.1 Seed phase
@@ -219,20 +202,22 @@ Required token permission: `pull-requests: write` (and `issues: write` if the co
 
 On a fresh PR (run #1), the seed job POSTs in declared order, so the conversation timeline becomes:
 
-```text
-↑ older                                              ↓ newer
-┌──────────────────────────────────────────────────────────┐
-│  tf:head:group:<group-1>      (group summary head)       │
-│  tf:head:group:<group-2>      (group summary head)       │
-│  …                                                       │
-│  tf:head:env:<env-a>          (per-env head)             │
-│  tf:head:env:<env-b>          (per-env head)             │
-│  …                                                       │
-│  tf:tag:plan:<env-a>:run-id-N:attempt-1 (plan extract)   │
-│  tf:tag:plan:<env-b>:run-id-N:attempt-1 (plan extract)   │
-│  …                                                       │
-│  <human reviewer comments interleaved chronologically>   │
-└──────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    older(["older"])
+    g1["tf-head-group-GROUP-1 - group summary head"]
+    g2["tf-head-group-GROUP-2 - group summary head"]
+    gDots["..."]
+    e1["tf-head-env-ENV-a - per-env head"]
+    e2["tf-head-env-ENV-b - per-env head"]
+    eDots["..."]
+    p1["tf-tag-plan-ENV-a-run-id-N-attempt-1 - plan extract"]
+    p2["tf-tag-plan-ENV-b-run-id-N-attempt-1 - plan extract"]
+    pDots["..."]
+    human["human reviewer comments interleaved chronologically"]
+    newer(["newer"])
+
+    older --> g1 --> g2 --> gDots --> e1 --> e2 --> eDots --> p1 --> p2 --> pDots --> human --> newer
 ```
 
 On subsequent runs, heads stay at their original `created_at` positions (PATCH preserves it). Plan tags are wiped per-env by the matrix delete-first step and re-POSTed at the bottom of the conversation. Order between heads never changes.

--- a/docs/Workflow-pr-comments.md
+++ b/docs/Workflow-pr-comments.md
@@ -113,15 +113,17 @@ This works because the purge happens before init — not after `create-validatio
 ### Terraform validation summary for environment: `<env>`
 |  | Step | Result |
 |:---:|---|---|
-| ⚙️ | Initialization | `success` |
-| 🔒 | Lock file | `success` |
-| 🖌 | Format and Style | `success` |
-| ✔ | Validate | `success` |
-| 🧹 | TFLint | `success` |
-| 📖 | Plan | `success` |
-| ⏱ | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |
-| 🔗 | Links | [log extract](#issuecomment-<plan-tag-id>)<br>[job log](<job-url>) |
+| <span title="Initialization">⚙️</span> | Initialization | `success` |
+| <span title="Lock file">🔒</span> | Lock file | `success` |
+| <span title="Format and Style">🖌</span> | Format and Style | `success` |
+| <span title="Validate">✔</span> | Validate | `success` |
+| <span title="TFLint">🧹</span> | TFLint | `success` |
+| <span title="Plan">📖</span> | Plan | `success` |
+| <span title="Plan time">⏱</span> | Plan time | <span title="mm:ss (minutes:seconds)">`1:23`</span> |
+| <span title="Links">🔗</span> | Links | [log extract](#issuecomment-<plan-tag-id>)<br>[job log](<job-url>) |
 ```
+
+This table is kept structurally in sync with the per-group head (§5.3) — same row set, labels, col-1 icon tooltips (`<span title="…">`), and Plan-details / Plan-time / Warnings cell conventions and row-presence rules. Two differences are **intentional**, not drift: (1) step-status cells here use text (`` `success` `` / `<kbd>failure</kbd>`) vs emoji in the grouped head — a column-width adaptation (one wide Result column vs many narrow per-env columns); (2) the header shape and footer scope (`[Job log]` job-scoped here vs `[Workflow log]` run-scoped in §5.3). When changing one head's row set or cell shape, change the other to match unless it's one of these two.
 
 The Links row sits at the bottom of the table — same shape as the per-group head's Links column (§5.3) so reviewers learn one navigation pattern. `[log extract]` anchors at this env's plan tag (§5.2) for the current run; `[job log]` anchors at this matrix job's `#logs`. The Links row replaces the standalone `[Job log]` footer that older versions emitted below the table.
 
@@ -129,14 +131,14 @@ The Links row is rendered by `create-validation-summary` when its `plan-tag-comm
 
 Status cells: `` `success` `` for successful steps, `<kbd>failure</kbd>` / `<kbd>cancelled</kbd>` / `<kbd>skipped</kbd>` / `<kbd></kbd>` (empty outcome) for everything else.
 
-Plan time row is always emitted in ungrouped mode. Renders the upstream `terraform-plan@v0` `plan-time` output as `` `mm:ss` `` inside `<span title="mm:ss (minutes:seconds)">`; the tooltip surfaces the unit on desktop hover. Defaults to `N/A` when the upstream action didn't supply a value.
+Plan time row is always emitted in ungrouped mode. Renders the upstream `terraform-plan@v0` `plan-time` output as `` `mm:ss` `` inside `<span title="mm:ss (minutes:seconds)">`; the tooltip surfaces the unit on desktop hover. Defaults to the em-dash `—` (not backtick-wrapped) when the upstream action didn't supply a value — same empty-state convention as the per-group head (§5.3).
 
-Warnings row is rendered between `📖 Plan` and `📊 Plan Details` when `warning-count > 0`. Shape: `| ⚠️ | Warnings | <span title="Warnings from init+validate+plan">⚠️ N</span> |`. Absent when count is 0, missing, or `?`. The warning bodies live in the plan-tag comment (§5.2), not the head. See [Plan-warnings.md](Plan-warnings.md).
+Warnings row is rendered between `📖 Plan` and `📊 Plan details` when `warning-count > 0`. Shape: `| <span title="Warnings">⚠️</span> | Warnings | <span title="Warnings from init+validate+plan">⚠️ N</span> |`. Absent when count is 0, missing, or `?`. The warning bodies live in the plan-tag comment (§5.2), not the head. See [Plan-warnings.md](Plan-warnings.md).
 
-Plan Details row is rendered only when `include-plan-details=true`. Shape:
+Plan details row is rendered only when `include-plan-details=true`. Shape (badge stack wrapped in `<div align="left">` to match the per-group head's cell):
 
 ```markdown
-| 📊 | Plan Details | <span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span> |
+| <span title="Plan details">📊</span> | Plan details | <div align="left"><span title="Resources to be added">`💫 1` add</span><br><span title="Resources to be changed">`🛠️ 0` change</span><br><span title="Resources to be destroyed">`💥 0` destroy</span></div> |
 ```
 
 Optional badges (move / import / remove) are appended `<br>`-separated when the count is non-zero.
@@ -186,11 +188,13 @@ The rolled-up grouped table aggregates every env in the group (alphabetical colu
 [Workflow log](<run-url>)
 ```
 
+This table is kept structurally in sync with the per-env head (§5.1) — same row set, labels, col-1 icon tooltips, and cell conventions / row-presence rules. The two intentional differences are noted in §5.1: status cells use emoji here (vs text) and the footer is run-scoped `[Workflow log]` (vs job-scoped `[Job log]`).
+
 Status cells map outcomes to emoji + tooltip: ✅ / ❌ / 🚫 / ⏭️ / — (empty outcome).
 
-Plan Details cells stack the count badges in a `<div align="left">` so they anchor left in the otherwise center-aligned column. The badges (`💫 N add`, `🛠️ N change`, `💥 N destroy`) always render; `🔀 move`, `📥 import`, `⛓️‍💥 remove` are appended only when non-zero.
+Plan details cells stack the count badges in a `<div align="left">` so they anchor left in the otherwise center-aligned column. The badges (`💫 N add`, `🛠️ N change`, `💥 N destroy`) always render; `🔀 move`, `📥 import`, `⛓️‍💥 remove` are appended only when non-zero. The whole Plan details **row** is omitted when no env in the group has plan data (parse-plan didn't run anywhere) — matching the per-env head's `include-plan-details` gate. When shown, data-less envs render `N/A`.
 
-Warnings row is rendered between the step rows and `📊 Plan details`. Cell: `⚠️ N` when `N > 0`, em-dash `—` when 0 or empty. Mirrors Plan time's empty-state convention rather than Plan details' "always render" — warnings absence is "not interesting" not "not applicable". See [Plan-warnings.md](Plan-warnings.md).
+Warnings row is rendered between the step rows and `📊 Plan details`, and only when at least one env in the group has warnings — the whole row is omitted otherwise, matching the per-env head (which suppresses at `warning-count == 0`). When shown, each cell is `⚠️ N` for envs with warnings and em-dash `—` for clean envs. Keeps ⚠️ a signal rather than a permanent fixture. See [Plan-warnings.md](Plan-warnings.md).
 
 Plan time cells: backtick-wrapped `mm:ss` when present, em-dash `—` when missing. Both wrapped in `<span title="mm:ss (minutes:seconds)">` so desktop hover surfaces the unit.
 

--- a/parse-terraform-warnings/action.yml
+++ b/parse-terraform-warnings/action.yml
@@ -1,0 +1,53 @@
+name: "Parse terraform Warning: diagnostics"
+description: |
+  Scans a terraform console-output file for 'Warning:' diagnostic blocks.
+  Emits one ::warning workflow-command annotation per block (with file/line
+  source context when terraform printed it) so warnings appear inline in
+  the GitHub UI. Renders a markdown summary file for embedding in the PR
+  plan-tag comment via create-validation-summary.
+
+  See docs/Plan-warnings.md for the full data flow and budgeting model.
+author: "Peder Schmedling"
+inputs:
+  console-output-file:
+    description: |
+      Absolute path to the file to scan (e.g. tf-plan-console-output-<env>.txt
+      from terraform-plan, tf-init-console-output-<env>.txt from
+      terraform-init). Missing/empty files are not an error: count=0 and an
+      empty markdown file is produced.
+    required: true
+  step-label:
+    description: |
+      Which terraform sub-step the input file came from: 'init', 'validate',
+      or 'plan'. Used as a subheader in the rendered markdown and in the
+      annotation title prefix.
+    required: true
+  environment-name:
+    description: |
+      Name of the deployment environment; used in the rendered markdown
+      file's name so multiple matrix jobs don't collide.
+    required: true
+outputs:
+  warning-count:
+    description: |
+      Total warning count, including the suppressed entries from
+      '(and N more similar warnings elsewhere)' aggregator suffixes
+      terraform emits.
+    value: ${{ steps.parse.outputs.warning-count }}
+  warnings-markdown-file:
+    description: |
+      Absolute path to the rendered markdown file (always populated; the
+      file is empty when warning-count is 0).
+    value: ${{ steps.parse.outputs.warnings-markdown-file }}
+runs:
+  using: "composite"
+  steps:
+    - id: parse
+      shell: bash
+      env:
+        input_console_output_file: ${{ inputs.console-output-file }}
+        input_step_label: ${{ inputs.step-label }}
+        input_environment_name: ${{ inputs.environment-name }}
+      run: |
+        set -o allexport
+        source "${{ github.action_path }}/step_parse_warnings.sh"

--- a/parse-terraform-warnings/helpers.sh
+++ b/parse-terraform-warnings/helpers.sh
@@ -1,0 +1,40 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name="$(basename "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)")"
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+function set-output { echo "${1}=${2}" >>$GITHUB_OUTPUT; }
+function set-multiline-output {
+  local outputName outputValue delimiter
+  outputName="${1}"
+  outputValue="${2}"
+  delimiter=$(echo $RANDOM | md5sum | head -c 20)
+  echo "${outputName}<<\"${delimiter}\"" >>$GITHUB_OUTPUT
+  echo "${outputValue}" >>$GITHUB_OUTPUT
+  echo "\"${delimiter}\"" >>$GITHUB_OUTPUT
+}
+function ws-path {
+  local inPath
+  inPath="${1}"
+  realpath --relative-to="${GITHUB_WORKSPACE}" "${inPath}"
+}
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."
+
+if [ -f "${GITHUB_ACTION_PATH}/helpers_additional.sh" ]; then
+  source "${GITHUB_ACTION_PATH}/helpers_additional.sh"
+fi

--- a/parse-terraform-warnings/parse_warnings.awk
+++ b/parse-terraform-warnings/parse_warnings.awk
@@ -1,0 +1,167 @@
+# State-machine parser for terraform 'Warning:' diagnostic blocks.
+#
+# Required variables (passed via -v):
+#   step_label  - 'init' | 'validate' | 'plan'; used in annotation titles
+#                 ("init warning", etc.) so reviewers can tell which step
+#                 emitted a warning from the run-page annotations panel.
+#   md_out      - Path to write per-block markdown bodies to. Each block
+#                 ends with a "---" separator line. Bash main wraps the
+#                 file with a "### From terraform <step>" header.
+#   annot_out   - Path to write annotations to. Bash main cats this to
+#                 stdout so GitHub picks the lines up as workflow commands.
+#   count_out   - Path to write the final integer warning-count to.
+#
+# Counting model: terraform shows ONE example per warning category and
+# appends '(and N more similar warnings elsewhere)' for the suppressed
+# rest. We emit one annotation per shown block (only the one example has
+# source context anyway) but sum (1 + N) into warning-count so the cell
+# in the PR table reflects total occurrences, not categories.
+#
+# Block boundaries: ^Warning: starts a block; next ^Warning: or ^Error:
+# or EOF ends it. Blank lines and indented context lines stay inside the
+# block. 'Plan:' is NOT a terminator — terraform plan logs put warnings
+# AFTER the 'Plan: N to add…' summary line.
+
+function escape_attr(s,   r) {
+  # Escapes for use in name=value attribute pairs in workflow commands.
+  # Order matters: % first so subsequent %xx sequences aren't re-escaped.
+  r = s
+  gsub(/%/, "%25", r)
+  gsub(/\r/, "%0D", r)
+  gsub(/\n/, "%0A", r)
+  gsub(/:/, "%3A", r)
+  gsub(/,/, "%2C", r)
+  return r
+}
+
+function escape_msg(s,   r) {
+  # Escapes for the message portion (after ::). Only %, \r, \n are special.
+  r = s
+  gsub(/%/, "%25", r)
+  gsub(/\r/, "%0D", r)
+  gsub(/\n/, "%0A", r)
+  return r
+}
+
+function emit_block(   message_oneline, message_escaped, title_escaped, file_escaped, annotation, md) {
+  # Annotation: one line per block. Use newline-joined message in the
+  # actual workflow-command (encoded as %0A) so the GitHub UI shows the
+  # full body when hovering the annotation.
+  message_oneline = message
+  # Trim trailing newlines
+  sub(/\n+$/, "", message_oneline)
+  message_escaped = escape_msg(message_oneline)
+  title_escaped = escape_attr("terraform " step_label " warning: " title)
+
+  if (file != "" && line != "") {
+    file_escaped = escape_attr(file)
+    annotation = "::warning file=" file_escaped ",line=" line ",title=" title_escaped "::" message_escaped
+  } else {
+    annotation = "::warning title=" title_escaped "::" message_escaped
+  }
+  print annotation > annot_out
+
+  # Markdown block. Wrapping the message in '> ' blockquote so it renders
+  # cleanly inside the outer <details> collapser without triple-backtick
+  # collisions on user-supplied terraform output.
+  md = "**Warning: " title "**\n"
+  if (file != "") {
+    if (line != "") {
+      md = md "- source: `" file ":" line "`\n"
+    } else {
+      md = md "- source: `" file "`\n"
+    }
+  }
+  if (suppressed > 0) {
+    md = md "- (and " suppressed " more similar warnings elsewhere)\n"
+  }
+  md = md "\n"
+  # Blockquote each non-empty line of the message
+  n = split(message_oneline, lines, "\n")
+  for (i = 1; i <= n; i++) {
+    if (lines[i] == "") {
+      md = md ">\n"
+    } else {
+      md = md "> " lines[i] "\n"
+    }
+  }
+  md = md "\n---\n\n"
+  printf "%s", md > md_out
+
+  total_count += 1 + suppressed
+}
+
+BEGIN {
+  in_block = 0
+  title = ""
+  file = ""
+  line = ""
+  message = ""
+  suppressed = 0
+  total_count = 0
+}
+
+# Block start
+/^Warning: / {
+  if (in_block) emit_block()
+  in_block = 1
+  body_started = 0
+  title = $0
+  sub(/^Warning: /, "", title)
+  file = ""
+  line = ""
+  message = ""
+  suppressed = 0
+  next
+}
+
+# Error terminates the current block
+/^Error: / {
+  if (in_block) { emit_block(); in_block = 0 }
+  next
+}
+
+# Inside a block
+in_block {
+  # Aggregator suffix can appear after message body — match before
+  # falling into the body-collection branch.
+  if (match($0, /^\(and [0-9]+ more similar warnings elsewhere\)/)) {
+    s = $0
+    sub(/^\(and /, "", s)
+    sub(/ more similar warnings elsewhere\).*/, "", s)
+    suppressed = s + 0
+    next
+  }
+
+  # Until the body starts, blank lines and indented context lines are
+  # skipped. Terraform's context block (the "  with module…", "  on file
+  # line N…", "   <N>: <code>" lines) is always indented; the message
+  # body always starts at column 1. Extract file/line from any "  on …
+  # line <N>" we see during this skipping phase.
+  if (!body_started) {
+    if ($0 ~ /^[[:space:]]*$/) next
+    if ($0 ~ /^[[:space:]]/) {
+      if (file == "" && match($0, /^[[:space:]]+on .+ line [0-9]+/)) {
+        s = $0
+        sub(/^[[:space:]]+on /, "", s)
+        if (match(s, / line [0-9]+/)) {
+          file = substr(s, 1, RSTART - 1)
+          rest = substr(s, RSTART + 6)  # skip " line "
+          if (match(rest, /^[0-9]+/)) {
+            line = substr(rest, RSTART, RLENGTH)
+          }
+        }
+      }
+      next
+    }
+    # First non-indented non-blank line — start of message body.
+    body_started = 1
+  }
+
+  message = message $0 "\n"
+}
+
+END {
+  if (in_block) emit_block()
+  printf "%d", total_count > count_out
+}

--- a/parse-terraform-warnings/run_all_tests.sh
+++ b/parse-terraform-warnings/run_all_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/env bash
+#
+# Orchestrates the per-step test suites for parse-terraform-warnings.
+# See docs/Testing-in-ci.md §4.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+overall_exit=0
+
+run_suite() {
+  local script="${1}"
+  local label="${2}"
+
+  echo ""
+  echo -e "${YELLOW}>>> Running ${label}${NC}"
+  bash "${script}" || overall_exit=1
+}
+
+run_suite "${_this_script_dir}/run_tests_step_parse_warnings.sh" "step_parse_warnings.sh tests"
+
+exit ${overall_exit}

--- a/parse-terraform-warnings/run_local_step_parse_warnings.sh
+++ b/parse-terraform-warnings/run_local_step_parse_warnings.sh
@@ -1,0 +1,31 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_parse_warnings.sh.
+# Uses the t05_multiple_blocks.log fixture; tweak input_console_output_file
+# to try other fixtures.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+export input_console_output_file="${_this_script_dir}/test-data/t05_multiple_blocks.log"
+export input_step_label="plan"
+export input_environment_name="sandbox"
+
+source "${_this_script_dir}/step_parse_warnings.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"
+echo ""
+echo "========================================"
+echo "Rendered markdown:"
+echo "========================================"
+md_file=$(grep '^warnings-markdown-file=' "${GITHUB_OUTPUT}" | cut -d= -f2-)
+cat "${md_file}" 2>/dev/null || echo "(missing)"

--- a/parse-terraform-warnings/run_tests_step_parse_warnings.sh
+++ b/parse-terraform-warnings/run_tests_step_parse_warnings.sh
@@ -1,0 +1,247 @@
+#!/bin/env bash
+#
+# Tests for step_parse_warnings.sh
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+_test_data_dir="${_this_script_dir}/test-data"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+  export input_step_label="plan"
+  export input_environment_name="testenv"
+  unset input_console_output_file
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_parse_warnings.sh"
+  ) >/tmp/test_output_parse_warnings.txt 2>&1
+  LAST_EXIT=$?
+}
+
+get_output() {
+  local key="${1}"
+  grep "^${key}=" "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat /tmp/test_output_parse_warnings.txt 2>/dev/null || true
+    echo "--- GITHUB_OUTPUT ---"
+    cat "${GITHUB_OUTPUT}" 2>/dev/null || true
+    echo "--- markdown ---"
+    cat "$(get_output warnings-markdown-file)" 2>/dev/null || true
+    echo "--- /markdown ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+count_annotations() {
+  # Counts ::warning lines in the step's stdout. grep -c always prints a
+  # number; it exits 1 when count is 0, hence the '|| true' rather than
+  # '|| echo 0' which would emit a second "0" line.
+  grep -c '^::warning' /tmp/test_output_parse_warnings.txt 2>/dev/null || true
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}    PARSE-TERRAFORM-WARNINGS STEP TESTS    ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# t01: clean file, no warnings
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${_test_data_dir}/t01_no_warnings.log"
+run_step
+assert "t01: exits 0" test "${LAST_EXIT}" -eq 0
+assert "t01: warning-count is 0" test "$(get_output warning-count)" = "0"
+assert "t01: no ::warning emitted" test "$(count_annotations)" -eq 0
+assert "t01: markdown file is empty" test ! -s "$(get_output warnings-markdown-file)"
+
+# ----------------------------------------------------------------------
+# t02: single warning with file/line context
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${_test_data_dir}/t02_single_warning_with_context.log"
+run_step
+assert "t02: exits 0" test "${LAST_EXIT}" -eq 0
+assert "t02: warning-count is 1" test "$(get_output warning-count)" = "1"
+assert "t02: one ::warning emitted" test "$(count_annotations)" -eq 1
+assert "t02: annotation has file=" \
+  grep -q "::warning file=.terraform/modules/foo/main.tf" /tmp/test_output_parse_warnings.txt
+assert "t02: annotation has line=176" \
+  grep -q "line=176" /tmp/test_output_parse_warnings.txt
+assert "t02: annotation title includes step label" \
+  grep -q "title=terraform plan warning" /tmp/test_output_parse_warnings.txt
+assert "t02: markdown contains source line" \
+  grep -q "source: .*main.tf:176" "$(get_output warnings-markdown-file)"
+assert "t02: markdown contains step header" \
+  grep -q "### From terraform plan" "$(get_output warnings-markdown-file)"
+
+# ----------------------------------------------------------------------
+# t03: single warning without file/line context (provider-level)
+# ----------------------------------------------------------------------
+setup_workdir
+export input_step_label="init"
+export input_console_output_file="${_test_data_dir}/t03_single_warning_no_context.log"
+run_step
+assert "t03: exits 0" test "${LAST_EXIT}" -eq 0
+assert "t03: warning-count is 1" test "$(get_output warning-count)" = "1"
+assert "t03: one ::warning emitted" test "$(count_annotations)" -eq 1
+assert "t03: annotation has NO file=" \
+  bash -c "! grep -q '::warning file=' /tmp/test_output_parse_warnings.txt"
+assert "t03: annotation has title=" \
+  grep -q "::warning title=terraform init warning" /tmp/test_output_parse_warnings.txt
+assert "t03: markdown step header reflects init label" \
+  grep -q "### From terraform init" "$(get_output warnings-markdown-file)"
+
+# ----------------------------------------------------------------------
+# t04: aggregator suffix '(and N more similar warnings elsewhere)'
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${_test_data_dir}/t04_aggregator_suppression.log"
+run_step
+assert "t04: warning-count is 3 (1 shown + 2 suppressed)" \
+  test "$(get_output warning-count)" = "3"
+assert "t04: exactly 1 ::warning emitted (aggregator doesn't multiply annotations)" \
+  test "$(count_annotations)" -eq 1
+assert "t04: markdown mentions 'and 2 more'" \
+  grep -q "and 2 more similar warnings elsewhere" "$(get_output warnings-markdown-file)"
+
+# ----------------------------------------------------------------------
+# t05: three distinct warning blocks
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${_test_data_dir}/t05_multiple_blocks.log"
+run_step
+# 1 + 2 + 1 + 2 + 1 + 0 = 7 (block1: 1+2, block2: 1+2, block3: 1+0)
+assert "t05: warning-count sums all blocks including suppressed" \
+  test "$(get_output warning-count)" = "7"
+assert "t05: three ::warning annotations emitted" \
+  test "$(count_annotations)" -eq 3
+assert "t05: markdown contains '---' separators between blocks" \
+  bash -c "[[ \$(grep -c '^---$' '$(get_output warnings-markdown-file)') -ge 3 ]]"
+
+# ----------------------------------------------------------------------
+# t05 regression: 'with module …' context line must NOT leak into the
+# message body of the second warning. (Bug observed during initial
+# implementation: indented context lines other than 'on … line N' and
+# the code-excerpt line were being collected as part of the message.)
+# ----------------------------------------------------------------------
+assert "t05 regression: second annotation does not contain 'with module'" \
+  bash -c "! grep -q 'with module' /tmp/test_output_parse_warnings.txt"
+
+# ----------------------------------------------------------------------
+# t06: Warning followed by Error — error body should NOT bleed in
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${_test_data_dir}/t06_warning_then_error.log"
+run_step
+assert "t06: warning-count is 1" test "$(get_output warning-count)" = "1"
+assert "t06: exactly 1 ::warning emitted" test "$(count_annotations)" -eq 1
+assert "t06: annotation does NOT include error text" \
+  bash -c "! grep -q 'undeclared resource' /tmp/test_output_parse_warnings.txt"
+assert "t06: markdown body does NOT contain 'Reference to undeclared resource'" \
+  bash -c "! grep -q 'undeclared resource' '$(get_output warnings-markdown-file)'"
+
+# ----------------------------------------------------------------------
+# t07: non-ASCII characters in message
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${_test_data_dir}/t07_non_ascii_message.log"
+run_step
+assert "t07: warning-count is 1" test "$(get_output warning-count)" = "1"
+assert "t07: markdown contains em-dash from source" \
+  grep -q "formerly known as" "$(get_output warnings-markdown-file)"
+assert "t07: markdown file is valid UTF-8" \
+  iconv -f UTF-8 -t UTF-8 "$(get_output warnings-markdown-file)" >/dev/null
+
+# ----------------------------------------------------------------------
+# t08: empty file → count=0, no crash
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${_test_data_dir}/t08_empty_file.log"
+run_step
+assert "t08: exits 0" test "${LAST_EXIT}" -eq 0
+assert "t08: warning-count is 0" test "$(get_output warning-count)" = "0"
+assert "t08: no annotations" test "$(count_annotations)" -eq 0
+
+# ----------------------------------------------------------------------
+# t09: init provider deprecation
+# ----------------------------------------------------------------------
+setup_workdir
+export input_step_label="init"
+export input_console_output_file="${_test_data_dir}/t09_init_provider_deprecation.log"
+run_step
+assert "t09: warning-count is 1" test "$(get_output warning-count)" = "1"
+assert "t09: annotation has file=" \
+  grep -q "::warning file=" /tmp/test_output_parse_warnings.txt
+assert "t09: file path is providers.tf" \
+  grep -q "providers.tf" /tmp/test_output_parse_warnings.txt
+assert "t09: line is 8" grep -q "line=8" /tmp/test_output_parse_warnings.txt
+
+# ----------------------------------------------------------------------
+# Missing input_console_output_file → count=0, no crash
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file=""
+run_step
+assert "missing input: exits 0" test "${LAST_EXIT}" -eq 0
+assert "missing input: warning-count is 0" test "$(get_output warning-count)" = "0"
+assert "missing input: markdown file exists but is empty" \
+  bash -c "[ -e '$(get_output warnings-markdown-file)' ] && [ ! -s '$(get_output warnings-markdown-file)' ]"
+
+# ----------------------------------------------------------------------
+# Nonexistent input file → count=0
+# ----------------------------------------------------------------------
+setup_workdir
+export input_console_output_file="${RUNNER_TEMP}/does-not-exist.log"
+run_step
+assert "nonexistent input: exits 0" test "${LAST_EXIT}" -eq 0
+assert "nonexistent input: warning-count is 0" test "$(get_output warning-count)" = "0"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}       step_parse_warnings.sh SUMMARY       ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/parse-terraform-warnings/step_parse_warnings.sh
+++ b/parse-terraform-warnings/step_parse_warnings.sh
@@ -1,0 +1,102 @@
+#!/bin/env bash
+#
+# Source for the parse-terraform-warnings step.
+#
+# Scans a terraform console-output file for 'Warning:' blocks, emits one
+# GitHub workflow ::warning annotation per block (with file=,line= when
+# terraform printed source context), and renders a markdown block listing
+# every warning for inclusion in the PR plan-tag comment.
+#
+# Required environment variables:
+#   input_console_output_file - Path to the file to scan. Empty / missing
+#                               / unreadable file is not an error: count=0,
+#                               markdown file empty.
+#   input_step_label          - One of 'init' | 'validate' | 'plan'. Used
+#                               in annotation titles and as the markdown
+#                               subheader so reviewers can tell which
+#                               step a warning came from.
+#   input_environment_name    - Used in the output markdown file name.
+#
+# Outputs:
+#   warning-count           - Integer total: sum of (1 + suppressed_count)
+#                             across all detected blocks. Suppressed entries
+#                             come from terraform's '(and N more similar
+#                             warnings elsewhere)' aggregator suffix.
+#   warnings-markdown-file  - Path of the rendered markdown file. Always
+#                             populated (the file is empty when count=0).
+#
+# Side effects:
+#   Emits one ::warning workflow command per detected block to stdout.
+#   GitHub picks these up as run-page annotations.
+#
+# IMPORTANT: do NOT expose the rendered markdown content as a step output
+# — only the file path. Past incident: large step-output values blew
+# ARG_MAX in downstream forks. See capture-matrix-job-meta/action.yml.
+#
+
+set +o nounset
+
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local console_file="${input_console_output_file:-}"
+  local step_label="${input_step_label:-unknown}"
+  local env_name="${input_environment_name:-}"
+
+  local md_file="${GITHUB_WORKSPACE}/tf-warnings-${env_name}-${step_label}.md"
+  : > "${md_file}"  # always create, even when empty
+  set-output 'warnings-markdown-file' "${md_file}"
+
+  if [ -z "${console_file}" ] || [ ! -s "${console_file}" ]; then
+    log-info "no console-output file to scan (label='${step_label}'); count=0"
+    set-output 'warning-count' "0"
+    return 0
+  fi
+
+  log-info "scanning '${console_file}' for warnings (label='${step_label}')"
+
+  # awk does the heavy lifting: state machine over the file, emits
+  # annotations to stdout and writes markdown blocks to a tmp file. Bash
+  # then prepends the per-step header and the per-block separators get
+  # collapsed into the final md_file.
+  local annotations_tmp="${RUNNER_TEMP:-/tmp}/warnings-annot-$$.txt"
+  local md_blocks_tmp="${RUNNER_TEMP:-/tmp}/warnings-md-$$.txt"
+  local count_tmp="${RUNNER_TEMP:-/tmp}/warnings-count-$$.txt"
+
+  awk -v step_label="${step_label}" \
+      -v md_out="${md_blocks_tmp}" \
+      -v annot_out="${annotations_tmp}" \
+      -v count_out="${count_tmp}" \
+      -f "${GITHUB_ACTION_PATH}/parse_warnings.awk" \
+      "${console_file}"
+
+  # Echo annotations to stdout so GitHub captures them. Writing them via
+  # awk -> tmp -> cat instead of awk -> stdout directly keeps them out of
+  # the interleaved log-info stream above.
+  if [ -s "${annotations_tmp}" ]; then
+    cat "${annotations_tmp}"
+  fi
+
+  # Compose the final markdown file: header (only when there's content)
+  # followed by the per-block bodies.
+  local count="0"
+  [ -s "${count_tmp}" ] && count="$(cat "${count_tmp}")"
+
+  if [ "${count}" -gt 0 ] && [ -s "${md_blocks_tmp}" ]; then
+    {
+      printf '### From terraform %s\n\n' "${step_label}"
+      cat "${md_blocks_tmp}"
+    } > "${md_file}"
+  fi
+
+  set-output 'warning-count' "${count}"
+
+  log-info "warning-count=${count}, markdown-file=${md_file}"
+
+  rm -f "${annotations_tmp}" "${md_blocks_tmp}" "${count_tmp}"
+  return 0
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/parse-terraform-warnings/test-data/t01_no_warnings.log
+++ b/parse-terraform-warnings/test-data/t01_no_warnings.log
@@ -1,0 +1,11 @@
+Initializing the backend...
+
+Initializing modules...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/azurerm from the dependency lock file
+- Reusing previous version of hashicorp/random from the dependency lock file
+
+Terraform has been successfully initialized!
+
+Plan: 0 to add, 0 to change, 0 to destroy.

--- a/parse-terraform-warnings/test-data/t02_single_warning_with_context.log
+++ b/parse-terraform-warnings/test-data/t02_single_warning_with_context.log
@@ -1,0 +1,9 @@
+Plan: 1 to add, 1 to change, 0 to destroy.
+
+Warning: Deprecated attribute
+
+  on .terraform/modules/foo/main.tf line 176, in resource "azurerm_windows_virtual_machine" "this":
+ 176:       vm_agent_platform_updates_enabled # Added property to ignore_changes as it continues to detect change in state.
+
+The attribute "vm_agent_platform_updates_enabled" is deprecated. Refer to the
+provider documentation for details.

--- a/parse-terraform-warnings/test-data/t03_single_warning_no_context.log
+++ b/parse-terraform-warnings/test-data/t03_single_warning_no_context.log
@@ -1,0 +1,10 @@
+Initializing the backend...
+
+Warning: Provider deprecation notice
+
+The provider hashicorp/azurerm version 3.x is deprecated. Please migrate to
+the 4.x line before the next major release.
+
+Initializing provider plugins...
+
+Terraform has been successfully initialized!

--- a/parse-terraform-warnings/test-data/t04_aggregator_suppression.log
+++ b/parse-terraform-warnings/test-data/t04_aggregator_suppression.log
@@ -1,0 +1,11 @@
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+Warning: Deprecated attribute
+
+  on .terraform/modules/main.compute/main.windows_vm.tf line 176, in resource "azurerm_windows_virtual_machine" "this":
+ 176:       vm_agent_platform_updates_enabled
+
+The attribute "vm_agent_platform_updates_enabled" is deprecated. Refer to the
+provider documentation for details.
+
+(and 2 more similar warnings elsewhere)

--- a/parse-terraform-warnings/test-data/t05_multiple_blocks.log
+++ b/parse-terraform-warnings/test-data/t05_multiple_blocks.log
@@ -1,0 +1,27 @@
+Plan: 1 to add, 1 to change, 5 to destroy.
+
+Warning: Deprecated attribute
+
+  on .terraform/modules/main.compute/main.windows_vm.tf line 176, in resource "azurerm_windows_virtual_machine" "this":
+ 176:       vm_agent_platform_updates_enabled
+
+The attribute "vm_agent_platform_updates_enabled" is deprecated. Refer to the
+provider documentation for details.
+
+(and 2 more similar warnings elsewhere)
+
+Warning: Argument is deprecated
+
+  with module.main.module.admin_key_vault["network-monitor"].azurerm_key_vault.this,
+  on .terraform/modules/main.admin_key_vault/main.tf line 7, in resource "azurerm_key_vault" "this":
+   7:   enable_rbac_authorization       = !var.legacy_access_policies_enabled
+
+This property has been renamed to `rbac_authorization_enabled` and will be
+removed in v5.0 of the provider
+
+(and 2 more similar warnings elsewhere)
+
+Warning: Some objects will no longer be managed by Terraform
+
+If you apply this plan, Terraform will discard its tracking information for
+the following objects, but it will not delete them.

--- a/parse-terraform-warnings/test-data/t06_warning_then_error.log
+++ b/parse-terraform-warnings/test-data/t06_warning_then_error.log
@@ -1,0 +1,15 @@
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+Warning: Deprecated attribute
+
+  on .terraform/modules/foo/main.tf line 12, in resource "azurerm_key_vault" "this":
+   12:   enable_rbac_authorization       = true
+
+This property has been renamed to `rbac_authorization_enabled`.
+
+Error: Reference to undeclared resource
+
+  on main.tf line 30, in resource "azurerm_storage_account" "this":
+   30:   resource_group_name = azurerm_resource_group.does_not_exist.name
+
+A managed resource "azurerm_resource_group" "does_not_exist" has not been declared.

--- a/parse-terraform-warnings/test-data/t07_non_ascii_message.log
+++ b/parse-terraform-warnings/test-data/t07_non_ascii_message.log
@@ -1,0 +1,10 @@
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+Warning: Deprecated attribute
+
+  on main.tf line 5, in resource "azurerm_key_vault" "this":
+   5:   enable_rbac_authorization = true
+
+This property — formerly known as `enable_rbac_authorization` — has been
+renamed to `rbac_authorization_enabled` (note the change). Migrate before
+v5.0 of the provider.

--- a/parse-terraform-warnings/test-data/t09_init_provider_deprecation.log
+++ b/parse-terraform-warnings/test-data/t09_init_provider_deprecation.log
@@ -1,0 +1,18 @@
+Initializing the backend...
+
+Initializing modules...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/azurerm from the dependency lock file
+- Reusing previous version of hashicorp/random from the dependency lock file
+
+Warning: Version constraints inside provider configuration blocks are deprecated
+
+  on .terraform/modules/main.network/providers.tf line 8, in provider "azurerm":
+   8:   version = "~> 3.0"
+
+Terraform 0.13 and earlier required these constraints to be set inside
+provider configuration blocks. Going forward, version constraints should be
+declared in the required_providers block.
+
+Terraform has been successfully initialized!

--- a/terraform-init/action.yml
+++ b/terraform-init/action.yml
@@ -1,18 +1,42 @@
 name: "Run terraform init in directory"
 description: |
-  Given a working directory this will run 'terraform init' within it.
+  Given a working directory this will run 'terraform init' within it, and
+  optionally in additional directories supplied via JSON. The combined
+  stdout/stderr of every init invocation is captured to a single console
+  file ('tf-init-console-output-<env>.txt') so downstream steps can scan
+  for diagnostics.
 author: "Peder Schmedling"
 inputs:
   working-directory:
     description: From what directory to invoke terraform.
     required: true
+  environment-name:
+    description: |
+      Name of the current deployment environment. Used when naming the
+      console-output file ('tf-init-console-output-<env>.txt').
+    required: false
+    default: ""
   additional-dirs-json:
     description: |
-      Name of the current deployment environment. This is used when naming the plan output files.
+      JSON array of additional directories (relative to GITHUB_WORKSPACE)
+      in which to also run 'terraform init'. Empty array or empty string
+      runs only the project init in working-directory.
     required: true
   plugin-cache-directory:
     description: |
       Optional: path to the terraform providers plugin cache directory.
+      When set, exported as TF_PLUGIN_CACHE_DIR (with
+      TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true) during the
+      additional-dirs init loop so providers are reused across envs.
+    required: false
+    default: ""
+outputs:
+  console-output-file:
+    description: |
+      Absolute path of the file containing the captured stdout/stderr
+      from every 'terraform init' invocation done by this step (project
+      init + any additional dirs, appended in order).
+    value: ${{ steps.init.outputs.tf-init-console-output-file }}
 runs:
   using: "composite"
   steps:
@@ -49,66 +73,18 @@ runs:
 
     - id: init
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         TF_IN_AUTOMATION: "true"
+        input_working_directory: ${{ inputs.working-directory }}
+        input_environment_name: ${{ inputs.environment-name }}
+        input_plugin_cache_directory: ${{ inputs.plugin-cache-directory }}
       run: |
-        # run terraform init
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        # keep track of exit codes
-        declare -A TF_INIT_RESULTS
-
-        # project init
-        start-group "running 'terraform init' in 'project-dir' '$(ws-path $(pwd))' ..."
-        set +e
-        terraform init -input=false -reconfigure
-        TF_INIT_EXITCODE=${?}
-        set -e
-        TF_INIT_RESULTS["$(pwd)"]="${TF_INIT_EXITCODE}"
-        if [ ! "${TF_INIT_EXITCODE}" == "0" ];then
-          log-error "init exited with code '${TF_INIT_EXITCODE}'!"
-        fi
-        end-group
-
-        # additional init
-        more_dirs_json=$(cat <<'EOF'
+        # JSON input via heredoc — keeps quotes/special chars intact and
+        # out of envp (the ARG_MAX guard pattern from CLAUDE.md).
+        input_additional_dirs_json=$(cat <<'EOF'
         ${{ inputs.additional-dirs-json }}
         EOF
         )
-        more_dirs=$(echo ${more_dirs_json} | jq -cr '.[]')
-        if [ -z "$more_dirs" ]; then
-          log-info "no additional directories to init specified"
-        else
-          log-info "additional directories to init specified"
-
-          export TF_PLUGIN_CACHE_DIR="${{ inputs.plugin-cache-directory }}"
-
-          # ref. https://developer.hashicorp.com/terraform/cli/config/config-file#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file
-          export TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE="true"
-
-          for extra_dir in ${more_dirs}; do
-            start-group "additional init directory '${extra_dir}'"
-            log-info "looking for directory ..."
-            if [ -d "${GITHUB_WORKSPACE}/${extra_dir}" ]; then
-              log-info "found it. Running terraform init now ..."
-              set +e
-              terraform -chdir="${GITHUB_WORKSPACE}/${extra_dir}" init -input=false -reconfigure
-              TF_INIT_EXITCODE=${?}
-              set -e
-              TF_INIT_RESULTS["${GITHUB_WORKSPACE}/${extra_dir}"]="${TF_INIT_EXITCODE}"
-              if [ ! "${TF_INIT_EXITCODE}" == "0" ];then
-                log-error "init exited with code '${TF_INIT_EXITCODE}'!"
-              fi
-            else
-              log-error "additional init directory '${extra_dir}' does not exist!"
-              exit 1
-            fi
-            end-group
-          done
-        fi
-
-        # exit code
-        TF_INIT_SUM_EXIT_CODES=$(IFS=+; echo "$((${TF_INIT_RESULTS[*]}))")
-        exit ${TF_INIT_SUM_EXIT_CODES}
+        export input_additional_dirs_json
+        set -o allexport
+        source "${{ github.action_path }}/step_init.sh"

--- a/terraform-init/run_all_tests.sh
+++ b/terraform-init/run_all_tests.sh
@@ -1,0 +1,34 @@
+#!/bin/env bash
+#
+# Orchestrates the per-step test suites for terraform-init.
+#
+# Each per-step script (run_tests_step_*.sh) emits the canonical
+#   Tests run:    <N>
+#   Tests passed: <N>
+#   Tests failed: <N>
+# lines that the action-tests workflow parses (docs/Testing-in-ci.md §4).
+# The workflow SUMS those lines across all matches in the orchestrator's
+# stdout, so this script must NOT emit a fourth aggregate block —
+# doing so would double-count (see docs/Testing-in-ci.md §4 paragraph on
+# multi-step orchestrators).
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+overall_exit=0
+
+run_suite() {
+  local script="${1}"
+  local label="${2}"
+
+  echo ""
+  echo -e "${YELLOW}>>> Running ${label}${NC}"
+  bash "${script}" || overall_exit=1
+}
+
+run_suite "${_this_script_dir}/run_tests_step_init.sh" "step_init.sh tests"
+
+exit ${overall_exit}

--- a/terraform-init/run_local_step_init.sh
+++ b/terraform-init/run_local_step_init.sh
@@ -1,0 +1,51 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_init.sh.
+# Simulates GitHub Actions environment using a stub 'terraform' binary,
+# so no real terraform install or backend is needed.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+WORK_DIR="${RUNNER_TEMP}/envs/sandbox"
+mkdir -p "${WORK_DIR}"
+
+# An additional dir relative to GITHUB_WORKSPACE so the multi-dir branch
+# also gets exercised when the local harness runs.
+EXTRA_DIR_REL="modules/foo"
+mkdir -p "${GITHUB_WORKSPACE}/${EXTRA_DIR_REL}"
+
+STUB_DIR="${RUNNER_TEMP}/stub-bin"
+mkdir -p "${STUB_DIR}"
+cat >"${STUB_DIR}/terraform" <<'EOF'
+#!/bin/env bash
+echo "stub terraform $*"
+echo "Initializing..."
+exit 0
+EOF
+chmod +x "${STUB_DIR}/terraform"
+export TF_BIN="${STUB_DIR}/terraform"
+
+export input_working_directory="${WORK_DIR}"
+export input_environment_name="sandbox"
+export input_additional_dirs_json="[\"${EXTRA_DIR_REL}\"]"
+export input_plugin_cache_directory=""
+
+source "${_this_script_dir}/step_init.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"
+echo ""
+echo "========================================"
+echo "Console-output file contents:"
+echo "========================================"
+console_file=$(grep '^tf-init-console-output-file=' "${GITHUB_OUTPUT}" | cut -d= -f2-)
+cat "${console_file}" 2>/dev/null || echo "(missing)"

--- a/terraform-init/run_tests_step_init.sh
+++ b/terraform-init/run_tests_step_init.sh
@@ -1,0 +1,245 @@
+#!/bin/env bash
+#
+# Tests for step_init.sh
+#
+# Uses a stub 'terraform' binary (injected via TF_BIN) so tests don't
+# require — and never call — the real terraform binary. The stub records
+# its argv when MOCK_TF_ARGV_FILE is set and obeys MOCK_TF_EXIT,
+# MOCK_TF_STDOUT env vars.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+  WORK_DIR="${RUNNER_TEMP}/work"
+  mkdir -p "${WORK_DIR}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_environment_name="testenv"
+  export input_additional_dirs_json="[]"
+  export input_plugin_cache_directory=""
+
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_ARGV_FILE
+}
+
+# Installs a stub terraform that records argv and obeys MOCK_TF_EXIT.
+# When MOCK_TF_EXIT_DIR_<base64-of-cwd> is set, the stub uses that value
+# instead — lets a single test exercise different exit codes per dir.
+install_stub_terraform() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/terraform" <<'STUB'
+#!/bin/env bash
+if [ -n "${MOCK_TF_ARGV_FILE:-}" ]; then
+  # Record argv plus PWD so tests can verify which dir each call ran from.
+  printf 'pwd=%s argv=%s\n' "$(pwd)" "$*" >>"${MOCK_TF_ARGV_FILE}"
+fi
+if [ -n "${MOCK_TF_STDOUT:-}" ]; then
+  printf '%s\n' "${MOCK_TF_STDOUT}"
+fi
+# Per-call exit override based on argv. Lets one test exercise mixed
+# success/failure across project-dir + additional-dirs init.
+for tok in "$@"; do
+  case "${tok}" in
+    -chdir=*)
+      _chdir="${tok#-chdir=}"
+      _env_var="MOCK_TF_EXIT_$(echo -n "${_chdir}" | md5sum | cut -c1-8)"
+      if [ -n "${!_env_var:-}" ]; then exit "${!_env_var}"; fi
+      ;;
+  esac
+done
+exit "${MOCK_TF_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/terraform"
+  export TF_BIN="${stub_dir}/terraform"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_init.sh"
+  ) >/tmp/test_output_init.txt 2>&1
+  LAST_EXIT=$?
+}
+
+get_output() {
+  local key="${1}"
+  grep "^${key}=" "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat /tmp/test_output_init.txt 2>/dev/null || true
+    echo "--- /step output ---"
+    echo "--- GITHUB_OUTPUT ---"
+    cat "${GITHUB_OUTPUT}" 2>/dev/null || true
+    echo "--- /GITHUB_OUTPUT ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}         TERRAFORM-INIT STEP TESTS         ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Test: Happy path, no additional dirs
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+export MOCK_TF_STDOUT="Terraform has been successfully initialized!"
+run_step
+assert "Happy path: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Happy path: console-output-file output is published" \
+  test -n "$(get_output tf-init-console-output-file)"
+assert "Happy path: console-output-file exists" \
+  test -s "$(get_output tf-init-console-output-file)"
+assert "Happy path: console-output-file contains stub stdout" \
+  grep -q "successfully initialized" "$(get_output tf-init-console-output-file)"
+
+# ----------------------------------------------------------------------
+# Test: Additional dirs — both init invocations land in the same console file
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+EXTRA_DIR="modules/foo"
+mkdir -p "${GITHUB_WORKSPACE}/${EXTRA_DIR}"
+export input_additional_dirs_json="[\"${EXTRA_DIR}\"]"
+export MOCK_TF_EXIT=0
+export MOCK_TF_STDOUT="initialized OK"
+export MOCK_TF_ARGV_FILE="${RUNNER_TEMP}/argv.log"
+run_step
+assert "Additional dirs: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Additional dirs: terraform invoked twice" \
+  bash -c "[[ \$(wc -l <\"${MOCK_TF_ARGV_FILE}\") -eq 2 ]]"
+assert "Additional dirs: second invocation uses -chdir=" \
+  grep -q -- "-chdir=${GITHUB_WORKSPACE}/${EXTRA_DIR}" "${MOCK_TF_ARGV_FILE}"
+_cf="$(get_output tf-init-console-output-file)"
+assert "Additional dirs: console file contains both invocations' output" \
+  bash -c "[[ \$(grep -c 'initialized OK' '${_cf}') -eq 2 ]]"
+
+# ----------------------------------------------------------------------
+# Test: Failure path — terraform exit 1 → step exits non-zero
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=1
+export MOCK_TF_STDOUT="Error: failed to init"
+run_step
+assert "Failure: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Failure: error log line present" \
+  grep -q "init exited with code '1'" /tmp/test_output_init.txt
+assert "Failure: console-output-file still captured" \
+  test -s "$(get_output tf-init-console-output-file)"
+
+# ----------------------------------------------------------------------
+# Test: Mixed success/failure across project dir + additional dir
+# Project init exits 0; additional dir's init exits 1; total non-zero.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+EXTRA_DIR="modules/bar"
+mkdir -p "${GITHUB_WORKSPACE}/${EXTRA_DIR}"
+export input_additional_dirs_json="[\"${EXTRA_DIR}\"]"
+export MOCK_TF_EXIT=0
+# Set exit-override for the extra dir's abs path
+_chdir_hash="$(echo -n "${GITHUB_WORKSPACE}/${EXTRA_DIR}" | md5sum | cut -c1-8)"
+declare -x "MOCK_TF_EXIT_${_chdir_hash}=1"
+run_step
+assert "Mixed: step exits non-zero overall" test "${LAST_EXIT}" -ne 0
+assert "Mixed: failure log mentions exit code 1" \
+  grep -q "init exited with code '1'" /tmp/test_output_init.txt
+unset "MOCK_TF_EXIT_${_chdir_hash}"
+
+# ----------------------------------------------------------------------
+# Test: Missing additional dir → step exits non-zero with descriptive log
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_additional_dirs_json="[\"modules/does-not-exist\"]"
+export MOCK_TF_EXIT=0
+run_step
+assert "Missing dir: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Missing dir: log mentions does-not-exist" \
+  grep -q "does not exist" /tmp/test_output_init.txt
+
+# ----------------------------------------------------------------------
+# Test: Empty additional-dirs JSON falls back to project-only init
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_additional_dirs_json=""
+export MOCK_TF_EXIT=0
+export MOCK_TF_ARGV_FILE="${RUNNER_TEMP}/argv.log"
+run_step
+assert "Empty JSON: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Empty JSON: terraform invoked exactly once" \
+  bash -c "[[ \$(wc -l <\"${MOCK_TF_ARGV_FILE}\") -eq 1 ]]"
+assert "Empty JSON: no-additional-dirs log line present" \
+  grep -q "no additional directories" /tmp/test_output_init.txt
+
+# ----------------------------------------------------------------------
+# Test: Environment name appears in console-output-file path
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_environment_name="my-special-env"
+export MOCK_TF_EXIT=0
+run_step
+cf="$(get_output tf-init-console-output-file)"
+assert "Env name: file name embeds environment name" \
+  bash -c "[[ '${cf}' == *'tf-init-console-output-my-special-env.txt' ]]"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}            step_init.sh SUMMARY            ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/terraform-init/step_init.sh
+++ b/terraform-init/step_init.sh
@@ -1,0 +1,123 @@
+#!/bin/env bash
+#
+# Source for the terraform-init main step.
+#
+# Runs 'terraform init' in the working directory (and any additional
+# directories), tees the combined stdout/stderr to a single console-output
+# file so downstream steps (parse-terraform-warnings, validation summary)
+# can scan it for diagnostics.
+#
+# Outputs:
+#   tf-init-console-output-file - Path of file with captured stdout/stderr
+#                                 across the project init + any additional
+#                                 init invocations. Additional dirs append
+#                                 (tee -a) so warnings from every init call
+#                                 are scannable from one place.
+#
+# Required environment variables:
+#   input_working_directory     - Where to invoke 'terraform init'.
+#   input_additional_dirs_json  - JSON array of extra directories (relative
+#                                 to GITHUB_WORKSPACE) to also init. Empty
+#                                 array or empty string skips the loop.
+#
+# Optional environment variables:
+#   input_environment_name      - Used in the console-file name. Defaults
+#                                 to empty (file becomes
+#                                 'tf-init-console-output-.txt' — ugly but
+#                                 functional).
+#   input_plugin_cache_directory - When set, exported as TF_PLUGIN_CACHE_DIR
+#                                  during the additional-dirs loop so
+#                                  providers are reused across envs.
+#   TF_BIN                       - Path to the terraform binary (defaults
+#                                  to 'terraform' on PATH). Used by tests
+#                                  to inject a stub.
+#
+
+set +o nounset
+
+# Load helpers
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tf_bin="${TF_BIN:-terraform}"
+
+  local console_file="${GITHUB_WORKSPACE}/tf-init-console-output-${input_environment_name}.txt"
+  set-output 'tf-init-console-output-file' "${console_file}"
+
+  # Track exit codes per directory. Sum at end so a failure anywhere
+  # surfaces as a non-zero overall exit (matches the legacy action's
+  # behaviour: "exit ${TF_INIT_SUM_EXIT_CODES}").
+  declare -A TF_INIT_RESULTS
+
+  cd "${input_working_directory}"
+
+  # Project init — tee with overwrite ('>' under tee) so re-runs of the
+  # step in the same workspace start fresh.
+  start-group "running 'terraform init' in 'project-dir' '$(ws-path "$(pwd)")' ..."
+  set -o pipefail
+  set +e
+  "${tf_bin}" init -input=false -reconfigure 2>&1 | tee "${console_file}"
+  local init_exit=${?}
+  set +o pipefail
+  TF_INIT_RESULTS["$(pwd)"]="${init_exit}"
+  if [ ! "${init_exit}" == "0" ]; then
+    log-error "init exited with code '${init_exit}'!"
+  fi
+  end-group
+
+  # Additional dirs init — parse JSON array, iterate, tee -a so each
+  # invocation's output is appended to the same console file.
+  local more_dirs_json="${input_additional_dirs_json:-[]}"
+  local more_dirs
+  more_dirs=$(printf '%s' "${more_dirs_json}" | jq -cr '.[]?' 2>/dev/null || echo "")
+
+  if [ -z "${more_dirs}" ]; then
+    log-info "no additional directories to init specified"
+  else
+    log-info "additional directories to init specified"
+
+    if [ -n "${input_plugin_cache_directory:-}" ]; then
+      export TF_PLUGIN_CACHE_DIR="${input_plugin_cache_directory}"
+      # ref. https://developer.hashicorp.com/terraform/cli/config/config-file#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file
+      export TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE="true"
+    fi
+
+    local extra_dir
+    for extra_dir in ${more_dirs}; do
+      start-group "additional init directory '${extra_dir}'"
+      local abs_dir="${GITHUB_WORKSPACE}/${extra_dir}"
+      log-info "looking for directory ..."
+      if [ -d "${abs_dir}" ]; then
+        log-info "found it. Running terraform init now ..."
+        set -o pipefail
+        set +e
+        "${tf_bin}" -chdir="${abs_dir}" init -input=false -reconfigure 2>&1 | tee -a "${console_file}"
+        local extra_exit=${?}
+        set +o pipefail
+        TF_INIT_RESULTS["${abs_dir}"]="${extra_exit}"
+        if [ ! "${extra_exit}" == "0" ]; then
+          log-error "init exited with code '${extra_exit}'!"
+        fi
+      else
+        log-error "additional init directory '${extra_dir}' does not exist!"
+        end-group
+        return 1
+      fi
+      end-group
+    done
+  fi
+
+  # Sum exit codes — any non-zero entry yields a non-zero total. Matches
+  # the legacy action behaviour. Empty array (no inits ran) shouldn't be
+  # possible — project init always runs — but guard anyway.
+  local sum_exit_codes=0
+  local v
+  for v in "${TF_INIT_RESULTS[@]}"; do
+    sum_exit_codes=$((sum_exit_codes + v))
+  done
+  return ${sum_exit_codes}
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/terraform-validate/action.yml
+++ b/terraform-validate/action.yml
@@ -1,11 +1,25 @@
 name: "Run terraform validate in directory"
 description: |
-  Runs 'terraform validate' in a given directory.
+  Runs 'terraform validate' in a given directory and tees stdout/stderr to
+  a console-output file ('tf-validate-console-output-<env>.txt') so
+  downstream steps can scan for diagnostics.
 author: "Peder Schmedling"
 inputs:
   working-directory:
     description: From what directory to invoke terraform.
     required: true
+  environment-name:
+    description: |
+      Name of the current deployment environment. Used when naming the
+      console-output file ('tf-validate-console-output-<env>.txt').
+    required: false
+    default: ""
+outputs:
+  console-output-file:
+    description: |
+      Absolute path of the file containing the captured stdout/stderr
+      from 'terraform validate'.
+    value: ${{ steps.validate.outputs.tf-validate-console-output-file }}
 runs:
   using: "composite"
   steps:
@@ -24,14 +38,12 @@ runs:
           log-info "using $(terraform version)"
         fi
         end-group
+
     - id: validate
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      env:
+        input_working_directory: ${{ inputs.working-directory }}
+        input_environment_name: ${{ inputs.environment-name }}
       run: |
-        # run terraform validate in a given directory
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        start-group "running 'terraform validate' in '$(ws-path $(pwd))'"
-        terraform validate
-        end-group
+        set -o allexport
+        source "${{ github.action_path }}/step_validate.sh"

--- a/terraform-validate/run_all_tests.sh
+++ b/terraform-validate/run_all_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/env bash
+#
+# Orchestrates the per-step test suites for terraform-validate.
+# See docs/Testing-in-ci.md §4.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+overall_exit=0
+
+run_suite() {
+  local script="${1}"
+  local label="${2}"
+
+  echo ""
+  echo -e "${YELLOW}>>> Running ${label}${NC}"
+  bash "${script}" || overall_exit=1
+}
+
+run_suite "${_this_script_dir}/run_tests_step_validate.sh" "step_validate.sh tests"
+
+exit ${overall_exit}

--- a/terraform-validate/run_local_step_validate.sh
+++ b/terraform-validate/run_local_step_validate.sh
@@ -1,0 +1,43 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_validate.sh.
+# Simulates GitHub Actions environment using a stub 'terraform' binary.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+WORK_DIR="${RUNNER_TEMP}/envs/sandbox"
+mkdir -p "${WORK_DIR}"
+
+STUB_DIR="${RUNNER_TEMP}/stub-bin"
+mkdir -p "${STUB_DIR}"
+cat >"${STUB_DIR}/terraform" <<'EOF'
+#!/bin/env bash
+echo "stub terraform $*"
+echo "Success! The configuration is valid."
+exit 0
+EOF
+chmod +x "${STUB_DIR}/terraform"
+export TF_BIN="${STUB_DIR}/terraform"
+
+export input_working_directory="${WORK_DIR}"
+export input_environment_name="sandbox"
+
+source "${_this_script_dir}/step_validate.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"
+echo ""
+echo "========================================"
+echo "Console-output file contents:"
+echo "========================================"
+console_file=$(grep '^tf-validate-console-output-file=' "${GITHUB_OUTPUT}" | cut -d= -f2-)
+cat "${console_file}" 2>/dev/null || echo "(missing)"

--- a/terraform-validate/run_tests_step_validate.sh
+++ b/terraform-validate/run_tests_step_validate.sh
@@ -1,0 +1,146 @@
+#!/bin/env bash
+#
+# Tests for step_validate.sh
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+  WORK_DIR="${RUNNER_TEMP}/work"
+  mkdir -p "${WORK_DIR}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_environment_name="testenv"
+
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT
+}
+
+install_stub_terraform() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/terraform" <<'STUB'
+#!/bin/env bash
+if [ -n "${MOCK_TF_STDOUT:-}" ]; then
+  printf '%s\n' "${MOCK_TF_STDOUT}"
+fi
+exit "${MOCK_TF_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/terraform"
+  export TF_BIN="${stub_dir}/terraform"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_validate.sh"
+  ) >/tmp/test_output_validate.txt 2>&1
+  LAST_EXIT=$?
+}
+
+get_output() {
+  local key="${1}"
+  grep "^${key}=" "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat /tmp/test_output_validate.txt 2>/dev/null || true
+    echo "--- GITHUB_OUTPUT ---"
+    cat "${GITHUB_OUTPUT}" 2>/dev/null || true
+    echo "--- /GITHUB_OUTPUT ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}       TERRAFORM-VALIDATE STEP TESTS       ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Test: Happy path (terraform exit 0)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=0
+export MOCK_TF_STDOUT="Success! The configuration is valid."
+run_step
+assert "Happy path: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Happy path: console-output-file output is published" \
+  test -n "$(get_output tf-validate-console-output-file)"
+assert "Happy path: console-output-file exists" \
+  test -s "$(get_output tf-validate-console-output-file)"
+assert "Happy path: console-output-file contains stub stdout" \
+  grep -q "configuration is valid" "$(get_output tf-validate-console-output-file)"
+
+# ----------------------------------------------------------------------
+# Test: Failure (terraform exit 1)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=1
+export MOCK_TF_STDOUT="Error: invalid configuration"
+run_step
+assert "Failure: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Failure: error log line present" \
+  grep -q "validate exited with code '1'" /tmp/test_output_validate.txt
+assert "Failure: console-output-file still captured" \
+  test -s "$(get_output tf-validate-console-output-file)"
+assert "Failure: console-output-file contains error text" \
+  grep -q "invalid configuration" "$(get_output tf-validate-console-output-file)"
+
+# ----------------------------------------------------------------------
+# Test: Environment name appears in console-output-file path
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_environment_name="weird-env-name"
+export MOCK_TF_EXIT=0
+run_step
+cf="$(get_output tf-validate-console-output-file)"
+assert "Env name: file name embeds environment name" \
+  bash -c "[[ '${cf}' == *'tf-validate-console-output-weird-env-name.txt' ]]"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}          step_validate.sh SUMMARY          ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/terraform-validate/step_validate.sh
+++ b/terraform-validate/step_validate.sh
@@ -1,0 +1,53 @@
+#!/bin/env bash
+#
+# Source for the terraform-validate main step.
+#
+# Runs 'terraform validate' in the working directory and tees the
+# combined stdout/stderr to a console-output file so downstream steps
+# (parse-terraform-warnings) can scan it for diagnostics.
+#
+# Outputs:
+#   tf-validate-console-output-file - Path of file with captured stdout/stderr.
+#
+# Required environment variables:
+#   input_working_directory     - Where to invoke 'terraform validate'.
+#
+# Optional environment variables:
+#   input_environment_name      - Used in the console-file name. Defaults
+#                                 to empty.
+#   TF_BIN                       - Path to the terraform binary (defaults
+#                                  to 'terraform' on PATH). Used by tests
+#                                  to inject a stub.
+#
+
+set +o nounset
+
+# Load helpers
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tf_bin="${TF_BIN:-terraform}"
+
+  local console_file="${GITHUB_WORKSPACE}/tf-validate-console-output-${input_environment_name}.txt"
+  set-output 'tf-validate-console-output-file' "${console_file}"
+
+  cd "${input_working_directory}"
+
+  start-group "running 'terraform validate' in '$(ws-path "$(pwd)")'"
+  set -o pipefail
+  set +e
+  "${tf_bin}" validate 2>&1 | tee "${console_file}"
+  local validate_exit=${?}
+  set +o pipefail
+  end-group
+
+  if [ "${validate_exit}" != "0" ]; then
+    log-error "validate exited with code '${validate_exit}'"
+  fi
+
+  return ${validate_exit}
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}


### PR DESCRIPTION
## Motivation

Today, terraform `Warning:` diagnostics (deprecation notices, soft state drift, provider-level advisories) appear only in the raw job log. Reviewers reading the PR conversation never see them, and nothing draws the eye in the GitHub UI — deprecations harden into errors months later, when the provider does a major release, but the moment to act was when the warning first fired.

This branch makes warnings first-class on the PR: counted in the validation summary table, listed in a collapsible block under the plan extract, and emitted as `::warning` annotations so they appear inline in the Files-changed view next to the offending source line.

See [docs/Plan-warnings.md](./docs/Plan-warnings.md) for the authoritative spec (data flow, warning-block grammar, annotation format, 65k budgeting algorithm, ARG_MAX caveat).

## Summary of changes

- **New action `parse-terraform-warnings/`** — awk state machine that scans a terraform console-output file for `Warning:` blocks, emits one `::warning file=…,line=…::message` per block (with file/line fallback when source context is absent), and renders a markdown body file ready for embedding in the PR plan-tag comment.
- **`terraform-init/` and `terraform-validate/` converted to modern `step_*.sh` layout** (per [docs/Action-implementation-guide.md](./docs/Action-implementation-guide.md)) — both now tee their terraform invocations to a console-output file so parse-terraform-warnings has something to scan. Adds `environment-name` input to keep file names unique across matrix jobs.
- **`create-validation-summary/`** gains a `⚠️ Warnings` row in the per-env head and a sibling `<details>⚠️ N warnings</summary>…</details>` collapser appended after the plan-block. Budgeting is warnings-first against a 65000-byte hard limit (warnings capped at 60k; plan-extract gets whatever remains). Replaces the latent `tail -c 65000` cut with a line-anchored variant — fixes a UTF-8 mid-codepoint bug that predates this feature.
- **`aggregate-validation-summaries/`** gains a `⚠️ Warnings` row in the grouped table, summing per-env warning counts across the three `parse-*-warnings` step ids. Em-dash `—` cell convention for "clean envs" / "step didn't run" mirrors the existing Plan time row.
- **`.github/workflows/terraform-ci-cd-default.yml`** wires three `parse-terraform-warnings` invocations after init/validate/plan (per-step extraction so each gets its own 10-annotation GHA budget — a noisy init can't crowd out plan-warning annotations), plus an inline `concat-warnings-md` shell step that aggregates the three markdown files and sums the per-step counts. The arithmetic lives in shell because GHA workflow expressions don't support `+` between `fromJSON()` values.

### Follow-up refinements (in this same PR)

- **`aggregate-validation-summaries/`: omit Warnings + Plan-details rows when empty** — the grouped table now suppresses the `⚠️ Warnings` row entirely when no env in the group has warnings, and the `📊 Plan details` row when no env has plan data. Matches the per-env head, which already gates both. When a row IS shown, clean / data-less envs render `—` / `N/A`. ⚠️ reads as a signal, not a permanent fixture.
- **`create-validation-summary/`: sync per-env head with grouped head** — col-1 step icons gain `<span title="…">` hover tooltips (new `_render_step_icon_cell` helper mirroring the grouped action's), `Plan Details` → `Plan details` (sentence-case), Plan-time default switches from `` `N/A` `` to em-dash `—`, and the Plan-details badge stack is wrapped in `<div align="left">`. The two heads now render identically except status cells (text in per-env's wide Result column vs emoji in the grouped head's narrow per-env columns — documented as an intentional column-width adaptation in `format-status` and both render-function headers).

## Test plan

- [x] All five touched per-action test suites pass locally:
  - `terraform-init/run_all_tests.sh` — 19/19
  - `terraform-validate/run_all_tests.sh` — 9/9
  - `parse-terraform-warnings/run_all_tests.sh` — 44/44 (9 fixtures, including 'with module …' context-line regression and UTF-8)
  - `create-validation-summary/run_all_tests.sh` — 70/70 (13 new — warnings row, collapser, 65k budgeting, UTF-8 boundary; goldens updated for the per-env↔grouped sync)
  - `aggregate-validation-summaries/run_all_tests.sh` — 45/45 (7 new — warnings row sum across three step ids, conditional row suppression, Plan-details row gating)
- [x] `pr-comment` and `pr-comments-reconcile` suites verified unaffected (marker-based, agnostic to body content).
- [x] All touched YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] **Calling-repo end-to-end** — verified on [dsb-infra/azure-terraform-ikt-app-platform-environments-config#721](https://github.com/dsb-infra/azure-terraform-ikt-app-platform-environments-config/pull/721) via a temporary `@dev-plan-warnings` tag (now removed). All three matrix envs (dev/prod/test) rendered the grouped Warnings row with `⚠️ 5` each, the per-env plan-tag comments carried the `<details>⚠️ 5 warnings</summary>…</details>` collapser with correct title / source / aggregator note / blockquoted body, and the check-runs API showed one `::warning` annotation per env with `file=`, `line=7`, and `title=terraform plan warning: Argument is deprecated`. Count of 5 vs 1 annotation is correct: terraform's `(and 4 more similar warnings elsewhere)` aggregator collapses categories, so the parser counts total occurrences but only emits one annotation per shown block (the only one with file/line context).

## Notes

- This PR no longer carries a dev-tag swap commit; `@v0` references are intact throughout the workflow files, so the branch is ready to merge once reviewed.
- The dev-tag-swap pattern from [docs/Development-and-release.md](./docs/Development-and-release.md) was used to exercise the feature end-to-end; both the temporary `dev-plan-warnings` tag and its swap commit have been removed from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)