### PR TITLE
fix(auto-merge-pr): stop exporting heredoc-captured JSON; document anti-pattern

### DIFF
--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -341,7 +341,8 @@ jobs:
         uses: actions/checkout@v6
       - name: "🎰 Create env matrix"
         id: create-matrix
-        uses: dsb-norge/github-actions-terraform/create-tf-vars-matrix@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-tf-vars-matrix@heredoc-export-dev
         with:
           inputs-json: ${{ toJSON(inputs) }}
 
@@ -444,7 +445,8 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: "🌱 Seed heads"
-        uses: dsb-norge/github-actions-terraform/pr-comments-reconcile@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/pr-comments-reconcile@heredoc-export-dev
         with:
           repo: ${{ github.repository }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -512,7 +514,8 @@ jobs:
           && github.event_name == 'pull_request'
           && github.event.action != 'closed'
           && github.event.action != 'converted_to_draft'
-        uses: dsb-norge/github-actions-terraform/pr-comment@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/pr-comment@heredoc-export-dev
         with:
           repo: ${{ github.repository }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -522,7 +525,8 @@ jobs:
         continue-on-error: true # allow job to continue, step outcome is ignored
 
       - name: "🎰 Export environment variables and secrets"
-        uses: dsb-norge/github-actions-terraform/export-env-vars@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/export-env-vars@heredoc-export-dev
         with:
           extra-envs: ${{ toJSON(matrix.vars.extra-envs) }}
           extra-envs-from-secrets: ${{ toJSON(matrix.vars.extra-envs-from-secrets) }}
@@ -545,12 +549,14 @@ jobs:
 
       - name: "🗄️ Setup Terraform provider plugin cache"
         id: setup-terraform-cache
-        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@heredoc-export-dev
 
       - name: "📥 Setup TFLint"
         id: setup-tflint
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'lint')
-        uses: dsb-norge/github-actions-terraform/setup-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-tflint@heredoc-export-dev
         with:
           tflint-version: ${{ matrix.vars.tflint-version }}
           working-directory: ${{ matrix.vars.project-dir }}
@@ -565,7 +571,8 @@ jobs:
       - name: ⚙️ Terraform Init
         id: init
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'init')
-        uses: dsb-norge/github-actions-terraform/terraform-init@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-init@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           additional-dirs-json: ${{ toJSON(matrix.vars.terraform-init-additional-dirs) }}
@@ -585,7 +592,8 @@ jobs:
           && github.event_name == 'pull_request'
           && github.event.action != 'closed'
           && github.event.action != 'converted_to_draft'
-        uses: dsb-norge/github-actions-terraform/verify-terraform-lock@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/verify-terraform-lock@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -593,7 +601,8 @@ jobs:
       - name: 🖌 Terraform Format
         id: fmt
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'format')
-        uses: dsb-norge/github-actions-terraform/terraform-fmt@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-fmt@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           format-check-in-root-dir: ${{ matrix.vars.format-check-in-root-dir }}
@@ -602,7 +611,8 @@ jobs:
       - name: ✔ Terraform Validate
         id: validate
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'validate')
-        uses: dsb-norge/github-actions-terraform/terraform-validate@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-validate@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -610,7 +620,8 @@ jobs:
       - name: 🧹 Lint with TFLint
         id: lint
         if: contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'lint')
-        uses: dsb-norge/github-actions-terraform/lint-with-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/lint-with-tflint@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -618,7 +629,8 @@ jobs:
       - name: 📖 Terraform Plan
         id: plan
         if: steps.init.outcome == 'success' && ( contains(matrix.vars.goals, 'all') || contains(matrix.vars.goals, 'plan') )
-        uses: dsb-norge/github-actions-terraform/terraform-plan@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-plan@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: ${{ matrix.vars.github-environment }}
@@ -627,7 +639,8 @@ jobs:
       - name: "🔍 Parse terraform plan"
         id: parse-plan
         if: steps.plan.outcome != 'cancelled' && steps.plan.outcome != 'skipped'
-        uses: dsb-norge/github-actions-terraform/parse-terraform-plan@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/parse-terraform-plan@heredoc-export-dev
         with:
           plan-console-file: ${{ steps.plan.outputs.console-output-file }}
         continue-on-error: true # allow job to continue, step outcome is ignored
@@ -645,7 +658,8 @@ jobs:
           && github.event_name == 'pull_request'
           && github.event.action != 'closed'
           && github.event.action != 'converted_to_draft'
-        uses: dsb-norge/github-actions-terraform/create-validation-summary@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-validation-summary@heredoc-export-dev
         with:
           environment-name: ${{ matrix.vars.github-environment }}
           plan-txt-output-file: ${{ steps.plan.outputs.txt-output-file }} # created by terraform by parsing the plan file, not available when plan fails
@@ -692,7 +706,8 @@ jobs:
         # the per-env head so the head's Links row can anchor at this
         # comment's id.
         if: always() && steps.create-validation-summary.outcome == 'success'
-        uses: dsb-norge/github-actions-terraform/pr-comment@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/pr-comment@heredoc-export-dev
         with:
           repo: ${{ github.repository }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -721,7 +736,8 @@ jobs:
           && github.event.action != 'closed'
           && github.event.action != 'converted_to_draft'
           && matrix.vars.pr-comment-group == ''
-        uses: dsb-norge/github-actions-terraform/create-validation-summary@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-validation-summary@heredoc-export-dev
         with:
           environment-name: ${{ matrix.vars.github-environment }}
           plan-txt-output-file: ${{ steps.plan.outputs.txt-output-file }}
@@ -771,7 +787,8 @@ jobs:
           always()
           && steps.create-validation-summary.outcome == 'success'
           && matrix.vars.pr-comment-group == ''
-        uses: dsb-norge/github-actions-terraform/pr-comment@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/pr-comment@heredoc-export-dev
         with:
           repo: ${{ github.repository }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -868,7 +885,8 @@ jobs:
               && github.event.action != 'converted_to_draft'
               && github.base_ref == matrix.vars.caller-repo-default-branch
           ) )
-        uses: dsb-norge/github-actions-terraform/terraform-apply@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-apply@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.plan.outputs.terraform-plan-file }}
@@ -880,7 +898,8 @@ jobs:
         if: |
           steps.init.outcome == 'success'
           && contains(matrix.vars.goals, 'destroy-plan')
-        uses: dsb-norge/github-actions-terraform/terraform-plan@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-plan@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: "${{ matrix.vars.github-environment }}-destroy"
@@ -910,7 +929,8 @@ jobs:
               && github.event.action != 'converted_to_draft'
               && github.base_ref == matrix.vars.caller-repo-default-branch
           ) )
-        uses: dsb-norge/github-actions-terraform/terraform-apply@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-apply@heredoc-export-dev
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.destroy-plan.outputs.terraform-plan-file }}
@@ -920,7 +940,8 @@ jobs:
       - name: "📊 Capture matrix job metadata"
         id: capture-metadata
         if: always()
-        uses: dsb-norge/github-actions-terraform/capture-matrix-job-meta@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/capture-matrix-job-meta@heredoc-export-dev
         with:
           environment-name: ${{ matrix.vars.github-environment }}
           matrix-context-json: ${{ toJSON(matrix) }}
@@ -960,7 +981,8 @@ jobs:
         # needs to run to clean up any orphan group comments).
         continue-on-error: true
       - name: "🧮 Reconcile per-group PR comments"
-        uses: dsb-norge/github-actions-terraform/aggregate-validation-summaries@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/aggregate-validation-summaries@heredoc-export-dev
         with:
           metadata-files-pattern: "matrix-job-meta-*.json"
           pr-number: ${{ github.event.pull_request.number }}
@@ -1027,7 +1049,8 @@ jobs:
           merge-multiple: true
       - name: "🔍 Evaluate PR auto merge eligibility across all environments"
         id: evaluate-automerge
-        uses: dsb-norge/github-actions-terraform/evaluate-automerge-eligibility@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/evaluate-automerge-eligibility@heredoc-export-dev
         with:
           metadata-files-pattern: "matrix-job-meta-*.json"
       - name: "🔑 Resolve auto-merge app private key"
@@ -1065,7 +1088,8 @@ jobs:
       - name: "🤖 Auto merge PR"
         id: auto-merge-pr
         if: steps.evaluate-automerge.outputs.is-eligible == 'true'
-        uses: dsb-norge/github-actions-terraform/auto-merge-pr@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/auto-merge-pr@heredoc-export-dev
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           github-event-context-json: ${{ toJSON(github.event) }}

--- a/.github/workflows/terraform-module-ci.yaml
+++ b/.github/workflows/terraform-module-ci.yaml
@@ -84,7 +84,8 @@ jobs:
 
       - name: "📝 Validate and update README.md"
         id: update-readme
-        uses: dsb-norge/github-actions-terraform/terraform-docs@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-docs@heredoc-export-dev
         with:
           readme-file-path: ${{ inputs.readme-file-path }}
         continue-on-error: true
@@ -111,7 +112,8 @@ jobs:
 
       - name: "🎰 Create the matrix"
         id: create-test-matrix
-        uses: dsb-norge/github-actions-terraform/create-tftest-matrix@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-tftest-matrix@heredoc-export-dev
 
   # runs all validation steps but also builds up the terraform provider plugin cache
   validate-project:
@@ -139,11 +141,13 @@ jobs:
 
       - name: "🗄️ Setup Terraform provider plugin cache"
         id: setup-terraform-cache
-        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-terraform-plugin-cache@heredoc-export-dev
 
       - name: "📥 Setup TFLint"
         id: setup-tflint
-        uses: dsb-norge/github-actions-terraform/setup-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/setup-tflint@heredoc-export-dev
         with:
           tflint-version: ${{ inputs.tflint-version }}
           working-directory: ${{ github.workspace }}
@@ -156,7 +160,8 @@ jobs:
 
       - name: ⚙️ Terraform Init
         id: init
-        uses: dsb-norge/github-actions-terraform/terraform-init@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-init@heredoc-export-dev
         with:
           working-directory: ${{ github.workspace }}
           additional-dirs-json: null
@@ -165,7 +170,8 @@ jobs:
 
       - name: 🖌 Terraform Format
         id: fmt
-        uses: dsb-norge/github-actions-terraform/terraform-fmt@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-fmt@heredoc-export-dev
         with:
           working-directory: ${{ github.workspace }}
           format-check-in-root-dir: true
@@ -173,14 +179,16 @@ jobs:
 
       - name: ✔ Terraform Validate
         id: validate
-        uses: dsb-norge/github-actions-terraform/terraform-validate@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-validate@heredoc-export-dev
         with:
           working-directory: ${{ github.workspace }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: 🧹 Lint with TFLint
         id: lint
-        uses: dsb-norge/github-actions-terraform/lint-with-tflint@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/lint-with-tflint@heredoc-export-dev
         with:
           working-directory: ${{ github.workspace }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -188,7 +196,8 @@ jobs:
       - name: 📝 Create validation summary
         id: create-validation-summary
         if: github.event_name == 'pull_request'
-        uses: dsb-norge/github-actions-terraform/create-validation-summary@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-validation-summary@heredoc-export-dev
         with:
           environment-name: "module"
           status-init: ${{ steps.init.outcome }}
@@ -270,7 +279,8 @@ jobs:
 
       - name: ⚙️ Terraform Init
         id: init
-        uses: dsb-norge/github-actions-terraform/terraform-init@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-init@heredoc-export-dev
         with:
           working-directory: ${{ github.workspace }}
           additional-dirs-json: null
@@ -279,7 +289,8 @@ jobs:
 
       - name: 🧪 Terraform Test
         id: test
-        uses: dsb-norge/github-actions-terraform/terraform-test@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/terraform-test@heredoc-export-dev
         with:
           test-file: ${{ matrix.test-file }}
         continue-on-error: true # allow job to continue, step outcome is evaluated later
@@ -287,7 +298,8 @@ jobs:
       - name: 📝 Create test report
         id: create-test-report
         if: github.event_name == 'pull_request'
-        uses: dsb-norge/github-actions-terraform/create-test-report@v0
+        # TODO revert to @v0
+        uses: dsb-norge/github-actions-terraform/create-test-report@heredoc-export-dev
         with:
           test-out-file: ${{ steps.test.outputs.json }}
           status-init: ${{ steps.init.outcome }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,17 @@ run: |
   source "${{ github.action_path }}/step_<name>.sh"
 ```
 
+### Watch for ARG_MAX in step scripts
+
+Under `set -o allexport`, any shell variable holding large data (file contents, `gh api` responses, plan extracts) gets exported to envp; once envp crosses Linux's `ARG_MAX` (~2 MB total) or `MAX_ARG_STRLEN` (128 KB per string), the next `fork+execve` — typically `jq`, `bash -c`, or another helper — fails with exit 126 "Argument list too long". The bug correlates with PR/data size so it stays silent in tests and only surfaces in production on a calling repo with a big-enough plan or comment thread.
+
+**Rule:** never assign large captured data to a shell variable while allexport is in scope. Route through `mktemp` files (or read straight from disk) and pass via stdin / `-f` / `-F body=@file` / `jq --slurpfile`. Four in-tree reference patterns to copy from when authoring or reviewing a step script:
+
+- File tails — `tail -c 65000 "<path>"` directly into the capture, never via an intermediate var (`create-validation-summary/step_create_validation_summary.sh`).
+- `gh api` responses — write the response to `mktemp`, then `jq` reads it (`aggregate-validation-summaries/step_aggregate.sh`, both `_resolve_per_env_job_urls` and `list_pr_state`).
+- Large JSON merge — `jq --slurpfile` (not `--argjson`, which puts the JSON on argv) and dereference with `[0]` (`capture-matrix-job-meta/step_capture.sh`).
+- Large gh CLI inputs — heredoc the body into a tempfile, post via `gh api -F body=@<tempfile>` (`pr-comment/action.yml`).
+
 ### PRs are gated by per-action test suites
 
 `.github/workflows/action-tests.yml` runs every action's `run_all_tests.sh` in parallel on each PR and exposes a single `tests-conclusion` check (intended to be required by branch protection). Result is reported as a PR comment, run-page annotations, and a `$GITHUB_STEP_SUMMARY` block — all three driven by the result-JSON artifacts each matrix job uploads.

--- a/auto-merge-pr/action.yml
+++ b/auto-merge-pr/action.yml
@@ -70,13 +70,19 @@ runs:
         input_repo_ref: ${{ github.repository }}
         input_pr_number: ${{ github.event.number }}
       run: |
-        # JSON inputs require special handling (heredocs)
+        # Heredoc capture (special chars in github.event JSON survive verbatim).
+        # Intentionally NOT exported — step_auto_merge_pr.sh is sourced from
+        # this same shell and reads ${input_github_event_context_json} as a
+        # shell-local, so it never needs to be in envp. github.event for PR
+        # events can be 30-100+ KB (long descriptions, large reviewer lists,
+        # labels). Exporting that pushed every subsequent gh / jq fork past
+        # MAX_ARG_STRLEN (128 KB per envp string on Ubuntu); see
+        # docs/Action-implementation-guide.md §"Anti-pattern: exporting
+        # heredoc-captured JSON".
         input_github_event_context_json=$(cat <<'EOF'
         ${{ inputs.github-event-context-json }}
         EOF
         )
-
-        export input_github_event_context_json
 
         source "${GITHUB_ACTION_PATH}/step_auto_merge_pr.sh"
         exit_code=$?

--- a/docs/Action-implementation-guide.md
+++ b/docs/Action-implementation-guide.md
@@ -195,7 +195,7 @@ For inputs that are simple strings, pass them as environment variables. Use `set
 
 ### Step shim pattern — JSON inputs
 
-JSON values passed from GitHub Actions expressions can contain special characters that break normal variable assignment. Use heredocs. The `set -o allexport` pattern still applies:
+JSON values passed from GitHub Actions expressions can contain special characters that break normal variable assignment. Use heredocs. **Do NOT `export` the heredoc-captured variable** — the step script is `source`d in the same shell and reads it as a shell-local, so it never needs to be in envp. Exporting it would push the JSON into envp for every subsequent fork and risk an ARG_MAX crash on big inputs — see [Anti-pattern: exporting heredoc-captured JSON](#anti-pattern-exporting-heredoc-captured-json) below for the full rationale.
 
 ```yaml
 - id: my-step
@@ -203,17 +203,18 @@ JSON values passed from GitHub Actions expressions can contain special character
   env:
     input_simple_var: ${{ inputs.simple-var }}
   run: |
-    # JSON inputs require special handling (heredocs)
+    # Heredoc capture (special chars survive verbatim). Intentionally NOT
+    # exported — step_my_step.sh reads it as a shell-local via `source`.
     input_json_data=$(cat <<'EOF'
     ${{ inputs.json-data }}
     EOF
     )
 
-    export input_json_data
-
     set -o allexport
     source "${{ github.action_path }}/step_my_step.sh"
 ```
+
+> Note the order: the heredoc capture happens **before** `set -o allexport`. That keeps `input_json_data` from being auto-exported. Variables set later by the step script (under allexport) still get the export attribute, which is what allexport is there for.
 
 ### Naming convention for step IDs
 
@@ -556,6 +557,70 @@ main
 _main_exit_code=$?
 exit ${_main_exit_code}
 ```
+
+---
+
+## Anti-pattern: exporting heredoc-captured JSON
+
+**Don't do this:**
+
+```yaml
+run: |
+  input_json_data=$(cat <<'EOF'
+  ${{ inputs.json-data }}
+  EOF
+  )
+  export input_json_data           # ← anti-pattern
+  source "${{ github.action_path }}/step_my_step.sh"
+```
+
+Equally bad — capturing under allexport:
+
+```yaml
+run: |
+  set -o allexport
+  input_json_data=$(cat <<'EOF'    # ← variables created under allexport are auto-exported
+  ${{ inputs.json-data }}
+  EOF
+  )
+  source "${{ github.action_path }}/step_my_step.sh"
+```
+
+### Why it breaks
+
+Under either form, `input_json_data` is in the shell's exported-variable set. At the next `fork+execve` — any time the step calls `jq`, `gh`, `terraform`, or any other external command — bash builds `envp` from the exported set. Linux enforces two limits on `envp`:
+
+- `ARG_MAX` (~2 MB total across argv + envp), and
+- `MAX_ARG_STRLEN` (128 KB per individual string on Ubuntu).
+
+The 128 KB per-string limit is the closer one in practice — a single big JSON input (a long PR body in `github.event`, a 65 KB plan extract, the full `toJSON(steps)` for a busy matrix job) trips it. The fork fails with exit 126 "Argument list too long". The original step looks like it succeeded; whatever it forks dies. The bug is **size-dependent**, so it doesn't appear in tests and only surfaces in production on a calling repo with a big-enough input.
+
+### Why it bites repeatedly
+
+The pattern looks reasonable: the script is sourced from the shim, so why wouldn't you "make sure" the variable is visible by exporting it? But sourcing a script means it runs in the **same shell** — the script already sees the caller's variable table without `export`. The `export` only changes what reaches forked subprocesses, which is exactly where the danger lives. Once you internalize "source sees locals" the temptation to `export` evaporates.
+
+This repo has been bitten by this exact bug multiple times: `capture-matrix-job-meta` (steps context with embedded plan extracts), `aggregate-validation-summaries` (paginated `gh api` responses), `pr-comment` (user-supplied comment body), `auto-merge-pr` (`github.event` JSON on PRs with long descriptions). Each fix was a one-line removal of the `export` (plus, in the more sophisticated cases, an internal switch from `--argjson` to `--slurpfile` for jq). Reference implementations are in the corresponding action directories.
+
+### The safe pattern (recap)
+
+```yaml
+run: |
+  # Heredoc capture, NOT exported.
+  input_json_data=$(cat <<'EOF'
+  ${{ inputs.json-data }}
+  EOF
+  )
+
+  # set -o allexport AFTER the heredoc so this variable isn't auto-exported.
+  set -o allexport
+  source "${{ github.action_path }}/step_my_step.sh"
+```
+
+Inside the step script: read `${input_json_data}` directly, or — if it might be very large and needs to be passed to a forked tool — write it to a tempfile and pass the path (`jq --slurpfile`, `gh api -F body=@<file>`, etc). See [CLAUDE.md → "Watch for ARG_MAX in step scripts"](../CLAUDE.md) for the in-tree reference patterns.
+
+### When to actually export
+
+`export FOO=value` is correct when you need an external command (e.g., `terraform`) to see `FOO` via the environment. In that case the data is bounded (a directory path, a flag, a token) and won't trip ARG_MAX. The anti-pattern is specifically about exporting **large user-supplied content** that the step only reads.
 
 ---
 


### PR DESCRIPTION
## Motivation

Repo audit (after the per-group upsert work in PR #40) found another instance of the export-heredoc-captured-JSON anti-pattern: [`auto-merge-pr/action.yml`](auto-merge-pr/action.yml) captures `github.event` into `input_github_event_context_json` via heredoc, then explicitly `export`s it before sourcing the step. `github.event` for PR events can be 30–100+ KB (long descriptions, large reviewer lists, labels). Ubuntu's `MAX_ARG_STRLEN` is 128 KB per envp string — a sufficiently large PR description tips every subsequent `gh` / `jq` fork inside `step_auto_merge_pr.sh` over the limit, exit 126 "Argument list too long". Same failure class that hit `capture-matrix-job-meta`, `aggregate-validation-summaries`, and `pr-comment` previously.

## Changes

- **`auto-merge-pr/action.yml`** — drop the `export input_github_event_context_json` line. The step script is `source`d in the same shell and reads the heredoc-captured variable as a shell-local; the `export` was unnecessary as well as unsafe. Replaces the previous comment with a why-not so the next contributor doesn't reintroduce it.
- **`CLAUDE.md`** — new subsection "Watch for ARG_MAX in step scripts" enumerating the four in-tree reference patterns (`tail -c` for file tails, `mktemp` + redirect for `gh api` responses, `jq --slurpfile` for JSON merges, heredoc + `body=@file` for gh CLI inputs).
- **`docs/Action-implementation-guide.md`** — the unsafe JSON-input shim example (which previously showed `export input_json_data` — the exact bug) is replaced with the safe shell-local pattern. Adds a new "Anti-pattern: exporting heredoc-captured JSON" section explaining the failure mode, why the pattern keeps being re-introduced (sourcing makes export feel correct), and when exporting is legitimately needed. The previous guide example was load-bearing — it was the template contributors copy/pasted, which is how the bug spread.

`terraform-init/action.yml` was flagged in my initial audit but turned out to be a stale read on my part — its current `main` form doesn't have the anti-pattern.

## Test coverage

- `auto-merge-pr/run_all_tests.sh` — **24 / 24 passing** locally. The action's tests don't exercise envp size, but the existing tests cover the actual behavior (PR matching, mergeability checks, github.event parsing) — they continue to pass with the variable now read as a shell-local rather than from envp.
- No new tests for the ARG_MAX-failure path itself — reproducing it would require constructing a >128 KB `github.event` fixture, which is impractical and brittle. The structural fix (removing the `export`) is what prevents the failure; the in-tree reference patterns are the lint-by-eye for future contributors.

## Dev tag for end-to-end testing

Branch is tagged `heredoc-export-dev` and the dev-tag swap has been applied (commits use `@heredoc-export-dev` instead of `@v0`). Calling repos can point at:

```yaml
uses: dsb-norge/github-actions-terraform/.github/workflows/terraform-ci-cd-default.yml@heredoc-export-dev
```

Before merge: revert the `chore: dev-tag swap` commit and delete the tag per `docs/Development-and-release.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
