### PR TITLE
feat: per-goal environment variables

### DIFF
--- a/.github/scripts/discover-actions.sh
+++ b/.github/scripts/discover-actions.sh
@@ -22,15 +22,14 @@ set -o pipefail
 set -o errexit
 
 # Hard exclusions: actions skipped regardless of whether run_all_tests.sh exists.
-# Keep this list in sync with docs/Testing-in-ci.md §3.
-EXCLUDED=(
-  create-tf-vars-matrix
-)
+# Keep this list in sync with docs/Testing-in-ci.md §3. Currently empty — the
+# array and the guard stay so re-adding an exclusion is a one-line change.
+EXCLUDED=()
 
 function is_excluded {
   local name="${1}"
   local entry
-  for entry in "${EXCLUDED[@]}"; do
+  for entry in ${EXCLUDED[@]+"${EXCLUDED[@]}"}; do
     [[ "${entry}" == "${name}" ]] && return 0
   done
   return 1

--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -62,6 +62,14 @@ on:
             - extra-envs-from-secrets-yml
                 YAML objects, make environment variables with secrets available, see the workflow input 'extra-envs-from-secrets-yml'.
                 note: this is a per environment setting, use the workflow input for a global setting that applies to all environments.
+            - extra-envs-from-secrets-per-goal-yml
+                YAML objects keyed by goal, make environment variables with secrets available to a single goal, see the workflow input 'extra-envs-from-secrets-per-goal-yml'.
+                note: this is a per environment setting, use the workflow input for a global setting that applies to all environments.
+                note: merged with the global value per goal key, so overriding one variable for one goal keeps that goal's other variables.
+            - extra-envs-per-goal-yml
+                YAML objects keyed by goal, make environment variables available to a single goal, see the workflow input 'extra-envs-per-goal-yml'.
+                note: this is a per environment setting, use the workflow input for a global setting that applies to all environments.
+                note: merged with the global value per goal key, so overriding one variable for one goal keeps that goal's other variables.
             - extra-envs-yml
                 YAML objects, make environment variables available, see the workflow input 'extra-envs-yml'.
                 note: this is a per environment setting, use the workflow input for a global setting that applies to all environments.
@@ -165,6 +173,65 @@ on:
               ARM_SUBSCRIPTION_ID: NAME_OF_GITHUB_SECRET_WITH_AZURE_SUBSCRIPTION_ID
 
           NOTE: This applies to all environments, for single environment specify this directly in the environment specification.
+        required: false
+        default: "{}" # empty object
+      extra-envs-per-goal-yml:
+        type: string
+        description: |
+          Key value pairs of environment variables to make available to a single terraform goal only, as opposed to 'extra-envs-yml' which applies to every goal.
+
+          Motivating case is memory tuning: 'plan' may need a much higher GOMEMLIMIT than 'validate', and a GOGC low enough to keep 'plan' inside a runner's memory would needlessly slow down 'lint'.
+
+          The values are applied to the goal's own process only, they do not reach any other step in the job. A YAML null value ('~') unsets the variable for that goal rather than setting it to the empty string.
+
+          Type: YAML object of objects, keyed by goal:
+            key:    goal name, one of: init, format, validate, lint, plan, apply, destroy-plan, destroy
+                    note: 'all' is NOT a valid key — it is not a stage. Use 'extra-envs-yml' for values that apply to every goal.
+                    note: the key is 'format', even though the workflow step is named 'fmt'.
+                    note: 'destroy-plan' / 'destroy' are separate from 'plan' / 'apply', which is what lets a destroy plan be tuned independently.
+            value:  YAML object of environment variables, as in 'extra-envs-yml'
+          Example:
+            extra-envs-per-goal-yml: |
+              plan:
+                GOMEMLIMIT: 12GiB
+                GOGC: 25
+              apply:
+                GOMEMLIMIT: ~     # unset for apply
+              lint:
+                GOGC: 400
+
+          An unknown goal key is a hard error, so a typo fails loudly instead of silently doing nothing.
+
+          Consider terraform's own 'TF_CLI_ARGS_<subcommand>' via 'extra-envs-yml' first — it covers anything expressible as CLI flags with no per-goal configuration at all. Caveat: it applies to both plan invocations, 'plan' and 'destroy-plan'.
+
+          NOTE: This applies to all environments, for single environment specify this directly in the environment specification.
+          Per environment values are deep merged with the global ones, so overriding one variable for one goal keeps that goal's other variables.
+
+          See docs/Workflow-terraform-ci-default.md for details.
+        required: false
+        default: "{}" # empty object
+      extra-envs-from-secrets-per-goal-yml:
+        type: string
+        description: |
+          Key value pairs of environment variables to make available to a single terraform goal only, with values retrieved from github secrets. The secret-sourced counterpart to 'extra-envs-per-goal-yml'.
+
+          IMPORTANT: these values reach the terraform/tflint process for that goal, NOT the workflow's 'Login to Azure' step.
+          A reader service principal for 'plan' and a contributor for 'apply' therefore does NOT work through this input: 'azure/login' runs once, early, and reads job-wide environment variables. Handing terraform a different ARM_CLIENT_ID after the OIDC token was already minted for another identity changes nothing. Use this for values terraform or a provider reads directly.
+
+          Type: YAML object of objects, keyed by goal (same keys as 'extra-envs-per-goal-yml'):
+            key:    goal name, one of: init, format, validate, lint, plan, apply, destroy-plan, destroy
+            value:  YAML object mapping environment variable name -> secret name to get the value from
+          Example:
+            extra-envs-from-secrets-per-goal-yml: |
+              plan:
+                TF_VAR_readonly_token: NAME_OF_GITHUB_SECRET
+
+          A secret name that is not available to the workflow is a hard error.
+
+          NOTE: This applies to all environments, for single environment specify this directly in the environment specification.
+          Per environment values are deep merged with the global ones.
+
+          See docs/Workflow-terraform-ci-default.md for details.
         required: false
         default: "{}" # empty object
       terraform-version:

--- a/.github/workflows/terraform-ci-cd-default.yml
+++ b/.github/workflows/terraform-ci-cd-default.yml
@@ -595,6 +595,21 @@ jobs:
           extra-envs-from-secrets: ${{ toJSON(matrix.vars.extra-envs-from-secrets) }}
           secrets-json: ${{ toJSON(secrets) }}
 
+      # Resolves the effective environment for every goal into one file per
+      # goal under $RUNNER_TEMP, and outputs that directory. The goal steps
+      # below receive a path, never a payload — see
+      # docs/Per-goal-environment-variables.md §3. This is the only step
+      # besides export-env-vars that is handed the secrets bag.
+      - name: "🎰 Resolve per-goal environment variables"
+        id: goal-envs
+        uses: dsb-norge/github-actions-terraform/resolve-goal-envs@v0
+        with:
+          extra-envs: ${{ toJSON(matrix.vars.extra-envs) }}
+          extra-envs-from-secrets: ${{ toJSON(matrix.vars.extra-envs-from-secrets) }}
+          extra-envs-per-goal: ${{ toJSON(matrix.vars.extra-envs-per-goal) }}
+          extra-envs-from-secrets-per-goal: ${{ toJSON(matrix.vars.extra-envs-from-secrets-per-goal) }}
+          secrets-json: ${{ toJSON(secrets) }}
+
       - name: "🔑 Login to Azure"
         uses: azure/login@v3
         if: env.ARM_TENANT_ID != '' && env.ARM_SUBSCRIPTION_ID != '' && env.ARM_CLIENT_ID != ''
@@ -638,6 +653,7 @@ jobs:
           environment-name: ${{ matrix.vars.github-environment }}
           additional-dirs-json: ${{ toJSON(matrix.vars.terraform-init-additional-dirs) }}
           plugin-cache-directory: ${{ steps.setup-terraform-cache.outputs.plugin-cache-directory }}
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/init.json
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       # Verify the committed .terraform.lock.hcl covers all required platforms.
@@ -665,6 +681,7 @@ jobs:
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           format-check-in-root-dir: ${{ matrix.vars.format-check-in-root-dir }}
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/format.json
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: ✔ Terraform Validate
@@ -674,6 +691,7 @@ jobs:
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: ${{ matrix.vars.github-environment }}
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/validate.json
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: 🧹 Lint with TFLint
@@ -682,6 +700,7 @@ jobs:
         uses: dsb-norge/github-actions-terraform/lint-with-tflint@v0
         with:
           working-directory: ${{ matrix.vars.project-dir }}
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/lint.json
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: 📖 Terraform Plan
@@ -691,6 +710,7 @@ jobs:
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: ${{ matrix.vars.github-environment }}
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/plan.json
         continue-on-error: true # allow job to continue, step outcome is evaluated later
 
       - name: "🔍 Parse terraform plan"
@@ -1032,6 +1052,7 @@ jobs:
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.plan.outputs.terraform-plan-file }}
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/apply.json
         # do not terminate if configured to ignore, fromJSON ensures bool
         continue-on-error: ${{ fromJSON(matrix.vars.allow-failing-terraform-operations) }}
 
@@ -1045,6 +1066,7 @@ jobs:
           working-directory: ${{ matrix.vars.project-dir }}
           environment-name: "${{ matrix.vars.github-environment }}-destroy"
           extra-plan-args: -destroy
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/destroy-plan.json
         # do not terminate if configured to ignore, fromJSON ensures bool
         continue-on-error: ${{ fromJSON(matrix.vars.allow-failing-terraform-operations) }}
 
@@ -1074,6 +1096,7 @@ jobs:
         with:
           working-directory: ${{ matrix.vars.project-dir }}
           terraform-plan-file: ${{ steps.destroy-plan.outputs.terraform-plan-file }}
+          extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/destroy.json
         # do not terminate if configured to ignore, fromJSON ensures bool
         continue-on-error: ${{ fromJSON(matrix.vars.allow-failing-terraform-operations) }}
 
@@ -1087,6 +1110,17 @@ jobs:
           github-context-json: ${{ toJSON(github) }}
           steps-context-json: ${{ toJSON(steps) }}
         continue-on-error: true # never fail the job due to metadata capture
+
+      # The resolved files hold plaintext secret values. $RUNNER_TEMP is
+      # documented as emptied per job, but 'runs-on' is caller-overridable to
+      # self-hosted groups and composite actions cannot declare 'post:' steps,
+      # so cleanup is explicit rather than delegated to runner behavior.
+      - name: "🧹 Shred resolved environment files"
+        if: always()
+        run: |
+          dir='${{ steps.goal-envs.outputs.envs-dir }}'
+          [ -n "${dir}" ] && [ -d "${dir}" ] && rm -rf "${dir}" || :
+        continue-on-error: true # never fail the job over cleanup
 
   # Reconciles per-group PR comments according to the desired set computed from
   # matrix-job-meta-*.json artifacts. Runs unconditionally on PR events (not gated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ python3 -c "import yaml; yaml.safe_load(open('<path-to>.yml'))"
 python3 -c "import json; json.load(open('<path-to>.json'))"
 ```
 
-The matrix-builder test harness (`create-tf-vars-matrix/test_action_source.sh`) is a known-flaky direct-invocation harness that requires a real tty and may fail on pristine main; rely on the modern per-action `run_all_tests.sh` suites where they exist.
+`create-tf-vars-matrix` has a modern `run_all_tests.sh` (helper unit tests + fixture-driven runs of the step source extracted from `action.yml` by `extract_step_source.py`) and is enrolled in CI like every other action. The older `test_action_source.sh` harness is a known-flaky direct-invocation harness that requires a real tty and may fail on pristine main — it is kept for manual debugging only and CI does not run it.
 
 ## Development workflow (see `docs/Development-and-release.md` for full procedure)
 

--- a/create-tf-vars-matrix/action.yml
+++ b/create-tf-vars-matrix/action.yml
@@ -32,7 +32,9 @@ runs:
         #  - pr-auto-merge-enabled
         YML_INPUTS=(
           environments-yml
+          extra-envs-from-secrets-per-goal-yml
           extra-envs-from-secrets-yml
+          extra-envs-per-goal-yml
           extra-envs-yml
           goals-yml
           pr-auto-merge-from-actors-yml
@@ -160,7 +162,9 @@ runs:
           #   - if defined merge with global value, otherwise use global
           #   - '*-yml' becomes '*'
           MERGE_INPUT_YML_FIELDS=(
+            extra-envs-from-secrets-per-goal-yml
             extra-envs-from-secrets-yml
+            extra-envs-per-goal-yml
             extra-envs-yml
             pr-auto-merge-from-actors-yml
             pr-auto-merge-limits-yml
@@ -177,9 +181,25 @@ runs:
               # merge env with global, env wins in cases where defined both places
               log-info "'${MERGE_FIELD}' was specified for environment, merging with global value"
               ENV_JSON=$(get-val "${MERGE_FIELD}" | yq e -o=json -)
-              MERGED_JSON=$(echo "${GLOBAL_ENVS_JSON} ${ENV_JSON}" | jq -s 'add')
+              MERGED_JSON=$(merge-yml-field-json "${GLOBAL_ENVS_JSON}" "${ENV_JSON}")
               set-field-from-json "${MERGE_FIELD//-yml/}" "${MERGED_JSON}" # modifies $ENVIRONMENT_OBJ
             fi
+          done
+
+          # per-goal env maps must contain all goal keys:
+          #   the workflow renders 'toJSON(matrix.vars.extra-envs-per-goal.plan)'
+          #   per goal, and an absent key renders as the four-character string
+          #   'null' — invalid input for the resolver's jq. Defaulting each key
+          #   to '{}' here means the resolver always receives an object.
+          PER_GOAL_FIELDS=(
+            extra-envs-from-secrets-per-goal
+            extra-envs-per-goal
+          )
+          log-info "Normalizing goal keys in per-goal yml fields ..."
+          for PER_GOAL_FIELD in ${PER_GOAL_FIELDS[*]}; do
+            log-info "Processing per-goal field '${PER_GOAL_FIELD}' ..."
+            NORMALIZED_JSON=$(normalize-goal-keys-json "$(get-val "${PER_GOAL_FIELD}")")
+            set-field-from-json "${PER_GOAL_FIELD}" "${NORMALIZED_JSON}" # modifies $ENVIRONMENT_OBJ
           done
 
           # yml fields should not exist in output
@@ -226,6 +246,8 @@ runs:
           environment
           extra-envs
           extra-envs-from-secrets
+          extra-envs-from-secrets-per-goal
+          extra-envs-per-goal
           github-environment
           goals
           pr-auto-merge-enabled

--- a/create-tf-vars-matrix/action.yml
+++ b/create-tf-vars-matrix/action.yml
@@ -181,7 +181,11 @@ runs:
               # merge env with global, env wins in cases where defined both places
               log-info "'${MERGE_FIELD}' was specified for environment, merging with global value"
               ENV_JSON=$(get-val "${MERGE_FIELD}" | yq e -o=json -)
-              MERGED_JSON=$(merge-yml-field-json "${GLOBAL_ENVS_JSON}" "${ENV_JSON}")
+              if ! MERGED_JSON=$(merge-yml-field-json "${GLOBAL_ENVS_JSON}" "${ENV_JSON}"); then
+                log-error "unable to merge the environment's '${MERGE_FIELD}' with the global value!"
+                log-error "the two are probably of different shapes, e.g. a mapping globally and a plain value per environment."
+                exit 1
+              fi
               set-field-from-json "${MERGE_FIELD//-yml/}" "${MERGED_JSON}" # modifies $ENVIRONMENT_OBJ
             fi
           done

--- a/create-tf-vars-matrix/extract_step_source.py
+++ b/create-tf-vars-matrix/extract_step_source.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Extract one step's `run:` block from action.yml into a runnable script.
+
+Used by run_all_tests.sh so the tests exercise the action's real inline bash
+rather than a copy of it. GitHub Actions expressions are substituted with
+literal text (no shell escaping involved, unlike a sed-based approach — the
+inputs are JSON blobs full of quotes and slashes).
+
+Usage:
+  extract_step_source.py <action.yml> <step-id> <out-file> [KEY=path-or-value ...]
+
+Each trailing argument replaces one expression:
+  inputs.inputs-json=@/path/to/file    -> contents of the file
+  github.ref_name=main                 -> the literal value
+"""
+
+import sys
+import yaml
+
+
+def main() -> int:
+    action_file, step_id, out_file = sys.argv[1:4]
+    substitutions = sys.argv[4:]
+
+    with open(action_file, encoding="utf-8") as handle:
+        action = yaml.safe_load(handle)
+
+    steps = action["runs"]["steps"]
+    matches = [step for step in steps if step.get("id") == step_id]
+    if not matches:
+        available = ", ".join(str(step.get("id")) for step in steps)
+        print(f"no step with id '{step_id}' (have: {available})", file=sys.stderr)
+        return 1
+
+    source = matches[0]["run"]
+
+    for substitution in substitutions:
+        key, _, value = substitution.partition("=")
+        if value.startswith("@"):
+            with open(value[1:], encoding="utf-8") as handle:
+                value = handle.read()
+        # Both spacing variants occur in this repo's action definitions.
+        for expression in (f"${{{{ {key} }}}}", f"${{{{{key}}}}}"):
+            source = source.replace(expression, value)
+
+    with open(out_file, "w", encoding="utf-8") as handle:
+        handle.write("#!/bin/env bash\n")
+        handle.write(source)
+        if not source.endswith("\n"):
+            handle.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/create-tf-vars-matrix/helpers_additional.sh
+++ b/create-tf-vars-matrix/helpers_additional.sh
@@ -21,5 +21,69 @@ function fail-field {
   end-group
 }
 
+# merge and normalize yml fields
+# ==========================================================
+
+# The goal keys valid in the per-goal environment-variable maps. Same
+# vocabulary a caller writes in 'goals-yml', except that 'all' is not a goal:
+# it is shorthand expanded inside each workflow step's 'if:', so there is
+# nothing to attach per-goal values to. The every-goal layer is the plain
+# 'extra-envs-yml'. Kept in sync with the 'resolve-goal-envs' action and
+# docs/Per-goal-environment-variables.md §2.2 — the resolver hard-fails on
+# keys outside this list, which is what makes 'all:' fail loudly here rather
+# than being silently dropped.
+GOAL_KEYS=(
+  init
+  format
+  validate
+  lint
+  plan
+  apply
+  destroy-plan
+  destroy
+)
+
+# Merge a global '*-yml' field value ($1) with an environment-specific one
+# ($2), environment wins.
+#
+# 'add' is a shallow merge: correct for the flat scalar maps, and the only
+# thing jq defines for arrays — 'pr-auto-merge-from-actors-yml' is a YAML
+# array and '*' errors on arrays outright. '*' recurses into objects while
+# replacing scalars, which is what the nested per-goal maps need: a
+# per-environment override of one goal must not discard that goal's other
+# keys. The two are provably identical for flat objects of scalars, so the
+# array case is the only one that forces the dispatch. '*' also preserves
+# null leaves, which the "a null value unsets the variable" semantics depend
+# on. Ref. docs/Per-goal-environment-variables.md §9.5.
+function merge-yml-field-json {
+  printf '%s\n%s\n' "${1}" "${2}" | jq -s '
+    if   (.[0] == null) then .[1]
+    elif (.[1] == null) then .[0]
+    elif ((.[0] | type) == "array") then add
+    else .[0] * .[1]
+    end
+  '
+}
+
+# Normalize a per-goal environment-variable map ($1) so that every goal key
+# exists, defaulting to an empty object.
+#
+# Without this, 'toJSON(matrix.vars.extra-envs-per-goal.plan)' in the workflow
+# renders the four-character string 'null' for an absent key, which then
+# reaches the resolver's jq as invalid input. Unknown keys are passed through
+# untouched — rejecting them is the resolver's job, so the caller gets one
+# error message from one place.
+function normalize-goal-keys-json {
+  local in_json="${1}" keys_json
+  [ -z "${in_json}" ] && in_json='{}'
+  keys_json=$(printf '%s\n' "${GOAL_KEYS[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')
+  printf '%s\n' "${in_json}" | jq -c --argjson keys "${keys_json}" '
+    ( . // {} )
+    | if type != "object" then . else
+        reduce $keys[] as $k (.; if has($k) then . else .[$k] = {} end)
+      end
+  '
+}
+
 # ==========================================================
 log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/create-tf-vars-matrix/run_all_tests.sh
+++ b/create-tf-vars-matrix/run_all_tests.sh
@@ -45,10 +45,11 @@ call_helper() {
   )
 }
 
-# Run the action's 'create-vars' step against an inputs-json fixture.
+# Run the action's 'create-vars' step against an inputs-json fixture, or
+# against FIXTURE_OVERRIDE when set (see run_create_vars_json).
 # Populates LAST_EXIT and MATRIX_JSON.
 run_create_vars() {
-  local fixture="${_this_script_dir}/test_data/${1}_inputs-json.json"
+  local fixture="${FIXTURE_OVERRIDE:-${_this_script_dir}/test_data/${1}_inputs-json.json}"
   local branch="${2:-main}"
 
   WORK_DIR="$(mktemp -d)"
@@ -75,7 +76,10 @@ STUB
 
   (
     cd "${GITHUB_WORKSPACE}" || exit 1
-    PATH="${WORK_DIR}/stub-bin:${PATH}" bash "${WORK_DIR}/step_create_vars.sh"
+    # Same shell flags the runner uses ('bash --noprofile --norc -eo pipefail'),
+    # so a failure the runner's errexit would catch is caught here too.
+    PATH="${WORK_DIR}/stub-bin:${PATH}" \
+      bash --noprofile --norc -eo pipefail "${WORK_DIR}/step_create_vars.sh"
   ) >"${OUT_FILE}" 2>&1
   LAST_EXIT=$?
 
@@ -94,9 +98,21 @@ run_validate() {
 
   (
     cd "${GITHUB_WORKSPACE}" || exit 1
-    bash "${WORK_DIR}/step_validate.sh"
+    bash --noprofile --norc -eo pipefail "${WORK_DIR}/step_validate.sh"
   ) >"${OUT_FILE}" 2>&1
   LAST_EXIT=$?
+}
+
+# Run 'create-vars' against inline inputs-json rather than a fixture file, for
+# the one-off malformed cases the three shared fixtures should not carry.
+run_create_vars_json() {
+  local json="${1}"
+  local tmp
+  tmp="$(mktemp -d)"
+  printf '%s' "${json}" >"${tmp}/inputs.json"
+  FIXTURE_OVERRIDE="${tmp}/inputs.json"
+  run_create_vars '' ''
+  FIXTURE_OVERRIDE=""
 }
 
 # Read a multiline output (name<<"DELIM" ... "DELIM") from $GITHUB_OUTPUT.
@@ -365,6 +381,107 @@ assert "invalid yaml: error names the offending input" \
 # ======================================================================
 # Summary
 # ======================================================================
+# ======================================================================
+# Negative cases
+# ======================================================================
+
+# Minimal valid inputs-json, as a base for the malformed variants below.
+BASE_INPUTS='{
+  "environments-yml": "- environment: \"my-tf-env\"\n",
+  "goals-yml": "[all]",
+  "extra-envs-from-secrets-yml": "{}",
+  "extra-envs-yml": "{}",
+  "extra-envs-per-goal-yml": "{}",
+  "extra-envs-from-secrets-per-goal-yml": "{}",
+  "terraform-version": "latest",
+  "tflint-version": "latest",
+  "add-pr-comment": "true",
+  "verify-lock-file": "true",
+  "pr-comment-group": "",
+  "pr-auto-merge-enabled": "false",
+  "pr-auto-merge-from-actors-yml": "[]",
+  "pr-auto-merge-limits-yml": "plan-max-count-add: 0\n"
+}'
+
+# ----------------------------------------------------------------------
+# An environment entry without the one required field
+# ----------------------------------------------------------------------
+run_create_vars_json "$(printf '%s' "${BASE_INPUTS}" | jq -c '.["environments-yml"] = "- project-dir: \".\"\n"')"
+assert "negative: an environment without 'environment' fails" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the missing property" \
+  grep -q "Missing property 'environment' in environments-yml" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# An empty environments-yml — nothing to build a matrix from
+# ----------------------------------------------------------------------
+run_create_vars_json "$(printf '%s' "${BASE_INPUTS}" | jq -c '.["environments-yml"] = "[]"')"
+assert "negative: an empty environments list still produces output" \
+  test "${LAST_EXIT}" -eq 0
+assert_eq "negative: ... and that output is an empty array" \
+  '0' "$(printf '%s' "${MATRIX_JSON}" | jq -c 'length')"
+run_validate
+assert "negative: the validate step rejects an empty matrix" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says the specification is empty" \
+  grep -q 'The specification is an empty array' "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Type mismatch between the global and per-environment value of a merged
+# field. Better a loud jq failure than a silently mangled matrix.
+# ----------------------------------------------------------------------
+run_create_vars_json "$(printf '%s' "${BASE_INPUTS}" \
+  | jq -c '.["extra-envs-per-goal-yml"] = "plan:\n  GOGC: 25\n"
+         | .["environments-yml"] = "- environment: \"my-tf-env\"\n  extra-envs-per-goal-yml: \"a plain string\"\n"')"
+assert "negative: an object-versus-string merge fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error explains the shape mismatch rather than dumping jq" \
+  grep -q 'the two are probably of different shapes' "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# The validate step's own guards, driven directly
+# ----------------------------------------------------------------------
+run_create_vars 'test_input_minimal'
+assert "validate: the baseline matrix is valid" test "${LAST_EXIT}" -eq 0
+
+# A required field removed from an otherwise valid matrix.
+MATRIX_JSON="$(printf '%s' "${MATRIX_JSON}" | jq -c 'map(del(.["extra-envs-per-goal"]))')"
+run_validate
+assert "negative: a missing required field fails validation" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the field" \
+  grep -q "Missing property 'extra-envs-per-goal'" "${OUT_FILE}"
+
+# project-dir must point at a directory that exists.
+run_create_vars 'test_input_minimal'
+MATRIX_JSON="$(printf '%s' "${MATRIX_JSON}" | jq -c 'map(.["project-dir"] = "./envs/does-not-exist")')"
+run_validate
+assert "negative: a non-existent project-dir fails validation" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'does not exist, make sure' "${OUT_FILE}"
+
+# An empty value in a NOT_EMPTY field. The two new per-goal fields are
+# deliberately absent from that list, since '{}' is a legitimate value.
+run_create_vars 'test_input_minimal'
+MATRIX_JSON="$(printf '%s' "${MATRIX_JSON}" | jq -c 'map(.["terraform-version"] = "")')"
+run_validate
+assert "negative: an empty required-non-empty field fails validation" \
+  test "${LAST_EXIT}" -ne 0
+assert "negative: the error says the property is empty" \
+  grep -q "Property 'terraform-version' is empty" "${OUT_FILE}"
+
+run_create_vars 'test_input_minimal'
+MATRIX_JSON="$(printf '%s' "${MATRIX_JSON}" | jq -c 'map(.["extra-envs-per-goal"] = {})')"
+run_validate
+assert "positive: an empty per-goal map is accepted, not treated as empty" \
+  test "${LAST_EXIT}" -eq 0
+
+# ----------------------------------------------------------------------
+# normalize-goal-keys-json leaves a non-object alone rather than guessing.
+# resolve-goal-envs is what rejects it, so the caller gets one error from one
+# place.
+# ----------------------------------------------------------------------
+assert_eq "normalize: an array input is passed through untouched" \
+  '[1,2]' "$(call_helper normalize-goal-keys-json '[1,2]' | jq -c .)"
+assert_eq "normalize: a string input is passed through untouched" \
+  '"nope"' "$(call_helper normalize-goal-keys-json '"nope"' | jq -c .)"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}      CREATE-TF-VARS-MATRIX SUMMARY         ${NC}"

--- a/create-tf-vars-matrix/run_all_tests.sh
+++ b/create-tf-vars-matrix/run_all_tests.sh
@@ -1,0 +1,382 @@
+#!/bin/env bash
+#
+# Tests for create-tf-vars-matrix.
+#
+# Two layers:
+#
+#  1. Unit tests of the merge/normalize helpers in helpers_additional.sh.
+#  2. Fixture-driven runs of the action's real inline bash. The 'create-vars'
+#     and 'validate' steps are extracted from action.yml by
+#     extract_step_source.py (literal expression substitution, no shell
+#     escaping) and executed against the JSON fixtures in test_data/, with a
+#     stub 'curl' standing in for the GitHub API call that resolves the calling
+#     repo's default branch.
+#
+# This is deterministic and needs no tty, unlike the older
+# test_action_source.sh harness, which remains for manual debugging.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+OUT_FILE=/tmp/test_output_create_tf_vars_matrix.txt
+
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+# Call a function from helpers_additional.sh in a subshell, so the helpers'
+# load-time logging never mixes into the value under test.
+call_helper() {
+  (
+    source "${_this_script_dir}/helpers.sh" >/dev/null 2>&1
+    "$@"
+  )
+}
+
+# Run the action's 'create-vars' step against an inputs-json fixture.
+# Populates LAST_EXIT and MATRIX_JSON.
+run_create_vars() {
+  local fixture="${_this_script_dir}/test_data/${1}_inputs-json.json"
+  local branch="${2:-main}"
+
+  WORK_DIR="$(mktemp -d)"
+  export GITHUB_OUTPUT="${WORK_DIR}/output.txt"
+  : >"${GITHUB_OUTPUT}"
+  export GITHUB_WORKSPACE="${WORK_DIR}/ws"
+  # Directories the fixtures point 'project-dir' at.
+  mkdir -p "${GITHUB_WORKSPACE}/envs/my-tf-env"
+
+  mkdir -p "${WORK_DIR}/stub-bin"
+  cat >"${WORK_DIR}/stub-bin/curl" <<'STUB'
+#!/bin/env bash
+echo '{"default_branch":"main"}'
+STUB
+  chmod +x "${WORK_DIR}/stub-bin/curl"
+
+  python3 "${_this_script_dir}/extract_step_source.py" \
+    "${_this_script_dir}/action.yml" create-vars "${WORK_DIR}/step_create_vars.sh" \
+    "inputs.inputs-json=@${fixture}" \
+    "github.repository=dsb-norge/test-repo" \
+    "github.token=fake-token" \
+    "github.ref_name=${branch}" \
+    "github.action_path=${_this_script_dir}"
+
+  (
+    cd "${GITHUB_WORKSPACE}" || exit 1
+    PATH="${WORK_DIR}/stub-bin:${PATH}" bash "${WORK_DIR}/step_create_vars.sh"
+  ) >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+
+  MATRIX_JSON="$(read_multiline_output json)"
+}
+
+# Run the action's 'validate' step against the JSON produced by the most
+# recent run_create_vars. Populates LAST_EXIT.
+run_validate() {
+  printf '%s\n' "${MATRIX_JSON}" >"${WORK_DIR}/create-vars.json"
+
+  python3 "${_this_script_dir}/extract_step_source.py" \
+    "${_this_script_dir}/action.yml" validate "${WORK_DIR}/step_validate.sh" \
+    "steps.create-vars.outputs.json=@${WORK_DIR}/create-vars.json" \
+    "github.action_path=${_this_script_dir}"
+
+  (
+    cd "${GITHUB_WORKSPACE}" || exit 1
+    bash "${WORK_DIR}/step_validate.sh"
+  ) >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+}
+
+# Read a multiline output (name<<"DELIM" ... "DELIM") from $GITHUB_OUTPUT.
+read_multiline_output() {
+  python3 - "${GITHUB_OUTPUT}" "${1}" <<'PY'
+import re
+import sys
+
+path, name = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+match = re.search(
+    r'^%s<<"([^"]+)"\n(.*?)\n"\1"\s*$' % re.escape(name), text, re.S | re.M
+)
+print(match.group(2) if match else "", end="")
+PY
+}
+
+# jq query against MATRIX_JSON for a single environment.
+env_query() {
+  local environment="${1}" filter="${2}"
+  printf '%s' "${MATRIX_JSON}" \
+    | jq -c --arg env "${environment}" '.[] | select(.environment == $env) | '"${filter}"
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output (tail) ---"
+    tail -n 40 "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# assert_eq <name> <expected> <actual>
+assert_eq() {
+  local name="${1}" expected="${2}" actual="${3}"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if [[ "${expected}" == "${actual}" ]]; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}: expected '${expected}', got '${actual}'"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}       CREATE-TF-VARS-MATRIX TESTS          ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ======================================================================
+# merge-yml-field-json — the type dispatch
+# See docs/Per-goal-environment-variables.md §9.5.
+# ======================================================================
+
+assert_eq "merge: arrays concatenate (the case '*' cannot do)" \
+  '["a","b"]' \
+  "$(call_helper merge-yml-field-json '["a"]' '["b"]' | jq -c .)"
+
+assert_eq "merge: null global yields the environment value" \
+  '["b"]' \
+  "$(call_helper merge-yml-field-json 'null' '["b"]' | jq -c .)"
+
+assert_eq "merge: null environment yields the global value" \
+  '{"A":1}' \
+  "$(call_helper merge-yml-field-json '{"A":1}' 'null' | jq -c .)"
+
+assert_eq "merge: flat objects override per key (unchanged from 'add')" \
+  '{"A":1,"B":3}' \
+  "$(call_helper merge-yml-field-json '{"A":1,"B":2}' '{"B":3}' | jq -Sc .)"
+
+assert_eq "merge: nested objects deep merge, sibling keys survive" \
+  '{"plan":{"GOGC":25,"GOMEMLIMIT":"24GiB"}}' \
+  "$(call_helper merge-yml-field-json '{"plan":{"GOGC":25,"GOMEMLIMIT":"12GiB"}}' '{"plan":{"GOMEMLIMIT":"24GiB"}}' | jq -Sc .)"
+
+assert_eq "merge: nested objects keep untouched sibling goals" \
+  '{"lint":{"GOGC":400},"plan":{"GOGC":25}}' \
+  "$(call_helper merge-yml-field-json '{"plan":{"GOGC":25},"lint":{"GOGC":400}}' '{"plan":{"GOGC":25}}' | jq -Sc .)"
+
+assert_eq "merge: a null leaf survives the merge (unset semantics)" \
+  '{"plan":{"GOMEMLIMIT":null}}' \
+  "$(call_helper merge-yml-field-json '{"plan":{"GOMEMLIMIT":"6GiB"}}' '{"plan":{"GOMEMLIMIT":null}}' | jq -Sc .)"
+
+assert_eq "merge: environment scalar replaces global scalar" \
+  '{"A":"env"}' \
+  "$(call_helper merge-yml-field-json '{"A":"global"}' '{"A":"env"}' | jq -Sc .)"
+
+# ======================================================================
+# normalize-goal-keys-json
+# ======================================================================
+
+ALL_GOAL_KEYS='["apply","destroy","destroy-plan","format","init","lint","plan","validate"]'
+
+assert_eq "normalize: empty object gains all eight goal keys" \
+  "${ALL_GOAL_KEYS}" \
+  "$(call_helper normalize-goal-keys-json '{}' | jq -c '[keys[]] | sort')"
+
+assert_eq "normalize: every added key defaults to an empty object" \
+  'true' \
+  "$(call_helper normalize-goal-keys-json '{}' | jq -c '[.[] | . == {}] | all')"
+
+assert_eq "normalize: JSON null input becomes the full key set" \
+  "${ALL_GOAL_KEYS}" \
+  "$(call_helper normalize-goal-keys-json 'null' | jq -c '[keys[]] | sort')"
+
+assert_eq "normalize: empty string input becomes the full key set" \
+  "${ALL_GOAL_KEYS}" \
+  "$(call_helper normalize-goal-keys-json '' | jq -c '[keys[]] | sort')"
+
+assert_eq "normalize: existing goal values are preserved" \
+  '{"GOGC":25}' \
+  "$(call_helper normalize-goal-keys-json '{"plan":{"GOGC":25}}' | jq -c '.plan')"
+
+assert_eq "normalize: goals not mentioned still become empty objects" \
+  '{}' \
+  "$(call_helper normalize-goal-keys-json '{"plan":{"GOGC":25}}' | jq -c '.apply')"
+
+assert_eq "normalize: a null leaf inside a goal is preserved" \
+  'null' \
+  "$(call_helper normalize-goal-keys-json '{"apply":{"GOMEMLIMIT":null}}' | jq -c '.apply.GOMEMLIMIT')"
+
+# Unknown keys pass through untouched — rejecting them is resolve-goal-envs'
+# job, so a caller writing 'all:' gets one error from one place.
+assert_eq "normalize: an unknown goal key passes through untouched" \
+  '{"NOPE":1}' \
+  "$(call_helper normalize-goal-keys-json '{"all":{"NOPE":1}}' | jq -c '.all')"
+
+assert_eq "normalize: unknown keys do not stop the eight from being added" \
+  '9' \
+  "$(call_helper normalize-goal-keys-json '{"all":{}}' | jq -c '[keys[]] | length')"
+
+# ======================================================================
+# Fixture: minimal — everything defaulted
+# ======================================================================
+
+run_create_vars 'test_input_minimal'
+
+assert "minimal: create-vars step exits 0" test "${LAST_EXIT}" -eq 0
+assert "minimal: output is a non-empty JSON array" \
+  bash -c "[[ \$(printf '%s' '${MATRIX_JSON}' | jq -r 'type') == 'array' ]] && [[ \$(printf '%s' '${MATRIX_JSON}' | jq -r 'length') -ge 1 ]]"
+
+assert_eq "minimal: 'extra-envs-per-goal' has all eight goal keys" \
+  "${ALL_GOAL_KEYS}" \
+  "$(env_query my-tf-env '[.["extra-envs-per-goal"] | keys[]] | sort')"
+
+assert_eq "minimal: 'extra-envs-from-secrets-per-goal' has all eight goal keys" \
+  "${ALL_GOAL_KEYS}" \
+  "$(env_query my-tf-env '[.["extra-envs-from-secrets-per-goal"] | keys[]] | sort')"
+
+assert_eq "minimal: every per-goal entry defaults to an empty object" \
+  'true' \
+  "$(env_query my-tf-env '[.["extra-envs-per-goal"][] | . == {}] | all')"
+
+assert_eq "minimal: no '*-yml' fields survive into the matrix output" \
+  '[]' \
+  "$(env_query my-tf-env '[keys[] | select(endswith("-yml"))]')"
+
+run_validate
+assert "minimal: validate step exits 0" test "${LAST_EXIT}" -eq 0
+
+# ======================================================================
+# Fixture: happy day — global + per-environment values of everything
+# ======================================================================
+
+run_create_vars 'test_input_happy_day'
+
+assert "happy day: create-vars step exits 0" test "${LAST_EXIT}" -eq 0
+assert_eq "happy day: three environments produced" \
+  '3' \
+  "$(printf '%s' "${MATRIX_JSON}" | jq -c 'length')"
+
+# --- deep merge: the load-bearing case -------------------------------------
+# 'my-second-env' overrides only plan.GOMEMLIMIT. A shallow merge would
+# replace the whole 'plan' object and drop GOGC back to the global default.
+assert_eq "deep merge: per-env override keeps the goal's other keys" \
+  '{"GOGC":25,"GOMEMLIMIT":"24GiB"}' \
+  "$(env_query my-second-env '.["extra-envs-per-goal"].plan | to_entries | sort_by(.key) | from_entries')"
+
+assert_eq "deep merge: other environments keep the global value" \
+  '{"GOGC":25,"GOMEMLIMIT":"12GiB"}' \
+  "$(env_query my-first-env '.["extra-envs-per-goal"].plan | to_entries | sort_by(.key) | from_entries')"
+
+assert_eq "deep merge: goals the environment did not mention are untouched" \
+  '{"GOGC":400}' \
+  "$(env_query my-second-env '.["extra-envs-per-goal"].lint')"
+
+# --- null leaves ----------------------------------------------------------
+assert_eq "null leaf: survives into the matrix as JSON null, not a dropped key" \
+  'true' \
+  "$(env_query my-second-env '.["extra-envs-per-goal"].apply | has("GOMEMLIMIT")')"
+
+assert_eq "null leaf: value is JSON null" \
+  'null' \
+  "$(env_query my-second-env '.["extra-envs-per-goal"].apply.GOMEMLIMIT')"
+
+# --- per-goal secrets ----------------------------------------------------
+assert_eq "per-goal secrets: global and per-env entries are merged" \
+  '{"ARM_CLIENT_ID":"ARM_CLIENT_ID_secret","TF_VAR_my_custom":"more"}' \
+  "$(env_query my-second-env '.["extra-envs-from-secrets-per-goal"].apply | to_entries | sort_by(.key) | from_entries')"
+
+assert_eq "per-goal secrets: environments without an override get the global" \
+  '{"ARM_CLIENT_ID":"ARM_CLIENT_ID_secret"}' \
+  "$(env_query my-first-env '.["extra-envs-from-secrets-per-goal"].apply')"
+
+assert_eq "per-goal: all eight keys normalized for every environment" \
+  'true' \
+  "$(printf '%s' "${MATRIX_JSON}" | jq -c '[.[] | ([.["extra-envs-per-goal"] | keys[]] | length) == 8] | all')"
+
+# --- the array field the type dispatch exists for -------------------------
+# 'pr-auto-merge-from-actors-yml' is a YAML array. A blanket switch to jq's
+# '*' would make this a hard error instead of a concatenation.
+assert_eq "array field: global and per-env arrays concatenate" \
+  '["global-actor","env-actor"]' \
+  "$(env_query my-second-env '.["pr-auto-merge-from-actors"]')"
+
+assert_eq "array field: environments without an override get the global" \
+  '["global-actor"]' \
+  "$(env_query my-first-env '.["pr-auto-merge-from-actors"]')"
+
+# --- flat objects: unchanged behaviour -----------------------------------
+assert_eq "flat object: per-env limit overrides one key only" \
+  '5' \
+  "$(env_query my-second-env '.["pr-auto-merge-limits"]["plan-max-count-add"]')"
+
+assert_eq "flat object: other limit keys keep the global value" \
+  '-1' \
+  "$(env_query my-second-env '.["pr-auto-merge-limits"]["plan-max-count-import"]')"
+
+assert_eq "flat object: 'extra-envs' is unaffected by the merge change" \
+  '{"ANOTHER_ENV":"1 2 3","ARM_USE_AZUREAD":true,"ARM_USE_OIDC":true}' \
+  "$(env_query my-first-env '.["extra-envs"] | to_entries | sort_by(.key) | from_entries')"
+
+assert_eq "flat object: 'extra-envs-from-secrets' is unaffected too" \
+  '4' \
+  "$(env_query my-first-env '.["extra-envs-from-secrets"] | length')"
+
+assert_eq "happy day: no '*-yml' fields survive into the matrix output" \
+  'true' \
+  "$(printf '%s' "${MATRIX_JSON}" | jq -c '[.[] | [keys[] | select(endswith("-yml"))] | length == 0] | all')"
+
+run_validate
+assert "happy day: validate step exits 0" test "${LAST_EXIT}" -eq 0
+
+# ======================================================================
+# Fixture: invalid yaml — must fail loudly
+# ======================================================================
+
+run_create_vars 'test_input_fail_yml_spec'
+assert "invalid yaml: create-vars step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "invalid yaml: error names the offending input" \
+  grep -q "input 'extra-envs-from-secrets-yml' is not valid yaml" "${OUT_FILE}"
+
+# ======================================================================
+# Summary
+# ======================================================================
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}      CREATE-TF-VARS-MATRIX SUMMARY         ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/create-tf-vars-matrix/test_data/test_input_fail_yml_spec_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_fail_yml_spec_inputs-json.json
@@ -3,9 +3,14 @@
   "goals-yml": "[all]",
   "extra-envs-from-secrets-yml": "| invalid yaml!",
   "extra-envs-yml": "{}",
+  "extra-envs-per-goal-yml": "{}",
+  "extra-envs-from-secrets-per-goal-yml": "{}",
   "terraform-version": "latest",
   "tflint-version": "latest",
   "add-pr-comment": "true",
   "verify-lock-file": "true",
-  "pr-comment-group": ""
+  "pr-comment-group": "",
+  "pr-auto-merge-enabled": "false",
+  "pr-auto-merge-from-actors-yml": "[]",
+  "pr-auto-merge-limits-yml": "plan-max-count-add: 0\nplan-max-count-change: 0\nplan-max-count-destroy: 0\nplan-max-count-import: -1\nplan-max-count-move: -1\nplan-max-count-remove: 0\n"
 }

--- a/create-tf-vars-matrix/test_data/test_input_happy_day_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_happy_day_inputs-json.json
@@ -1,13 +1,18 @@
 {
-  "environments-yml": "- environment: \"my-first-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  format-check-in-root-dir: false\n  pr-comment-group: \"dev\"\n  terraform-init-additional-dirs-yml:\n    - \"./main\"\n    - \"./modules\"\n  goals-yml: [all, destroy-plan, destroy, apply-on-pr, destroy-plan-on-pr, destroy-on-pr]\n- environment: \"my-second-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  pr-comment-group: \"dev\"\n- environment: \"also an env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  goals-yml: [init, format, validate, lint]\n",
+  "environments-yml": "- environment: \"my-first-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  format-check-in-root-dir: false\n  pr-comment-group: \"dev\"\n  terraform-init-additional-dirs-yml:\n    - \"./main\"\n    - \"./modules\"\n  goals-yml: [all, destroy-plan, destroy, apply-on-pr, destroy-plan-on-pr, destroy-on-pr]\n- environment: \"my-second-env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  pr-comment-group: \"dev\"\n  extra-envs-per-goal-yml:\n    plan:\n      GOMEMLIMIT: 24GiB\n  extra-envs-from-secrets-per-goal-yml:\n    apply:\n      TF_VAR_my_custom: more\n  pr-auto-merge-from-actors-yml:\n    - \"env-actor\"\n  pr-auto-merge-limits-yml:\n    plan-max-count-add: 5\n- environment: \"also an env\"\n  project-dir: \".\"\n  url: \"https://github.com\"\n  goals-yml: [init, format, validate, lint]\n",
   "goals-yml": "[all, dummy, apple]",
   "extra-envs-from-secrets-yml": "ARM_CLIENT_ID: ARM_CLIENT_ID_secret\nARM_SUBSCRIPTION_ID: ARM_SUBSCRIPTION_ID_secret\nARM_TENANT_ID: ARM_TENANT_ID_secret\nTF_VAR_my_custom: TF_VAR_my_custom_secret\n",
   "extra-envs-yml": "ARM_USE_OIDC: true\nARM_USE_AZUREAD: true\nANOTHER_ENV: \"1 2 3\"",
+  "extra-envs-per-goal-yml": "plan:\n  GOMEMLIMIT: 12GiB\n  GOGC: 25\napply:\n  GOMEMLIMIT: ~\nlint:\n  GOGC: 400\n",
+  "extra-envs-from-secrets-per-goal-yml": "apply:\n  ARM_CLIENT_ID: ARM_CLIENT_ID_secret\n",
   "terraform-version": "1.4.4",
   "tflint-version": "v0.46.1",
   "terraform-init-additional-dirs-yml": "- \"./main\"\n- \"./module/1\"\n- \"./module/2\"\n",
   "format-check-in-root-dir": "true",
   "add-pr-comment": "true",
   "verify-lock-file": "true",
-  "pr-comment-group": ""
+  "pr-comment-group": "",
+  "pr-auto-merge-enabled": "true",
+  "pr-auto-merge-from-actors-yml": "- \"global-actor\"\n",
+  "pr-auto-merge-limits-yml": "plan-max-count-add: 0\nplan-max-count-change: 0\nplan-max-count-destroy: 0\nplan-max-count-import: -1\nplan-max-count-move: -1\nplan-max-count-remove: 0\n"
 }

--- a/create-tf-vars-matrix/test_data/test_input_minimal_inputs-json.json
+++ b/create-tf-vars-matrix/test_data/test_input_minimal_inputs-json.json
@@ -3,9 +3,14 @@
   "goals-yml": "[all]",
   "extra-envs-from-secrets-yml": "{}",
   "extra-envs-yml": "{}",
+  "extra-envs-per-goal-yml": "{}",
+  "extra-envs-from-secrets-per-goal-yml": "{}",
   "terraform-version": "latest",
   "tflint-version": "latest",
   "add-pr-comment": "true",
   "verify-lock-file": "true",
-  "pr-comment-group": ""
+  "pr-comment-group": "",
+  "pr-auto-merge-enabled": "false",
+  "pr-auto-merge-from-actors-yml": "[]",
+  "pr-auto-merge-limits-yml": "plan-max-count-add: 0\nplan-max-count-change: 0\nplan-max-count-destroy: 0\nplan-max-count-import: -1\nplan-max-count-move: -1\nplan-max-count-remove: 0\n"
 }

--- a/docs/Per-goal-environment-variables.md
+++ b/docs/Per-goal-environment-variables.md
@@ -1,0 +1,878 @@
+# Per-goal environment variables
+
+Status: **spec — design decisions settled, not yet implemented**. Living document — update as implementation lands.
+
+Lets callers set environment variables (plain and secret-sourced) for a single
+terraform goal rather than for the whole job. Motivating case: `GOMEMLIMIT` and
+`GOGC` tuned differently for `plan` than for the rest of the job.
+
+## 1. Why
+
+Today `extra-envs-yml` / `extra-envs-from-secrets-yml` resolve to a single set of
+values that `export-env-vars` writes to `$GITHUB_ENV`
+([export-env-vars/helpers_additional.sh:25-27](../export-env-vars/helpers_additional.sh#L25-L27)).
+`$GITHUB_ENV` is append-only and job-wide, so every value reaches every
+subsequent step — init, fmt, validate, lint, plan, apply, destroy, plus all the
+parse and PR-comment steps. Scope granularity is the environment (= the matrix
+row = the job), and nothing finer exists.
+
+That is wrong for values whose correct setting differs per stage. `plan` may need
+a much higher `GOMEMLIMIT` than `validate`; `terraform show -json` on a large plan
+is a serious allocator while `fmt` is not; a `GOGC` low enough to keep `plan`
+inside a runner's memory would needlessly slow down `lint`.
+
+Goals of this design:
+
+- Per-goal values for both plain and secret-sourced environment variables.
+- Values scoped to the goal's own process — not leaked into sibling steps.
+- Genuine *unset*, not just "set to empty string".
+- Exactly one place in the repo handles the secrets bag.
+- No large payload on `argv` or in `envp` (see [§8](#8-arg_max-and-payload-handling)).
+
+## 2. Caller-facing API
+
+### 2.1 New workflow inputs
+
+Two new inputs on `.github/workflows/terraform-ci-cd-default.yml`, mirroring the
+existing pair exactly (see [§4](#4-matrix-builder-changes) for the alignment
+points):
+
+| input | type | default |
+|---|---|---|
+| `extra-envs-per-goal-yml` | string (YAML) | `"{}"` |
+| `extra-envs-from-secrets-per-goal-yml` | string (YAML) | `"{}"` |
+
+Both are also valid **per-environment fields** inside `environments-yml`, like
+their global counterparts.
+
+```yaml
+      extra-envs-yml: |
+        ARM_USE_OIDC: true
+        GOGC: 50
+        GOMEMLIMIT: 6GiB
+
+      extra-envs-per-goal-yml: |
+        plan:
+          GOMEMLIMIT: 12GiB
+          GOGC: 25
+        apply:
+          GOMEMLIMIT: ~          # cleared for apply
+        lint:
+          GOGC: 400
+
+      extra-envs-from-secrets-yml: |
+        ARM_TENANT_ID: AZURE_TENANT_ID
+        ARM_CLIENT_ID: AZURE_PLAN_READER_CLIENT_ID
+
+      extra-envs-from-secrets-per-goal-yml: |
+        apply:
+          ARM_CLIENT_ID: AZURE_APPLY_CONTRIBUTOR_CLIENT_ID
+
+      environments-yml: |
+        - environment: dev
+        - environment: prod
+          extra-envs-per-goal-yml:
+            plan:
+              GOMEMLIMIT: 24GiB
+```
+
+> **Read [§9.3](#93-limitation-per-goal-secrets-cannot-swap-cloud-identity) before
+> writing `extra-envs-from-secrets-per-goal-yml` for `ARM_*` credentials.** It
+> does not do what it looks like it does.
+
+### 2.2 Goal keys
+
+Valid keys, matching the **goal** vocabulary a caller writes in `goals-yml`
+(not the workflow's step ids):
+
+`init` · `format` · `validate` · `lint` · `plan` · `apply` · `destroy-plan` · `destroy`
+
+Notes:
+
+- The key is `format`, though the workflow step id is `fmt`. The caller-facing
+  name follows `goals-yml`.
+- `destroy-plan` / `destroy` are separate keys from `plan` / `apply` even though
+  they reuse the same two actions. This is deliberate — it is what lets a destroy
+  plan be tuned independently.
+- **There is no key for `all`.** `all` is not a stage; it is shorthand expanded
+  inside each step's `if:` condition. The "applies to every goal" layer is the
+  existing `extra-envs-yml`. An unknown key is a hard error
+  ([§5.4](#54-validation)) precisely so `all:` fails loudly instead of silently
+  doing nothing.
+
+### 2.3 Merge and precedence
+
+Resolution happens in two stages. The matrix builder resolves *global vs
+per-environment*; the resolver action resolves *global vs per-goal* and expands
+secret names.
+
+Effective value for a given (environment, goal, key), last wins:
+
+1. global `extra-envs-yml`
+2. global `extra-envs-from-secrets-yml` (resolved)
+3. per-goal `extra-envs-per-goal-yml[goal]`
+4. per-goal `extra-envs-from-secrets-per-goal-yml[goal]` (resolved)
+
+Two rules encoded there:
+
+- **Specificity beats source.** A per-goal plain value overrides a global
+  secret-sourced value for the same key (3 beats 2).
+- **Within one specificity level, secrets win** (2 beats 1, 4 beats 3). This is
+  not arbitrary — it preserves today's behavior, where
+  [export-env-vars/action.yml:60-85](../export-env-vars/action.yml#L60-L85) runs
+  the plain loop first and the secrets loop second, so a key present in both
+  global maps already resolves to the secret value. Changing it would be a silent
+  behavior change for existing callers.
+
+Per-environment overrides are applied *before* any of this, by the matrix
+builder, and are a **deep** merge — see
+[§9.5](#95-deep-merge-one-existing-field-is-an-array).
+
+Worked example from [§2.1](#21-new-workflow-inputs):
+
+| | `GOGC` | `GOMEMLIMIT` | `ARM_CLIENT_ID` |
+|---|---|---|---|
+| dev · init/validate/format/destroy-* | 50 | 6GiB | `AZURE_PLAN_READER_CLIENT_ID` |
+| dev · plan | 25 | 12GiB | `AZURE_PLAN_READER_CLIENT_ID` |
+| dev · lint | 400 | 6GiB | `AZURE_PLAN_READER_CLIENT_ID` |
+| dev · apply | 50 | *unset* | `AZURE_APPLY_CONTRIBUTOR_CLIENT_ID` |
+| **prod · plan** | **25** | **24GiB** | `AZURE_PLAN_READER_CLIENT_ID` |
+
+The prod·plan row is the deep-merge test: `GOGC` survives from the global
+per-goal `plan:` block while `GOMEMLIMIT` is overridden by the environment's
+`plan:` block. A shallow merge would replace the whole `plan:` object and drop
+`GOGC` back to 50.
+
+### 2.4 Clear semantics: null vs empty string
+
+| YAML | JSON | effect |
+|---|---|---|
+| `GOMEMLIMIT: ~` (or `null`) | `null` | variable is **unset** in the goal's process |
+| `GOMEMLIMIT: ""` | `""` | variable is **set to the empty string** |
+
+The distinction is real and observable. For `GOGC`/`GOMEMLIMIT` specifically the
+two are indistinguishable in effect — Go's `readGOGC` falls back to 100 when
+`atoi32("")` fails, and `readGOMEMLIMIT` returns `maxInt64` on `p == ""` — but
+for anything that treats empty string as a meaningful value, only `~` actually
+removes it.
+
+Being able to express `unset` at all is the main functional gain of this design
+over routing per-goal values through `$GITHUB_ENV`, which has no unset mechanism.
+
+## 3. Data flow
+
+```mermaid
+flowchart TD
+    A["workflow inputs<br/>extra-envs-yml<br/>extra-envs-from-secrets-yml<br/>extra-envs-per-goal-yml<br/>extra-envs-from-secrets-per-goal-yml"] --> B
+    A2["environments-yml<br/>(per-env overrides of all four)"] --> B
+    B["create-tf-vars-matrix<br/>global ⊕ per-env, deep merge"] --> C
+
+    C["matrix.vars.extra-envs<br/>matrix.vars.extra-envs-from-secrets<br/>matrix.vars.extra-envs-per-goal<br/>matrix.vars.extra-envs-from-secrets-per-goal"] --> D
+    S["toJSON(secrets)"] --> D
+
+    D["resolve-goal-envs<br/><i>the only action that sees secrets</i><br/>merge · resolve · validate"] --> E
+
+    E["$RUNNER_TEMP/&lt;tmp&gt;/<br/>init.json format.json validate.json<br/>lint.json plan.json apply.json<br/>destroy-plan.json destroy.json<br/>(0700 dir, 0600 files)"]
+
+    E -. "path only" .-> F1["terraform-init<br/>extra-envs-file"]
+    E -. "path only" .-> F2["terraform-fmt"]
+    E -. "path only" .-> F3["terraform-validate"]
+    E -. "path only" .-> F4["lint-with-tflint"]
+    E -. "path only" .-> F5["terraform-plan<br/>3 invocations"]
+    E -. "path only" .-> F6["terraform-apply"]
+
+    F5 --> G["apply-extra-envs<br/>export / unset in the step's own shell<br/>→ terraform child process only"]
+
+    style D fill:#4a3,color:#fff
+    style E fill:#a63,color:#fff
+```
+
+The load-bearing property: **what crosses from the resolver into a goal action is
+a filesystem path, never a payload.** Secret values are therefore absent from
+`argv`, from `envp`, and from the goal step's interpolated run-block script text.
+
+## 4. Matrix-builder changes
+
+`extra-envs-yml` and `extra-envs-from-secrets-yml` are currently aligned in five
+places. The new pair follows them into all five:
+
+| location | change |
+|---|---|
+| [create-tf-vars-matrix/action.yml:33-42](../create-tf-vars-matrix/action.yml#L33-L42) `YML_INPUTS` | add both |
+| [:162-183](../create-tf-vars-matrix/action.yml#L162-L183) `MERGE_INPUT_YML_FIELDS` | add both — **but see [§9.5](#95-deep-merge-one-existing-field-is-an-array)** |
+| [:227-228](../create-tf-vars-matrix/action.yml#L227-L228) `REQ_FIELDS` | add `extra-envs-per-goal`, `extra-envs-from-secrets-per-goal` |
+| [:250-251](../create-tf-vars-matrix/action.yml#L250-L251) `NOT_EMPTY_FIELDS` | **do not add** — `{}` is a legitimate value |
+| workflow inputs + `environments-yml` docs | add both |
+
+Additionally, the builder **normalizes both maps to contain all eight goal keys**,
+defaulting each to `{}`. Without this, `toJSON(matrix.vars.extra-envs-per-goal.plan)`
+renders the four-character string `null` for an absent key, which then reaches the
+resolver's `jq` as invalid input.
+
+Test fixtures to update — all three pairs in
+[create-tf-vars-matrix/test_data/](../create-tf-vars-matrix/test_data/):
+`test_input_happy_day_*`, `test_input_minimal_*`, `test_input_fail_yml_spec_*`.
+
+## 5. New action: `resolve-goal-envs`
+
+Modern layout per [Action-implementation-guide.md](Action-implementation-guide.md).
+This is the **only** action in the repo that receives `toJSON(secrets)` besides
+the existing `export-env-vars`.
+
+### 5.1 Interface
+
+```yaml
+inputs:
+  extra-envs:                        # JSON object, global (per-env already applied)
+  extra-envs-from-secrets:           # JSON object, global
+  extra-envs-per-goal:               # JSON object of objects, keyed by goal
+  extra-envs-from-secrets-per-goal:  # JSON object of objects, keyed by goal
+  secrets-json:                      # toJSON(secrets)
+outputs:
+  envs-dir:                          # path to the directory of per-goal JSON files
+```
+
+All five inputs arrive via the heredoc pattern
+([Action-implementation-guide.md §"Step shim pattern — JSON inputs"](Action-implementation-guide.md)).
+`secrets-json` is heredoc'd straight to a `mktemp` file **before**
+`set -o allexport`, and only the path is exported — see
+[§8](#8-arg_max-and-payload-handling).
+
+### 5.2 Output contract
+
+```
+$RUNNER_TEMP/<mktemp -d>/          0700
+├── init.json                      0600
+├── format.json                    0600
+├── validate.json                  0600
+├── lint.json                      0600
+├── plan.json                      0600
+├── apply.json                     0600
+├── destroy-plan.json              0600
+└── destroy.json                   0600
+```
+
+Every file always exists, containing at minimum `{}`. Each is the **fully
+resolved effective set** for that goal — goal actions apply it verbatim and
+perform no merging.
+
+`$RUNNER_TEMP`, not `$GITHUB_WORKSPACE`: keeps the files out of
+`actions/upload-artifact` globs, out of `terraform fmt -recursive` traversal, and
+out of anything that could commit them.
+
+### 5.3 Resolution algorithm
+
+For each of the eight goals:
+
+1. Start from `extra-envs`.
+2. Overlay `extra-envs-from-secrets` with each value replaced by the
+   corresponding secret's value.
+3. Overlay `extra-envs-per-goal[goal]`.
+4. Overlay `extra-envs-from-secrets-per-goal[goal]`, resolved as in 2.
+5. Write to `<goal>.json`.
+
+`null` values are preserved as JSON `null` through all overlays — they are
+instructions to the consumer ([§6.2](#62-the-apply-extra-envs-helper)), not
+absences. A `null` at a later stage overrides a value from an earlier one.
+
+### 5.4 Validation
+
+All failures are hard errors with `log-error` and a non-zero exit. Resolving at
+one site means these are caught once, early, before any terraform runs.
+
+| check | rationale |
+|---|---|
+| goal key is one of the eight | catches `all:`, `fmt:`, typos |
+| secret name exists in `secrets-json` | **fixes an existing wart** — [export-env-vars/action.yml:83](../export-env-vars/action.yml#L83) resolves a missing secret to the literal string `null` with no warning. Multiplied across eight goal keys this becomes easy to hit and hard to see. |
+| env name matches `[A-Za-z_][A-Za-z0-9_]*` | a name with `=` or a space silently corrupts the consumer |
+| value is string, number, boolean, or null | an object/array is a config error, not a value |
+
+There is deliberately **no reserved-name list**. A caller who sets
+`TF_PLUGIN_CACHE_DIR` or `TF_IN_AUTOMATION` is assumed to mean it; guarding
+against it would buy little and cost a list that has to be kept in sync with six
+actions. The resulting override behavior is documented instead — see
+[§6.3](#63-ordering-and-overriding-action-managed-variables).
+
+### 5.5 Log hygiene
+
+Log **keys only**, never values — mirroring the existing split between
+`export-environment-variable` (logs the value) and
+`export-secret-environment-variable` (does not) in
+[export-env-vars/helpers_additional.sh](../export-env-vars/helpers_additional.sh).
+Since a single map may now mix plain and secret-sourced keys, the safe default is
+to log no values at all.
+
+The runner masks secret values it has registered, so an accidental echo is
+usually redacted — but that is a backstop, not the design.
+
+## 6. Goal-action changes
+
+### 6.1 New input
+
+Each of the six goal actions gains exactly one input. None of them gains
+`secrets-json`.
+
+```yaml
+  extra-envs-file:
+    description: |
+      Path to a JSON file with environment variables to apply to this action's
+      invocations only. A JSON null value unsets the variable rather than setting
+      it empty.
+
+      A path rather than a payload so that values — which may be secrets — never
+      enter argv, envp, or this step's script text.
+    required: false
+    default: ""
+```
+
+Shim side it is just a path, so it is safe in the `env:` block under allexport:
+
+```yaml
+    - id: plan
+      shell: bash
+      env:
+        TF_IN_AUTOMATION: "true"
+        input_working_directory: ${{ inputs.working-directory }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
+      run: |
+        set -o allexport
+        source "${{ github.action_path }}/step_plan.sh"
+```
+
+### 6.2 The `apply-extra-envs` helper
+
+Lives in each action's `helpers_additional.sh`
+([§9.6](#96-helperssh-is-off-limits-so-the-helper-is-duplicated)). `jq
+--raw-output0` emits NUL-terminated strings, so keys and values are read as exact
+byte sequences — multiline values (PEM keys) and shell metacharacters pass through
+untouched, with no encoding hop and no per-variable subshell. Requires jq 1.7
+([§9.2](#92-assumption-jq-17-baseline)).
+
+```bash
+# Applies a JSON env map to the current shell. A JSON null unsets rather than
+# empties — $GITHUB_ENV cannot express that, and the distinction matters for
+# anything treating "" as a real value.
+#
+# Takes a path, not the JSON: values may be secrets, and nothing here may hold
+# the payload in a shell variable while allexport is in scope (ref. the ARG_MAX
+# rule in CLAUDE.md). NUL-delimited so multiline values and shell
+# metacharacters survive verbatim; the sentinel marks a null, while an empty
+# field is a genuine empty-string value.
+readonly _EXTRA_ENVS_UNSET='__DSB_UNSET__'
+readonly _EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
+
+function apply-extra-envs {
+  local file="${1}" key value
+  [ -z "${file}" ] && return 0
+  if [ ! -f "${file}" ]; then
+    log-error "extra-envs file '${file}' does not exist!"
+    return 1
+  fi
+  while IFS= read -r -d '' key && IFS= read -r -d '' value; do
+    if [ "${value}" = "${_EXTRA_ENVS_UNSET}" ]; then
+      log-info "unsetting '${key}'"
+      unset "${key}"
+    else
+      log-info "setting '${key}'"
+      export "${key}=${value}"
+    fi
+  done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${file}")
+}
+```
+
+Verified against `GOGC=50`, `GOMEMLIMIT=6GiB`, a two-line value, `""`, a JSON
+number, a value containing `$ \` " * \`, and `null`, all under `set -o allexport`:
+values arrive intact in the child process's environment, empty stays distinct
+from unset, and a `null` genuinely removes a variable that was already exported.
+
+The sentinel is a defined constant rather than a bare `-` so that a caller whose
+real value happens to be the sentinel string is the only pathological case, and
+it is an obviously deliberate one.
+
+### 6.3 Ordering and overriding action-managed variables
+
+Call `apply-extra-envs` **early in `main`, before the action's own exports**. With
+no reserved-name list ([§5.4](#54-validation)), that ordering is what decides who
+wins, and the result is asymmetric:
+
+| variable | set by | who wins |
+|---|---|---|
+| `TF_PLUGIN_CACHE_DIR`, `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE` | [terraform-init/step_init.sh:80-82](../terraform-init/step_init.sh#L80-L82) — the script, at runtime | **the action** |
+| `TF_IN_AUTOMATION` | the shim's `env:` block, before the script runs | **the caller** |
+| `GITHUB_TOKEN` (lint) | the shim's `env:` block | **the caller** |
+
+The asymmetry is a consequence of when each assignment happens, not a policy. It
+is the safe direction on the one that matters — a caller cannot accidentally
+disable provider plugin caching — and callers who deliberately want to override
+`TF_IN_AUTOMATION` can. Document it on the input; do not add code to enforce it.
+
+### 6.4 Call sites
+
+| action | step scripts to touch | notes |
+|---|---|---|
+| `terraform-init` | `step_init.sh` | modern already |
+| `terraform-validate` | `step_validate.sh` | modern already |
+| `terraform-plan` | `step_plan.sh`, `step_plan_show.sh`, `step_plan_json.sh` | **three** — see below |
+| `terraform-fmt` | *(new)* `step_fmt.sh` | requires conversion, [§9.1](#91-blocker-three-legacy-actions-must-be-converted-first) |
+| `lint-with-tflint` | *(new)* `step_lint.sh` | requires conversion |
+| `terraform-apply` | *(new)* `step_apply.sh` | requires conversion |
+
+`terraform-plan` runs terraform three times in three separate composite steps —
+`plan`, `plan-show`, `plan-json`
+([terraform-plan/action.yml:69-100](../terraform-plan/action.yml#L69-L100)) —
+each in its own shell. **Apply the envs in all three.** `terraform show -json` on
+a large plan is itself a significant allocator, so for the motivating
+`GOMEMLIMIT` case, covering only `step_plan.sh` would miss a likely OOM site.
+
+### 6.5 Array-built invocations
+
+In scope for this work: every terraform/tflint invocation these actions make is
+built as a bash **array** and invoked as `"${cmd[@]}"`, so arguments are never
+word-split or glob-expanded.
+
+Most invocations are already direct and correctly quoted —
+`step_init.sh:59,94`, `step_validate.sh:39`, `step_plan_show.sh:33`,
+`step_plan_json.sh:33` need no change. The work is confined to four places:
+
+| site | current | why it matters |
+|---|---|---|
+| [terraform-plan/step_plan.sh:54,70](../terraform-plan/step_plan.sh#L54) | `plan_cmd="… ${input_extra_global_args} plan … ${input_extra_plan_args}"` then bare `${plan_cmd}` | the **only** invocation interpolating caller-controlled argument strings, then relying on word-splitting to re-split them |
+| [terraform-apply/action.yml:51-54](../terraform-apply/action.yml#L51-L54) | `APPLY_CMD="terraform apply … ${{ inputs.terraform-plan-file }}"` then bare `${APPLY_CMD}` | plan-file path is unquoted; converted anyway under [§9.1](#91-blocker-three-legacy-actions-must-be-converted-first) |
+| [terraform-fmt/action.yml:56](../terraform-fmt/action.yml#L56) | `TF_FMT_DIRS` is a newline-joined **string** iterated as `${TF_FMT_DIRS[*]}` | `[*]` on a scalar is not array iteration — it word-splits. A project path containing a space silently lints the wrong directories |
+| [lint-with-tflint/action.yml:100,111](../lint-with-tflint/action.yml#L100) | same pattern for `TFLINT_DIRS` | same |
+
+The last two are pre-existing latent bugs, not regressions introduced here. They
+are in the files being rewritten anyway, and `jq -r` output over
+`.terraform/modules/modules.json` paths is exactly where a space eventually shows
+up — fix them as part of the conversion using `mapfile -t` (or `read -r -d ''`
+over `jq --raw-output0`) into a real array.
+
+Keep the existing `log-info "command string is …"` diagnostics; render the array
+with `${cmd[*]@Q}` so the log stays copy-pasteable and shows the real quoting.
+
+Note this makes an `env`-prefix approach to env scoping possible later
+(`env -u VAR terraform …` as array elements), but that is **not** what this
+feature uses — scoping is via `apply-extra-envs` in the step's own shell
+([§6.2](#62-the-apply-extra-envs-helper)). The arrays are for quoting robustness
+on their own merits.
+
+## 7. Workflow changes
+
+One resolver step, placed immediately after the existing
+`🎰 Export environment variables and secrets` step at
+[terraform-ci-cd-default.yml:524](../.github/workflows/terraform-ci-cd-default.yml#L524)
+and before `🔑 Login to Azure`:
+
+```yaml
+      - name: "🎰 Resolve per-goal environment variables"
+        id: goal-envs
+        uses: dsb-norge/github-actions-terraform/resolve-goal-envs@v0
+        with:
+          extra-envs: ${{ toJSON(matrix.vars.extra-envs) }}
+          extra-envs-from-secrets: ${{ toJSON(matrix.vars.extra-envs-from-secrets) }}
+          extra-envs-per-goal: ${{ toJSON(matrix.vars.extra-envs-per-goal) }}
+          extra-envs-from-secrets-per-goal: ${{ toJSON(matrix.vars.extra-envs-from-secrets-per-goal) }}
+          secrets-json: ${{ toJSON(secrets) }}
+```
+
+Then one line added to each goal step's `with:`:
+
+| step | line | added |
+|---|---|---|
+| `init` | [568](../.github/workflows/terraform-ci-cd-default.yml#L568) | `extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/init.json` |
+| `fmt` | [597](../.github/workflows/terraform-ci-cd-default.yml#L597) | `.../format.json` |
+| `validate` | [606](../.github/workflows/terraform-ci-cd-default.yml#L606) | `.../validate.json` |
+| `lint` | [615](../.github/workflows/terraform-ci-cd-default.yml#L615) | `.../lint.json` |
+| `plan` | [623](../.github/workflows/terraform-ci-cd-default.yml#L623) | `.../plan.json` |
+| `apply` | [964](../.github/workflows/terraform-ci-cd-default.yml#L964) | `.../apply.json` |
+| `destroy-plan` | [976](../.github/workflows/terraform-ci-cd-default.yml#L976) | `.../destroy-plan.json` |
+| `destroy` | [1006](../.github/workflows/terraform-ci-cd-default.yml#L1006) | `.../destroy.json` |
+
+Plus a cleanup step at the end of the `terraform` job:
+
+```yaml
+      - name: "🧹 Shred resolved environment files"
+        if: always()
+        run: |
+          dir='${{ steps.goal-envs.outputs.envs-dir }}'
+          [ -n "${dir}" ] && [ -d "${dir}" ] && rm -rf "${dir}" || :
+```
+
+`$RUNNER_TEMP` is documented as emptied per job, but `runs-on` is caller-overridable
+to self-hosted groups ([:317-326](../.github/workflows/terraform-ci-cd-default.yml#L317-L326))
+and composite actions cannot declare `post:` steps, so cleanup is explicit rather
+than delegated to runner behavior.
+
+## 8. ARG_MAX and payload handling
+
+Per the ARG_MAX rule in [CLAUDE.md](../CLAUDE.md): under `set -o allexport`, every
+assignment — **including `local` inside a function** — gets the export attribute
+and lands in `envp` for any subsequent `fork+execve`. Confirmed empirically; a
+`local` holding a payload is exported to children for as long as the function is
+on the stack. Once `envp` crosses `ARG_MAX` (~2 MB) or `MAX_ARG_STRLEN` (128 KB
+per string), the next `jq` or `bash -c` fails with exit 126 "Argument list too
+long" — a failure that correlates with data size and so stays invisible in tests.
+
+Rules for this feature:
+
+1. **`secrets-json` is heredoc'd to a `mktemp` file before `set -o allexport`,
+   and only the path is exported.** `toJSON(secrets)` is the one genuinely large
+   payload here — a bag containing a PEM private key (this repo references
+   `TF_CICD_APP_PRIVATE_KEY`) is single-handedly enough to matter. Note that
+   [export-env-vars/action.yml:40-59](../export-env-vars/action.yml#L40-L59) is
+   already safe by construction: it does `set +o allexport` *before* assigning
+   `SECRETS_JSON`. A modern-layout shim defaults to the opposite, so this must be
+   deliberate.
+2. **Goal actions receive a path, never a payload.** This is the whole point of
+   [§5.2](#52-output-contract) — it is what keeps six actions from each needing
+   the discipline in rule 1.
+3. **`apply-extra-envs` never assigns the JSON to a variable.** `jq` reads the
+   file; the loop consumes a stream. Only individual keys and base64-encoded
+   values transit shell variables, and those are bounded by the size of a single
+   env var.
+4. The resolved per-goal env values do of course end up in `envp` — that is what
+   an environment variable is. They are bounded by whatever the caller configures,
+   and unlike the `$GITHUB_ENV` route they are gone when the step ends.
+
+## 9. Constraints, decisions and blockers
+
+### 9.1 Blocker: three legacy actions must be converted first
+
+`terraform-fmt`, `lint-with-tflint`, and `terraform-apply` still embed their bash
+in `action.yml` and have no `step_*.sh` to host `apply-extra-envs`. Per
+[CLAUDE.md](../CLAUDE.md), touching a legacy action for non-trivial work means
+converting it to the modern layout per
+[Action-implementation-guide.md §"Converting an Existing Inline-Bash Action"](Action-implementation-guide.md).
+
+**This is the bulk of the effort in this feature.** Assessment per action:
+
+| action | lines | scope | difficulty |
+|---|---|---|---|
+| [terraform-apply](../terraform-apply/action.yml) | 56 | `check-prereqs` stays inline; `apply` step → `step_apply.sh` (~8 lines of logic) | low |
+| [terraform-fmt](../terraform-fmt/action.yml) | 70 | `check-prereqs` stays inline; `fmt` step → `step_fmt.sh`: `modules.json` discovery, loop over dirs, associative array of exit codes, summed exit | medium — tests need a fake `.terraform/modules/modules.json` fixture and a `terraform` stub |
+| [lint-with-tflint](../lint-with-tflint/action.yml) | 121 | `check-prereqs` stays inline; **two** step scripts — `step_get_config.sh` (config discovery, emits an output) and `step_lint.sh` (`add-matcher`, `modules.json`, `tflint --init` + lint per dir, summed exit) | **highest** — an output contract between two steps, `${{ steps.get-config.outputs.file }}` becomes `input_config_file`, a problem matcher to preserve, and tests need a `tflint` stub on `PATH` |
+
+Per the guide, prerequisite binary checks are explicitly fine to leave inline, so
+each conversion is smaller than the raw line count suggests.
+
+Consequences:
+
+- Each converted action **auto-enrolls in CI** via
+  [.github/scripts/discover-actions.sh](../.github/scripts/discover-actions.sh) —
+  no matrix edit in `action-tests.yml`. But each new `run_all_tests.sh` must emit
+  the canonical `Tests run:` / `Tests passed:` / `Tests failed:` lines verbatim or
+  CI fails the suite on format drift ([Testing-in-ci.md](Testing-in-ci.md)).
+- These three actions currently have **zero test coverage**. Conversion is where
+  it gets written — which is a benefit, but it is also why the estimate is not
+  small.
+- Rewriting the internals of `terraform-apply` is the highest-risk change in this
+  feature. It is the only step that mutates infrastructure, and it ships to every
+  `@v0` caller the moment the tag moves ([§9.9](#99-v0-force-move-blast-radius)).
+
+### 9.2 Assumption: jq 1.7 baseline
+
+`jq --raw-output0` in [§6.2](#62-the-apply-extra-envs-helper) requires **jq 1.7+**.
+Accepted as a baseline: this repo targets the current GitHub-hosted runner images,
+where jq is 1.7.x, and the standing convention is to assume preinstalled runner
+tooling rather than probe or install it.
+
+`runs-on` is nominally caller-overridable to a self-hosted group
+([:317-326](../.github/workflows/terraform-ci-cd-default.yml#L317-L326)), so a
+sufficiently old self-hosted image would fail here. Not designed around. If it
+ever matters, the fallback is to base64-encode values in the jq filter
+(`.value | tostring | @base64`) and decode per variable, which is line-oriented
+and works on jq 1.5+ at the cost of a subshell per variable.
+
+### 9.3 Limitation: per-goal secrets cannot swap cloud identity
+
+The most attractive use case for `extra-envs-from-secrets-per-goal-yml` — a
+reader service principal for `plan`, a contributor for `apply` — **does not work
+under this design**, and the failure is silent.
+
+```yaml
+      - name: "🔑 Login to Azure"
+        uses: azure/login@v3
+        if: env.ARM_TENANT_ID != '' && env.ARM_SUBSCRIPTION_ID != '' && env.ARM_CLIENT_ID != ''
+```
+
+[:533](../.github/workflows/terraform-ci-cd-default.yml#L533) — the consumer of
+`ARM_*` is `azure/login`, not terraform, it runs **once, early**, and it reads
+`env.`, i.e. job-wide `$GITHUB_ENV`. Variables that exist only inside
+`terraform-apply`'s step process are invisible to it. Handing terraform a
+different `ARM_CLIENT_ID` after the OIDC token was already minted for another
+identity changes nothing useful.
+
+Mitigations, in order of preference:
+
+1. **Document it prominently** on the input itself: per-goal secret envs reach the
+   terraform/tflint process, not `azure/login`. Suitable for things terraform or a
+   provider reads directly; not for the workflow's cloud login.
+2. A follow-up that adds a re-login step before `apply`. This needs the values in
+   job-wide `$GITHUB_ENV`, which is the *other* design (a per-goal
+   `export-env-vars` injector step) — so it is a genuinely separate mechanism,
+   not an extension of this one. The two can coexist.
+3. Reject `ARM_*` in `extra-envs-from-secrets-per-goal-yml` outright. Blunt, and
+   wrong for callers who legitimately want terraform's azurerm provider to
+   authenticate via env vars independently of the CLI login.
+
+**Decision: 1.** Documented, not guarded — consistent with dropping the
+reserved-name list ([§5.4](#54-validation)). The caveat goes on the input
+description and in the caller-facing docs, worded so the limitation is obvious
+before someone builds a plan/apply identity split on top of it. 2 remains a
+possible follow-up on the other mechanism; 3 is rejected.
+
+### 9.4 Missing secrets currently resolve to the string `null`
+
+[export-env-vars/action.yml:83](../export-env-vars/action.yml#L83) does
+`jq -r '.[$key]'` against the secrets bag with no existence check, so a secret
+name absent from `secrets-json` exports the literal four characters `null`. Today
+that is one mapping per environment and it fails soon after at Azure login.
+Spread across eight goal keys, it becomes easy to typo a name in the `apply` block
+only — `plan` works, `apply` authenticates as nothing, and the error surfaces far
+from its cause.
+
+`resolve-goal-envs` hard-fails on unresolvable names ([§5.4](#54-validation)).
+Fixing the same wart in `export-env-vars` is a small, separable improvement worth
+doing in the same PR.
+
+### 9.5 Deep merge: one existing field is an array
+
+`MERGE_INPUT_YML_FIELDS`
+([create-tf-vars-matrix/action.yml:169-183](../create-tf-vars-matrix/action.yml#L169-L183))
+merges with `jq -s 'add'` — a **shallow** merge. Correct for the existing flat
+maps, wrong for a nested goal→envs map, where a per-environment `plan:` block
+would replace the global `plan:` block wholesale instead of merging per key.
+
+**A blanket switch to `.[0] * .[1]` is a regression.** `pr-auto-merge-from-actors-yml`
+is a YAML **array** (default `"[]"`,
+[:243-248](../.github/workflows/terraform-ci-cd-default.yml#L243-L248)) and it is
+in the merge list. jq's `*` is undefined for arrays:
+
+```console
+$ echo '["a"] ["b"]' | jq -s 'add'            # current behavior: concatenate
+["a","b"]
+$ echo '["a"] ["b"]' | jq -s '.[0] * .[1]'
+jq: error (at <stdin>:1): array (["a"]) and array (["b"]) cannot be multiplied
+```
+
+Verified per-field behavior across the merge list:
+
+| field | shape | `add` | `*` | affected |
+|---|---|---|---|---|
+| `extra-envs-yml` | flat object of scalars | `{"A":1,"B":3}` | `{"A":1,"B":3}` | no — identical |
+| `extra-envs-from-secrets-yml` | flat object of scalars | identical | identical | no |
+| `pr-auto-merge-limits-yml` | flat object of integers | identical | identical | no |
+| `pr-auto-merge-from-actors-yml` | **array** | concatenates | **errors** | **yes** |
+| `extra-envs-per-goal-yml` *(new)* | nested object | drops sibling keys | merges per key | needs `*` |
+| `extra-envs-from-secrets-per-goal-yml` *(new)* | nested object | drops sibling keys | merges per key | needs `*` |
+
+`*` and `add` are provably identical for every flat scalar object, so only the
+array field forces the dispatch. One expression handles both without branching in
+bash:
+
+```bash
+# 'add' is shallow: correct for flat maps, and the only thing defined for arrays
+# (pr-auto-merge-from-actors-yml). '*' recurses into objects but replaces scalars
+# — required for the nested per-goal maps, where a per-env override of one goal
+# must not discard that goal's other keys.
+MERGED_JSON=$(echo "${GLOBAL_ENVS_JSON} ${ENV_JSON}" \
+  | jq -s 'if (.[0] | type) == "array" then add else .[0] * .[1] end')
+```
+
+Also verified: `*` preserves `null` leaves
+(`{"plan":{"M":"6GiB"}} * {"plan":{"M":null}}` → `{"plan":{"M":null}}`), which the
+unset semantics in [§2.4](#24-clear-semantics-null-vs-empty-string) depend on.
+
+Regression tests required — see [§10](#10-test-scenarios) T31-T35. Note that
+`pr-auto-merge-from-actors-yml` is documented as having *no* per-environment
+setting even though it sits in the merge list, so its array path may be
+unexercised in practice. Do not rely on that: `has-field` will still find it if a
+caller sets it, and an untested path that now hard-errors is worse than one that
+silently concatenates.
+
+### 9.6 `helpers.sh` is off-limits, so the helper is duplicated
+
+`helpers.sh` must stay byte-identical across actions and be cherry-picked
+unmodified ([CLAUDE.md](../CLAUDE.md)), so `apply-extra-envs` goes into each
+action's `helpers_additional.sh` — **six copies**. Three of those actions have no
+`helpers_additional.sh` today and get one during conversion.
+
+**This is by design, not a compromise.** A shared file at the repo root would
+technically resolve via `${{ github.action_path }}/../`, since GitHub checks out
+the whole repo under `_actions/dsb-norge/github-actions-terraform/<ref>/`, but the
+repo has deliberately settled this the other way for `helpers.sh`: each action
+directory is self-contained. Duplicate, and keep the six copies byte-identical so
+a future `diff` across them stays meaningful.
+
+### 9.7 Resolved secret values are written to disk
+
+`resolve-goal-envs` writes plaintext secrets to files. Not a new exposure class —
+`$GITHUB_ENV` is itself a plaintext file on the runner containing exactly these
+resolved values today — but it is a new *location*, so:
+
+- `mktemp -d` under `$RUNNER_TEMP` (0700), files 0600.
+- Outside `$GITHUB_WORKSPACE`, so no artifact glob, `fmt -recursive` walk, or
+  stray `git add` can reach them.
+- Explicit cleanup step ([§7](#7-workflow-changes)), because composite actions
+  cannot declare `post:` steps and self-hosted runners may not clear
+  `$RUNNER_TEMP` as reliably as hosted ones.
+- Keys logged, values never ([§5.5](#55-log-hygiene)).
+
+### 9.8 `all` is not a goal
+
+Callers will try `all:` in `extra-envs-per-goal-yml`. It is not a stage — it is
+shorthand expanded inside each step's `if:` — so there is nothing to attach to.
+The global `extra-envs-yml` is the every-goal layer. Handled by rejecting unknown
+keys ([§5.4](#54-validation)) so the mistake fails loudly rather than being
+silently dropped.
+
+### 9.9 `@v0` force-move blast radius
+
+The major tag is force-moved on every minor release, so everything here reaches
+every `@v0` caller immediately. The two new workflow inputs and six new action
+inputs are additive and defaulted, so they are safe. The **rewritten internals of
+`terraform-fmt`, `lint-with-tflint`, and `terraform-apply` are not** — those are
+behavior-preserving-by-intention rewrites of untested code.
+
+**Decision: one release for all of it.** The dev-tag swap flow in
+[Development-and-release.md](Development-and-release.md) is mandatory, and
+verification happens from a calling repo's PR that exercises `fmt`, `lint`, and
+`apply` against real infrastructure — not just this repo's own test suites. That
+end-to-end verification is what makes a single release acceptable despite the
+conversions riding along; do not merge on green `action-tests` alone.
+
+Re-tag and force-push the dev tag on every pushed commit, and delete it from
+local and origin before merge ([§11](#11-implementation-order)).
+
+## 10. Test scenarios
+
+`resolve-goal-envs/run_all_tests.sh`:
+
+- **T1** — All inputs `{}` → eight files, each `{}`.
+- **T2** — Global plain only → identical content in all eight files.
+- **T3** — Per-goal override of one key → that goal differs, the other seven do not.
+- **T4** — Per-goal `null` → JSON `null` present in that goal's file, value present in others.
+- **T5** — Secret resolution → env name mapped to the secret's *value*, not its name.
+- **T6** — Precedence: key in all four inputs → resolves per [§2.3](#23-merge-and-precedence) ordering.
+- **T7** — Per-goal plain beats global secret for the same key.
+- **T8** — Global secret beats global plain for the same key (backwards-compat guard).
+- **T9** — Unknown goal key (`all`, `fmt`) → non-zero exit, error logged.
+- **T10** — Secret name absent from `secrets-json` → non-zero exit.
+- **T11** — `TF_PLUGIN_CACHE_DIR` / `TF_IN_AUTOMATION` → **accepted**, written to the file (no reserved-name list, [§5.4](#54-validation)).
+- **T12** — Invalid env name (`FOO BAR`, `FOO=BAR`) → non-zero exit.
+- **T13** — Object/array value → non-zero exit.
+- **T14** — Multiline secret value (fake PEM) → survives byte-identical into the file.
+- **T15** — Directory is 0700, files 0600.
+- **T16** — No secret value appears anywhere in captured stdout/stderr.
+
+Per goal action, in its existing suite:
+
+- **T17** — `extra-envs-file` empty/unset → no-op, action behaves exactly as before *(regression guard for all existing callers)*.
+- **T18** — Path to a non-existent file → non-zero exit with a clear error.
+- **T19** — `{}` → no-op.
+- **T20** — Plain values → present in the environment the invocation sees.
+- **T21** — `null` → variable genuinely unset even when previously exported job-wide.
+- **T22** — `""` → set and empty, distinct from 21.
+- **T23** — Multiline value → intact.
+- **T24** — Value containing `$`, backticks, quotes, `*` → no shell interpretation.
+- **T25** — Values do **not** leak to the next step *(the core scoping claim; assert via a following step in `run_local_*`)*.
+- **T26** — `terraform-plan` specifically: envs applied in all three of `plan`, `plan-show`, `plan-json`.
+
+Array-built invocations ([§6.5](#65-array-built-invocations)), per action:
+
+- **T27** — Argument containing a space (`-var=foo=a b`) reaches terraform as **one** argv element.
+- **T28** — Argument containing a glob (`*`) is not expanded against the working directory.
+- **T29** — Empty `extra-global-args` / `extra-plan-args` produce no empty argv element.
+- **T30** — `terraform-fmt` / `lint-with-tflint`: a discovered directory path containing a space is linted as one directory, not two *(the latent bug this fixes)*.
+
+`create-tf-vars-matrix` — deep-merge regression suite ([§9.5](#95-deep-merge-one-existing-field-is-an-array)):
+
+- **T31** — Deep merge — per-env `plan:` block overriding one key preserves the global `plan:` block's other keys (the [§2.3](#23-merge-and-precedence) prod·plan row).
+- **T32** — **`pr-auto-merge-from-actors-yml` set both globally and per-env → arrays concatenate, no jq error** *(the regression the type dispatch exists for)*.
+- **T33** — `pr-auto-merge-limits-yml` set both globally and per-env → per-key override, unchanged from before.
+- **T34** — `extra-envs-yml` / `extra-envs-from-secrets-yml` set both globally and per-env → per-key override, unchanged from before *(guards the three flat fields against the merge change)*.
+- **T35** — Per-goal map with a `null` leaf survives the per-env merge as `null`, not as a dropped key.
+- **T36** — All eight goal keys normalized to exist when inputs omit them.
+- **T37** — Both new fields absent from the workflow input entirely → `{}`, and `*-yml` fields stripped from matrix output.
+
+T32-T34 are the ones that would otherwise catch a merge-semantics regression
+only in production, on a calling repo that happens to use per-environment
+auto-merge configuration.
+
+## 11. Implementation order
+
+One PR, one minor release — the dev tag is verified end-to-end from a calling
+repo's PR, which covers the conversions and the feature together
+([§9.9](#99-v0-force-move-blast-radius)). Ordering within the PR, so that each
+step is independently reviewable:
+
+**1 — legacy conversions**
+`terraform-apply` → `terraform-fmt` → `lint-with-tflint`, easiest first. No
+behavior change intended, no new inputs yet. Fold in the array-built invocations
+and the `TF_FMT_DIRS` / `TFLINT_DIRS` array fix
+([§6.5](#65-array-built-invocations)) here — these files are being rewritten
+anyway, and doing it now means the new suites cover the fixed behavior from the
+start rather than being written twice.
+
+**2 — array-built invocation in `terraform-plan`**
+[step_plan.sh:54,70](../terraform-plan/step_plan.sh#L54) to an array. Separate
+from step 1 because this action is already modern and already tested — the
+existing suite should pass unchanged, with T27-T29 added.
+
+**3 — matrix builder + inputs**
+Both new workflow inputs, `environments-yml` docs, the five alignment points,
+type-dispatched merge ([§9.5](#95-deep-merge-one-existing-field-is-an-array)),
+goal-key normalization, fixtures. Land the deep-merge regression suite (T31-T35) *with* this change, not after.
+
+**4 — `resolve-goal-envs`**
+The new action plus its full suite. Fold the `export-env-vars` missing-secret fix
+([§9.4](#94-missing-secrets-currently-resolve-to-the-string-null)) in here.
+
+**5 — goal-action inputs + wiring**
+`extra-envs-file` on all six, `apply-extra-envs` in six `helpers_additional.sh`,
+the resolver step and eight `extra-envs-file:` lines in the workflow, the cleanup
+step. This is where the feature becomes live.
+
+**6 — docs**
+Caller-facing section in
+[Workflow-terraform-ci-default.md](Workflow-terraform-ci-default.md) alongside
+the existing `extra-envs-yml` material, with the
+[§9.3](#93-limitation-per-goal-secrets-cannot-swap-cloud-identity) caveat and the
+[§6.3](#63-ordering-and-overriding-action-managed-variables) override behavior
+stated plainly. Update this document's status line.
+
+## 12. Out of scope / follow-ups
+
+- **Re-login before `apply`** for genuine per-goal cloud identity. Needs job-wide
+  `$GITHUB_ENV`, so it is the per-goal `export-env-vars` injector design rather
+  than an extension of this one ([§9.3](#93-limitation-per-goal-secrets-cannot-swap-cloud-identity)).
+- **Non-goal steps.** `setup-tflint`, `verify-terraform-lock`, `parse-terraform-*`
+  and the PR-comment actions get no per-goal envs. Add keys if a need appears; the
+  eight-key list is not load-bearing beyond validation.
+- **Per-goal `extra-plan-args` / `extra-global-args`.** `terraform-plan` already
+  has both inputs and the workflow only uses `extra-plan-args` for `-destroy`
+  ([:980](../.github/workflows/terraform-ci-cd-default.yml#L980)). Exposing them
+  per-goal is a smaller change than this feature and covers some of the same
+  ground — worth doing separately.
+- **`TF_CLI_ARGS_<subcommand>`.** Terraform's own per-subcommand mechanism already
+  works through the existing `extra-envs-yml` with no repo changes, and covers any
+  need expressible as CLI flags. Document it as the cheaper alternative so callers
+  do not reach for per-goal envs unnecessarily. Caveat: it applies to *both* plan
+  invocations, `plan` and `destroy-plan`.
+- **`terraform-test`.** [terraform-test/action.yml:63-71](../terraform-test/action.yml#L63-L71)
+  has the same string-built-command pattern that [§6.5](#65-array-built-invocations)
+  fixes elsewhere, but it is not a goal action and not part of the default
+  workflow. Worth the same treatment eventually; not here.
+
+Settled, recorded so they are not re-litigated:
+
+- **Reserved-name list** — rejected. Callers may override anything; the resulting
+  precedence is documented in [§6.3](#63-ordering-and-overriding-action-managed-variables).
+- **Duplicating `apply-extra-envs` across six actions** — by design, consistent
+  with `helpers.sh` ([§9.6](#96-helperssh-is-off-limits-so-the-helper-is-duplicated)).
+- **jq 1.7 as a baseline** — accepted ([§9.2](#92-assumption-jq-17-baseline)).
+- **Secrets winning over plain values at the same specificity level** — preserved
+  from current behavior ([§2.3](#23-merge-and-precedence)).
+- **Array-built invocations** — in scope, [§6.5](#65-array-built-invocations).
+- **Single release for conversions plus feature** — [§9.9](#99-v0-force-move-blast-radius),
+  [§11](#11-implementation-order).

--- a/docs/Per-goal-environment-variables.md
+++ b/docs/Per-goal-environment-variables.md
@@ -1,6 +1,7 @@
 # Per-goal environment variables
 
-Status: **spec — design decisions settled, not yet implemented**. Living document — update as implementation lands.
+Status: **implemented**. Living document — see [§13](#13-implementation-notes) for where the
+implementation deviates from what is described above, and why.
 
 Lets callers set environment variables (plain and secret-sourced) for a single
 terraform goal rather than for the whole job. Motivating case: `GOMEMLIMIT` and
@@ -477,16 +478,16 @@ and before `🔑 Login to Azure`:
 
 Then one line added to each goal step's `with:`:
 
-| step | line | added |
-|---|---|---|
-| `init` | [568](../.github/workflows/terraform-ci-cd-default.yml#L568) | `extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/init.json` |
-| `fmt` | [597](../.github/workflows/terraform-ci-cd-default.yml#L597) | `.../format.json` |
-| `validate` | [606](../.github/workflows/terraform-ci-cd-default.yml#L606) | `.../validate.json` |
-| `lint` | [615](../.github/workflows/terraform-ci-cd-default.yml#L615) | `.../lint.json` |
-| `plan` | [623](../.github/workflows/terraform-ci-cd-default.yml#L623) | `.../plan.json` |
-| `apply` | [964](../.github/workflows/terraform-ci-cd-default.yml#L964) | `.../apply.json` |
-| `destroy-plan` | [976](../.github/workflows/terraform-ci-cd-default.yml#L976) | `.../destroy-plan.json` |
-| `destroy` | [1006](../.github/workflows/terraform-ci-cd-default.yml#L1006) | `.../destroy.json` |
+| step id | added |
+|---|---|
+| `init` | `extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/init.json` |
+| `fmt` | `.../format.json` |
+| `validate` | `.../validate.json` |
+| `lint` | `.../lint.json` |
+| `plan` | `.../plan.json` |
+| `apply` | `.../apply.json` |
+| `destroy-plan` | `.../destroy-plan.json` |
+| `destroy` | `.../destroy.json` |
 
 Plus a cleanup step at the end of the `terraform` job:
 
@@ -876,3 +877,72 @@ Settled, recorded so they are not re-litigated:
 - **Array-built invocations** — in scope, [§6.5](#65-array-built-invocations).
 - **Single release for conversions plus feature** — [§9.9](#99-v0-force-move-blast-radius),
   [§11](#11-implementation-order).
+
+## 13. Implementation notes
+
+Where the shipped code differs from the design above, and why. Everything not
+listed here landed as described.
+
+### 13.1 `apply-extra-envs`: locals renamed, constants not `readonly`
+
+The sketch in [§6.2](#62-the-apply-extra-envs-helper) uses `local file key value`
+and `readonly` constants. Shipped as `_extra_envs_file` / `_extra_envs_key` /
+`_extra_envs_value`, with plain assignments:
+
+- Underscore-prefixed locals because `unset "${key}"` inside a function unsets a
+  local of that name before the global. A caller whose environment variable is
+  literally named `file` would have unset the helper's own state.
+- Not `readonly`, because a second `source helpers.sh` in the same shell would
+  then hard-fail on the re-assignment. Nothing does that today; the cost of
+  guarding is zero.
+
+### 13.2 Caller-supplied argument strings are still whitespace-split
+
+[§6.5](#65-array-built-invocations) lists T27 as "an argument containing a space
+reaches terraform as **one** argv element". That holds for every path the actions
+build themselves — the `-out=` plan file, `-chdir=` directories, `--config=`,
+the plan file handed to apply — and those are the argv elements that carry
+`modules.json` paths and environment names, i.e. the ones a space realistically
+turns up in.
+
+It does **not** hold for `extra-global-args` / `extra-plan-args`. Those are
+documented as strings of arguments the caller injects verbatim, and honoring
+quotes inside them would require `eval` or `xargs`. Both change behaviour for
+existing callers in ways worse than the bug they would fix — an unbalanced
+apostrophe currently passes through fine and would start failing under `xargs`.
+`split-args-to-array` therefore splits on whitespace, once and explicitly, which
+is behaviour-identical to the previous word-splitting minus the glob expansion
+and minus empty argv elements. Tests cover all four cases.
+
+### 13.3 `lint-with-tflint`: a failing `tflint --init` no longer aborts the step
+
+Previously a non-zero `tflint --init` terminated the whole step immediately,
+leaving the remaining directories unlinted and unreported. It is now recorded as
+that directory's result: the step still fails, because the exit codes are summed,
+but the other directories are linted and the summary shows which were reached.
+Same outcome for the workflow, strictly more information in the log.
+
+### 13.4 The matrix builder got a CI-facing test suite
+
+[§10](#10-test-scenarios) puts T31-T37 in `create-tf-vars-matrix`, which had no
+`run_all_tests.sh` and was excluded from `action-tests` discovery because its only
+harness (`test_action_source.sh`) needs a real tty. Rather than leave the
+deep-merge regressions untested in CI, the action now has a deterministic
+`run_all_tests.sh`: unit tests of `merge-yml-field-json` and
+`normalize-goal-keys-json`, plus fixture-driven runs of the action's real inline
+bash, extracted from `action.yml` by `extract_step_source.py`. The action is no
+longer on the exclusion list. `test_action_source.sh` stays as a manual
+debugging aid.
+
+Both merge-semantics regressions the type dispatch exists to prevent were
+verified to fail this suite before being fixed — shallow `add` breaks the
+deep-merge cases, blanket `*` breaks the array case.
+
+### 13.5 Extra validation in `resolve-goal-envs`
+
+Beyond the four checks in [§5.4](#54-validation), the action rejects any of its
+five inputs that is not a JSON object, and treats an empty, whitespace-only or
+literal-`null` input as `{}` (`toJSON(...)` renders `null` for a matrix key that
+does not exist). It also checks the validation pass's own exit code separately
+from whether it produced error lines — a jq failure would otherwise have read as
+"no problems found" and let bad input through.

--- a/docs/Testing-in-ci.md
+++ b/docs/Testing-in-ci.md
@@ -84,11 +84,13 @@ Fails if `needs.discover.result != success`, or if `needs.test.result` is `failu
 
 ## 3. Discovery rules and exclusions
 
-Discovery globs both `*/action.yml` and `*/action.yaml` from the repo root. The following directories are **excluded by name**, regardless of whether `run_all_tests.sh` is present:
+Discovery globs both `*/action.yml` and `*/action.yaml` from the repo root. Directories can additionally be **excluded by name**, regardless of whether `run_all_tests.sh` is present:
 
 | Excluded | Reason |
 |---|---|
-| `create-tf-vars-matrix` | Has a known-flaky `test_action_source.sh` harness that requires a real tty and may fail on pristine main. Documented in [`CLAUDE.md`](../CLAUDE.md). Not yet ported to the modern `run_all_tests.sh` shape. |
+| *(none)* | — |
+
+`create-tf-vars-matrix` used to be excluded here: its only harness was `test_action_source.sh`, which needs a real tty and may fail on pristine main. It now has a deterministic `run_all_tests.sh` (helper unit tests plus fixture-driven runs of the step source extracted from `action.yml`) and is discovered like any other action. `test_action_source.sh` is left in place as a manual debugging aid and is not invoked by CI.
 
 `.github/` is naturally excluded because the glob is `*/action.{yml,yaml}`, not `**/action.{yml,yaml}`.
 
@@ -104,7 +106,7 @@ Tests passed: <N>
 Tests failed: <N>
 ```
 
-This format is set by the template in [Action-implementation-guide.md §`run_all_tests.sh`](Action-implementation-guide.md#run_all_testssh--automated-tests) and is currently emitted by all 8 modern suites.
+This format is set by the template in [Action-implementation-guide.md §`run_all_tests.sh`](Action-implementation-guide.md#run_all_testssh--automated-tests) and is emitted by every modern suite.
 
 Multi-step orchestrator scripts (e.g. [`aggregate-validation-summaries/run_all_tests.sh`](../aggregate-validation-summaries/run_all_tests.sh)) emit these lines once **per delegated step script**. The parser sums them, so the action's totals are the sum across its sub-suites.
 
@@ -328,8 +330,8 @@ bash -n .github/scripts/aggregate-action-tests.sh
 
 ```bash
 bash .github/scripts/discover-actions.sh
-# Expect: tests-matrix=[...] and no-tests-list=[...] on stdout, with create-tf-vars-matrix
-# in the no-tests list (regardless of file presence — see §3).
+# Expect: tests-matrix=[...] and no-tests-list=[...] on stdout, partitioned on the
+# presence of run_all_tests.sh (plus any name on the exclusion list — see §3).
 ```
 
 **Aggregator script** — exercise it with fixture results in DRY_RUN so it builds the markdown without trying to post:

--- a/docs/Testing-in-ci.md
+++ b/docs/Testing-in-ci.md
@@ -92,6 +92,8 @@ Discovery globs both `*/action.yml` and `*/action.yaml` from the repo root. Dire
 
 `create-tf-vars-matrix` used to be excluded here: its only harness was `test_action_source.sh`, which needs a real tty and may fail on pristine main. It now has a deterministic `run_all_tests.sh` (helper unit tests plus fixture-driven runs of the step source extracted from `action.yml`) and is discovered like any other action. `test_action_source.sh` is left in place as a manual debugging aid and is not invoked by CI.
 
+The same `extract_step_source.py` approach gives `export-env-vars` a suite without converting it to the modern layout first — useful for any action whose logic is still inline bash in `action.yml`.
+
 `.github/` is naturally excluded because the glob is `*/action.{yml,yaml}`, not `**/action.{yml,yaml}`.
 
 When an excluded directory gets a real `run_all_tests.sh` later, drop it from the exclusion list in the same PR.

--- a/docs/Workflow-terraform-ci-default.md
+++ b/docs/Workflow-terraform-ci-default.md
@@ -50,6 +50,76 @@ For _global_ values, those to be passed for all terraform environments specified
 
 For environment specific values specify **the fields** `extra-envs-yml` and `extra-envs-from-secrets-yml` for one or more environment defined in the `environments-yml` workflow input.
 
+#### Variables for a single goal
+
+`extra-envs-yml` and `extra-envs-from-secrets-yml` reach every step of the job. When the correct value differs per stage — `plan` may need a much higher `GOMEMLIMIT` than `validate`, and a `GOGC` low enough to keep `plan` inside a runner's memory would needlessly slow down `lint` — use `extra-envs-per-goal-yml` and `extra-envs-from-secrets-per-goal-yml` instead. Both exist as workflow inputs and as per-environment fields, like their global counterparts.
+
+```yaml
+      extra-envs-yml: |
+        ARM_USE_OIDC: true
+        GOGC: 50
+        GOMEMLIMIT: 6GiB
+
+      extra-envs-per-goal-yml: |
+        plan:
+          GOMEMLIMIT: 12GiB
+          GOGC: 25
+        apply:
+          GOMEMLIMIT: ~          # cleared for apply
+        lint:
+          GOGC: 400
+
+      environments-yml: |
+        - environment: dev
+        - environment: prod
+          extra-envs-per-goal-yml:
+            plan:
+              GOMEMLIMIT: 24GiB
+```
+
+Valid goal keys are the ones you write in `goals-yml`: `init`, `format`, `validate`, `lint`, `plan`, `apply`, `destroy-plan`, `destroy`. Three things to know about them:
+
+- The key is **`format`**, even though the workflow step is called `fmt`.
+- **`destroy-plan` and `destroy` are separate** from `plan` and `apply`, so a destroy plan can be tuned independently.
+- **There is no `all` key.** `all` is not a stage, it is shorthand expanded inside each step's condition, so there is nothing to attach values to — the every-goal layer is `extra-envs-yml`. Writing `all:` is a hard error rather than a silent no-op.
+
+An unknown goal key, a secret name that is not available to the workflow, an environment variable name that is not a valid one, or a value that is a list or a mapping all fail the job early, before any terraform runs.
+
+Effective value for a given (environment, goal, variable), last wins:
+
+1. global `extra-envs-yml`
+2. global `extra-envs-from-secrets-yml`
+3. per-goal `extra-envs-per-goal-yml[goal]`
+4. per-goal `extra-envs-from-secrets-per-goal-yml[goal]`
+
+So specificity beats source — a per-goal plain value overrides a global secret-sourced one for the same variable — while within one level, secret-sourced wins, which is what the global maps already did before this existed. Per-environment values are merged into the global ones first, per goal and per variable: the `prod` example above ends up with `GOMEMLIMIT: 24GiB` **and** `GOGC: 25` for `plan`.
+
+For the resulting table across the example:
+
+| | `GOGC` | `GOMEMLIMIT` |
+|---|---|---|
+| dev · init/validate/format/destroy-* | 50 | 6GiB |
+| dev · plan | 25 | 12GiB |
+| dev · lint | 400 | 6GiB |
+| dev · apply | 50 | *unset* |
+| **prod · plan** | **25** | **24GiB** |
+
+##### Clearing a variable
+
+`GOMEMLIMIT: ~` (YAML null) **unsets** the variable for that goal. `GOMEMLIMIT: ""` sets it to the empty string, which is a different thing for anything that treats an empty value as meaningful. Being able to express *unset* at all is the main functional gain over routing these through `$GITHUB_ENV`, which has no unset mechanism.
+
+##### Two caveats
+
+**Per-goal secrets do not swap cloud identity.** The values reach the terraform/tflint process for that goal — not the workflow's `Login to Azure` step, which runs once, early, and reads job-wide environment variables. A reader service principal for `plan` and a contributor for `apply` therefore does **not** work through `extra-envs-from-secrets-per-goal-yml`: handing terraform a different `ARM_CLIENT_ID` after the OIDC token was already minted for another identity changes nothing. Use it for values terraform or a provider reads directly.
+
+**Overriding a variable the workflow manages itself is allowed, and who wins depends on how the workflow sets it.** There is no reserved-name list. A variable the action exports at runtime — `TF_PLUGIN_CACHE_DIR` in `init` — wins over your value, so provider plugin caching cannot be disabled by accident. A variable set in the step's environment — `TF_IN_AUTOMATION`, and `GITHUB_TOKEN` for `lint` — is overridden by your value. The asymmetry is a consequence of when each assignment happens, not a policy.
+
+##### The cheaper alternative
+
+Terraform's own `TF_CLI_ARGS_<subcommand>` mechanism already works through plain `extra-envs-yml` with no per-goal configuration at all, and covers anything expressible as a CLI flag. Reach for it first. One caveat: `TF_CLI_ARGS_plan` applies to **both** plan invocations, `plan` and `destroy-plan`.
+
+Full design, including why the values are passed as a file path rather than as a payload: [Per-goal-environment-variables.md](./Per-goal-environment-variables.md).
+
 #### Example usage
 
 #### Basic

--- a/export-env-vars/action.yml
+++ b/export-env-vars/action.yml
@@ -77,6 +77,16 @@ runs:
               log-info "Get secret name for '${ENV_KEY}' ..."
               ENV_SECRET_NAME=$(echo "${EXTRA_SECRETS_JSON}" | jq --arg key "${ENV_KEY}" -r '.[$key]')
 
+              # A secret name that is not available to the workflow used to
+              # resolve to the literal four characters 'null' and get exported
+              # as if it were a value, with no warning. That surfaced far from
+              # its cause — typically as an opaque Azure login failure.
+              if [ ! "$(echo "${SECRETS_JSON}" | jq --arg key "${ENV_SECRET_NAME}" 'has($key)')" == 'true' ]; then
+                log-error "the secret '${ENV_SECRET_NAME}', configured for environment variable '${ENV_KEY}', is not available to this workflow!"
+                log-error "check the spelling, and that the calling workflow passes secrets down with 'secrets: inherit'."
+                exit 1
+              fi
+
               log-info "Secret is named '${ENV_SECRET_NAME}', reading value ..."
               ENV_SECRET_VALUE=$(echo "${SECRETS_JSON}" | jq --arg key "${ENV_SECRET_NAME}" -r '.[$key]')
               export-secret-environment-variable "${ENV_KEY}" "${ENV_SECRET_VALUE}"

--- a/export-env-vars/extract_step_source.py
+++ b/export-env-vars/extract_step_source.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Extract one step's `run:` block from action.yml into a runnable script.
+
+Used by run_all_tests.sh so the tests exercise the action's real inline bash
+rather than a copy of it. GitHub Actions expressions are substituted with
+literal text (no shell escaping involved, unlike a sed-based approach — the
+inputs are JSON blobs full of quotes and slashes).
+
+Usage:
+  extract_step_source.py <action.yml> <step-id> <out-file> [KEY=path-or-value ...]
+
+Each trailing argument replaces one expression:
+  inputs.inputs-json=@/path/to/file    -> contents of the file
+  github.ref_name=main                 -> the literal value
+"""
+
+import sys
+import yaml
+
+
+def main() -> int:
+    action_file, step_id, out_file = sys.argv[1:4]
+    substitutions = sys.argv[4:]
+
+    with open(action_file, encoding="utf-8") as handle:
+        action = yaml.safe_load(handle)
+
+    steps = action["runs"]["steps"]
+    matches = [step for step in steps if step.get("id") == step_id]
+    if not matches:
+        available = ", ".join(str(step.get("id")) for step in steps)
+        print(f"no step with id '{step_id}' (have: {available})", file=sys.stderr)
+        return 1
+
+    source = matches[0]["run"]
+
+    for substitution in substitutions:
+        key, _, value = substitution.partition("=")
+        if value.startswith("@"):
+            with open(value[1:], encoding="utf-8") as handle:
+                value = handle.read()
+        # Both spacing variants occur in this repo's action definitions.
+        for expression in (f"${{{{ {key} }}}}", f"${{{{{key}}}}}"):
+            source = source.replace(expression, value)
+
+    with open(out_file, "w", encoding="utf-8") as handle:
+        handle.write("#!/bin/env bash\n")
+        handle.write(source)
+        if not source.endswith("\n"):
+            handle.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/export-env-vars/run_all_tests.sh
+++ b/export-env-vars/run_all_tests.sh
@@ -1,0 +1,252 @@
+#!/bin/env bash
+#
+# Tests for the export-env-vars action.
+#
+# The action's logic is still inline bash in action.yml, so the step's 'run:'
+# block is extracted by extract_step_source.py (literal expression
+# substitution, no shell escaping — the inputs are JSON blobs full of quotes)
+# and executed with the same shell flags the runner uses. Assertions are on the
+# resulting $GITHUB_ENV file, which is the action's only real output.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+OUT_FILE=/tmp/test_output_export_env_vars.txt
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+setup() {
+  WORK_DIR="$(mktemp -d)"
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_ENV="${WORK_DIR}/github_env.txt"
+  : >"${GITHUB_ENV}"
+
+  EXTRA_ENVS='{}'
+  EXTRA_SECRETS='{}'
+  SECRETS='{}'
+}
+
+# run_step — extract the action's step source with the current inputs
+# substituted in, then run it under the runner's shell flags.
+run_step() {
+  printf '%s' "${EXTRA_ENVS}" >"${WORK_DIR}/extra-envs.json"
+  printf '%s' "${EXTRA_SECRETS}" >"${WORK_DIR}/extra-envs-from-secrets.json"
+  printf '%s' "${SECRETS}" >"${WORK_DIR}/secrets.json"
+
+  python3 "${_this_script_dir}/extract_step_source.py" \
+    "${_this_script_dir}/action.yml" export-envs "${WORK_DIR}/step.sh" \
+    "inputs.extra-envs=@${WORK_DIR}/extra-envs.json" \
+    "inputs.extra-envs-from-secrets=@${WORK_DIR}/extra-envs-from-secrets.json" \
+    "inputs.secrets-json=@${WORK_DIR}/secrets.json" \
+    "github.action_path=${_this_script_dir}"
+
+  bash --noprofile --norc -eo pipefail "${WORK_DIR}/step.sh" >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+}
+
+# Exact value of one variable as written to $GITHUB_ENV. The action uses the
+# heredoc-delimiter form, so this has to parse it rather than split on '='.
+env_file_value() {
+  python3 - "${1}" "${GITHUB_ENV}" <<'PY'
+import re
+import sys
+
+name, path = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+match = re.search(
+    r'^%s<<"([^"]+)"\n(.*?)\n"\1"\s*$' % re.escape(name), text, re.S | re.M
+)
+sys.stdout.write(match.group(2) if match else "")
+PY
+}
+
+env_file_has() {
+  grep -q "^${1}<<" "${GITHUB_ENV}"
+}
+
+env_file_eq() {
+  local var="${1}" expected="${2}" actual
+  env_file_has "${var}" || return 1
+  actual="$(env_file_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    echo "--- GITHUB_ENV ---"
+    cat "${GITHUB_ENV}" 2>/dev/null || true
+    echo "--- /GITHUB_ENV ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}         EXPORT-ENV-VARS TESTS              ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Empty maps — the default for a caller that configures neither input
+# ----------------------------------------------------------------------
+setup
+run_step
+assert "empty: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "empty: nothing is written to GITHUB_ENV" test ! -s "${GITHUB_ENV}"
+
+# ----------------------------------------------------------------------
+# Plain environment variables
+# ----------------------------------------------------------------------
+setup
+EXTRA_ENVS='{"ARM_USE_OIDC":"true","ANOTHER_ENV":"1 2 3"}'
+run_step
+assert "plain: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "plain: a value is written" env_file_eq ARM_USE_OIDC 'true'
+assert "plain: a value containing spaces is written intact" \
+  env_file_eq ANOTHER_ENV '1 2 3'
+assert "plain: the value is logged (this action logs plain values)" \
+  grep -q "ARM_USE_OIDC' -> '1\|ARM_USE_OIDC' -> 'true'" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Secret-sourced environment variables
+# ----------------------------------------------------------------------
+setup
+EXTRA_SECRETS='{"ARM_CLIENT_ID":"AZURE_CLIENT_ID"}'
+SECRETS='{"AZURE_CLIENT_ID":"the-client-id-value","UNUSED":"x"}'
+run_step
+assert "secrets: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "secrets: the variable holds the secret's value, not its name" \
+  env_file_eq ARM_CLIENT_ID 'the-client-id-value'
+assert "secrets: the secret name is logged" \
+  grep -q "Secret is named 'AZURE_CLIENT_ID'" "${OUT_FILE}"
+assert "secrets: the secret VALUE is never logged" \
+  bash -c "! grep -q 'the-client-id-value' '${OUT_FILE}'"
+
+# ----------------------------------------------------------------------
+# A multiline secret value — the heredoc-delimiter form exists for this
+# ----------------------------------------------------------------------
+setup
+EXTRA_SECRETS='{"APP_PRIVATE_KEY":"PEM"}'
+SECRETS='{"PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----"}'
+run_step
+assert "multiline: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "multiline: the value round-trips through GITHUB_ENV" \
+  env_file_eq APP_PRIVATE_KEY '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----'
+
+# ----------------------------------------------------------------------
+# Precedence: a key in both maps resolves to the secret-sourced value.
+# resolve-goal-envs preserves this deliberately, so it needs a guard here.
+# ----------------------------------------------------------------------
+setup
+EXTRA_ENVS='{"SHARED_KEY":"from-plain"}'
+EXTRA_SECRETS='{"SHARED_KEY":"THE_SECRET"}'
+SECRETS='{"THE_SECRET":"from-secret"}'
+run_step
+assert "precedence: step exits 0" test "${LAST_EXIT}" -eq 0
+# $GITHUB_ENV is append-only and last-wins, and the secrets loop runs second.
+assert "precedence: both entries are appended" \
+  test "$(grep -c '^SHARED_KEY<<' "${GITHUB_ENV}")" -eq 2
+assert "precedence: the secret-sourced entry is appended last, so it wins" \
+  bash -c "tail -n 3 '${GITHUB_ENV}' | grep -q 'from-secret'"
+
+# ----------------------------------------------------------------------
+# A secret name that is not available to the workflow.
+#
+# This used to export the literal four characters 'null' with no warning; the
+# error then surfaced far from its cause, usually as an opaque Azure login
+# failure two steps later.
+# ----------------------------------------------------------------------
+setup
+EXTRA_SECRETS='{"ARM_CLIENT_ID":"TYPOED_SECRET_NAME"}'
+SECRETS='{"AZURE_CLIENT_ID":"the-client-id-value"}'
+run_step
+assert "negative: a missing secret fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the secret and the variable" \
+  grep -q "the secret 'TYPOED_SECRET_NAME', configured for environment variable 'ARM_CLIENT_ID'" "${OUT_FILE}"
+assert "negative: the error hints at the likely causes" \
+  grep -q "secrets: inherit" "${OUT_FILE}"
+assert "negative: the literal string 'null' is NOT exported" \
+  bash -c "! grep -qx 'null' '${GITHUB_ENV}'"
+
+# ----------------------------------------------------------------------
+# The distinction the fix turns on: a secret that EXISTS and whose value
+# happens to be the string "null" must still be exported. Checking the value
+# instead of the key's existence would reject this one.
+# ----------------------------------------------------------------------
+setup
+EXTRA_SECRETS='{"WEIRD_BUT_VALID":"A_SECRET"}'
+SECRETS='{"A_SECRET":"null"}'
+run_step
+assert "existence check: a secret whose value is the string 'null' is accepted" \
+  test "${LAST_EXIT}" -eq 0
+assert "existence check: and it is exported verbatim" \
+  env_file_eq WEIRD_BUT_VALID 'null'
+
+# An existing but empty secret is legitimate too.
+setup
+EXTRA_SECRETS='{"MAYBE_EMPTY":"EMPTY_SECRET"}'
+SECRETS='{"EMPTY_SECRET":""}'
+run_step
+assert "existence check: an existing but empty secret is accepted" \
+  test "${LAST_EXIT}" -eq 0
+assert "existence check: and exported as the empty string" \
+  env_file_eq MAYBE_EMPTY ''
+
+# ----------------------------------------------------------------------
+# Only the first bad secret needs to fail the step, but the plain
+# variables processed before it must already have been written — the step is
+# not transactional and callers should not be told otherwise.
+# ----------------------------------------------------------------------
+setup
+EXTRA_ENVS='{"GOOD_PLAIN":"written"}'
+EXTRA_SECRETS='{"BAD":"NO_SUCH_SECRET"}'
+SECRETS='{"OTHER":"x"}'
+run_step
+assert "negative: the step still fails" test "${LAST_EXIT}" -ne 0
+assert "negative: plain variables written before the failure are kept" \
+  env_file_eq GOOD_PLAIN 'written'
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}          EXPORT-ENV-VARS SUMMARY           ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/lint-with-tflint/action.yml
+++ b/lint-with-tflint/action.yml
@@ -38,84 +38,18 @@ runs:
         end-group
     - id: get-config
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      env:
+        input_working_directory: ${{ inputs.working-directory }}
+        input_config_file_path: ${{ inputs.config-file-path }}
       run: |
-        # locate TFLint config file
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        configured_path='${{ inputs.config-file-path }}'
-        possible_paths=(
-          "$(pwd)/.tflint.hcl"
-          "${GITHUB_WORKSPACE}/.tflint.hcl"
-        )
-
-        if [ ! -z "${configured_path}" ]; then
-          log-info "using configured TFLint config file path"
-          if [ -f "${configured_path}" ]; then
-            path_to_use="${configured_path}"
-          elif [ -f "$(pwd)/${configured_path}" ]; then
-            path_to_use="$(pwd)/${configured_path}"
-          else
-            log-error "the configured path '${configured_path}' does not exist, unable to perform linting!"
-            exit 1
-          fi
-        else
-          log-info "TFLint config file path was not configured, attempting to locate one ..."
-          for path_to_use in ${possible_paths[*]}; do
-            [ -f "${path_to_use}" ] && break || :
-          done
-          if [ ! -f "${path_to_use}" ]; then
-            log-error "could not find a TFLint config file to use, unable to perform linting!"
-            exit 1
-          fi
-        fi
-        log-info "using TFLint config file located at '$(ws-path ${path_to_use})'"
-        set-output 'file' "${path_to_use}"
+        set -o allexport
+        source "${{ github.action_path }}/step_get_config.sh"
     - id: lint
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        input_working_directory: ${{ inputs.working-directory }}
+        input_config_file: ${{ steps.get-config.outputs.file }}
       run: |
-        # determine directories to lint in and go
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        # decoration in github
-        echo "::add-matcher::${{ github.action_path }}/tflint_matcher.json"
-
-        # dirs
-        MODULES_FILE="$(pwd)/.terraform/modules/modules.json"
-        log-info "looking for terraform modules file at '$(ws-path ${MODULES_FILE})'"
-        if [ -f "${MODULES_FILE}" ]; then
-          log-info "found it, parsing directories to lint"
-          TFLINT_DIRS=$(jq -cr --arg pwd "$(pwd)/" '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' "${MODULES_FILE}")
-        else
-          log-info "no modules file found, linting will only be performed in '$(ws-path $(pwd))'"
-          TFLINT_DIRS="$(pwd)"
-        fi
-
-        # lint
-        declare -A TFLINT_RESULTS
-        for TFLINT_DIR in ${TFLINT_DIRS[*]}; do
-          start-group "directory '$(ws-path ${TFLINT_DIR})'"
-          log-info "TFLint init ..."
-          tflint --init --config="${{ steps.get-config.outputs.file }}" --chdir="${TFLINT_DIR}"
-          log-info "linting ..."
-          set +e
-          tflint --format=compact --config="${{ steps.get-config.outputs.file }}" --chdir="${TFLINT_DIR}"
-          TFLINT_RESULTS["./${TFLINT_DIR}"]=${?}
-          set -e
-          end-group
-        done
-
-        # summary
-        log-info "summary:"
-        for TFLINT_DIR in ${TFLINT_DIRS[*]}; do
-          log-info "  - $([[ ${TFLINT_RESULTS["./${TFLINT_DIR}"]} -ne 0 ]] && echo 'failure ->' || echo 'success ->') ./$(ws-path ${TFLINT_DIR})"
-        done
-
-        # exit code
-        TFLINT_SUM_EXIT_CODES=$(IFS=+; echo "$((${TFLINT_RESULTS[*]}))")
-        exit ${TFLINT_SUM_EXIT_CODES}
+        set -o allexport
+        source "${{ github.action_path }}/step_lint.sh"

--- a/lint-with-tflint/action.yml
+++ b/lint-with-tflint/action.yml
@@ -18,6 +18,22 @@ inputs:
       See https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
     required: false
     default: ${{ github.token }}
+  extra-envs-file:
+    description: |
+      Path to a JSON file with environment variables to apply to this action's
+      invocations only, as produced by the 'resolve-goal-envs' action. A JSON
+      null value unsets the variable rather than setting it to the empty
+      string.
+
+      A path rather than a payload so that the values — which may be secrets —
+      never enter argv, envp, or this step's script text.
+
+      The values are applied before this action's own exports, so an action-managed
+      variable set by the step script at runtime (e.g. TF_PLUGIN_CACHE_DIR) wins,
+      while one set in the step's env: block (e.g. TF_IN_AUTOMATION) is overridden
+      by the caller. See docs/Per-goal-environment-variables.md §6.3.
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -50,6 +66,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         input_working_directory: ${{ inputs.working-directory }}
         input_config_file: ${{ steps.get-config.outputs.file }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         set -o allexport
         source "${{ github.action_path }}/step_lint.sh"

--- a/lint-with-tflint/helpers_additional.sh
+++ b/lint-with-tflint/helpers_additional.sh
@@ -20,14 +20,31 @@ function read-terraform-module-dirs {
   local -n _dirs_out="${1}"
   local _modules_file="${2}"
   local _prefix="${3}"
-  local _dir
+  local _dir _out_file _err_file
 
   _dirs_out=()
+  _out_file="$(mktemp)"
+  _err_file="$(mktemp)"
+
+  # jq's exit code is checked rather than piping straight into the read loop:
+  # an unparseable modules.json, or one without a '.Modules' array, otherwise
+  # yields zero directories and the caller reports success having checked
+  # nothing at all.
+  if ! jq --raw-output0 --arg pwd "${_prefix}" \
+    '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' \
+    "${_modules_file}" >"${_out_file}" 2>"${_err_file}"; then
+    log-error "failed to read directories from the terraform modules file '${_modules_file}':"
+    log-error "$(cat "${_err_file}")"
+    rm -f "${_out_file}" "${_err_file}"
+    return 1
+  fi
+
   while IFS= read -r -d '' _dir; do
     _dirs_out+=("${_dir}")
-  done < <(jq --raw-output0 --arg pwd "${_prefix}" \
-    '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' \
-    "${_modules_file}")
+  done <"${_out_file}"
+
+  rm -f "${_out_file}" "${_err_file}"
+  return 0
 }
 
 # Apply a JSON environment-variable map to the current shell

--- a/lint-with-tflint/helpers_additional.sh
+++ b/lint-with-tflint/helpers_additional.sh
@@ -1,0 +1,34 @@
+#!/bin/env bash
+#
+# Action-specific helpers for lint-with-tflint.
+# Auto-loaded by helpers.sh.
+#
+
+# Read the module directories terraform recorded in
+# '<project-dir>/.terraform/modules/modules.json' into the array named by $1.
+#
+#   $1 - name of the array variable to populate
+#   $2 - path to modules.json
+#   $3 - prefix to prepend to each relative directory (usually "$(pwd)/")
+#
+# NUL-delimited (jq --raw-output0 + read -d '') rather than newline-joined into
+# a single string: the previous form iterated that string as '${DIRS[*]}', which
+# is not array iteration but word-splitting — so a module path containing a
+# space silently visited two directories that do not exist instead of the one
+# that does. Requires jq 1.7, ref. docs/Per-goal-environment-variables.md §9.2.
+function read-terraform-module-dirs {
+  local -n _dirs_out="${1}"
+  local _modules_file="${2}"
+  local _prefix="${3}"
+  local _dir
+
+  _dirs_out=()
+  while IFS= read -r -d '' _dir; do
+    _dirs_out+=("${_dir}")
+  done < <(jq --raw-output0 --arg pwd "${_prefix}" \
+    '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' \
+    "${_modules_file}")
+}
+
+# ==========================================================
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/lint-with-tflint/helpers_additional.sh
+++ b/lint-with-tflint/helpers_additional.sh
@@ -101,6 +101,18 @@ function apply-extra-envs {
     return 1
   fi
 
+  # How many entries must end up applied. 'length' works on any jq, which is
+  # the point: it is the cross-check that catches a jq too old for
+  # --raw-output0 (ref. docs/Per-goal-environment-variables.md §9.2). Without
+  # it, such a jq makes the read loop consume nothing and the step continues
+  # having applied nothing — silently, and only on the runner images where it
+  # happens to be old.
+  local _extra_envs_expected _extra_envs_applied=0
+  if ! _extra_envs_expected=$(jq -r 'length' "${_extra_envs_file}"); then
+    log-error "unable to count the entries in '${_extra_envs_file}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
     # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
@@ -128,7 +140,15 @@ function apply-extra-envs {
         return 1
       fi
     fi
+    _extra_envs_applied=$((_extra_envs_applied + 1))
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+
+  if [ ! "${_extra_envs_applied}" == "${_extra_envs_expected}" ]; then
+    log-error "applied ${_extra_envs_applied} of ${_extra_envs_expected} environment variable(s) from '${_extra_envs_file}'!"
+    log-error "this usually means jq is older than 1.7 and does not support '--raw-output0' — check the runner image."
+    end-group
+    return 1
+  fi
   end-group
 
   return 0

--- a/lint-with-tflint/helpers_additional.sh
+++ b/lint-with-tflint/helpers_additional.sh
@@ -30,5 +30,59 @@ function read-terraform-module-dirs {
     "${_modules_file}")
 }
 
+# Apply a JSON environment-variable map to the current shell
+# ==========================================================
+# Applies the resolved environment for this action's goal, as produced by the
+# 'resolve-goal-envs' action. A JSON null unsets the variable rather than
+# emptying it — $GITHUB_ENV cannot express that, and the distinction matters for
+# anything that treats "" as a meaningful value.
+#
+# Takes a path, not the JSON itself: the values may be secrets, and nothing here
+# may hold the payload in a shell variable while allexport is in scope (ref. the
+# ARG_MAX rule in CLAUDE.md). jq reads the file and the loop consumes a stream,
+# so only one key and one value transit shell variables at a time.
+#
+# NUL-delimited (jq --raw-output0, requires jq 1.7) so multiline values such as
+# PEM keys and values containing shell metacharacters survive verbatim, with no
+# encoding hop and no per-variable subshell. The sentinel marks a JSON null; an
+# empty field is a genuine empty-string value.
+#
+# Call this early in main, BEFORE the action's own exports: there is no
+# reserved-name list, so that ordering is what decides who wins. See
+# docs/Per-goal-environment-variables.md §6.2 and §6.3.
+#
+# Locals are underscore-prefixed on purpose — a caller whose variable is named
+# 'file', 'key' or 'value' must not collide with them. Not 'readonly' either:
+# helpers.sh being sourced twice in one shell would then hard-fail.
+_EXTRA_ENVS_UNSET='__DSB_UNSET__'
+_EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
+
+function apply-extra-envs {
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+
+  if [ -z "${_extra_envs_file}" ]; then
+    log-info "no per-goal environment variables file configured."
+    return 0
+  fi
+  if [ ! -f "${_extra_envs_file}" ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' does not exist!"
+    return 1
+  fi
+
+  start-group "applying per-goal environment variables"
+  while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
+      log-info "unsetting '${_extra_envs_key}'"
+      unset "${_extra_envs_key}"
+    else
+      log-info "setting '${_extra_envs_key}'"
+      export "${_extra_envs_key}=${_extra_envs_value}"
+    fi
+  done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+  end-group
+
+  return 0
+}
+
 # ==========================================================
 log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/lint-with-tflint/helpers_additional.sh
+++ b/lint-with-tflint/helpers_additional.sh
@@ -58,7 +58,7 @@ _EXTRA_ENVS_UNSET='__DSB_UNSET__'
 _EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
 
 function apply-extra-envs {
-  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value _extra_envs_type
 
   if [ -z "${_extra_envs_file}" ]; then
     log-info "no per-goal environment variables file configured."
@@ -69,14 +69,47 @@ function apply-extra-envs {
     return 1
   fi
 
+  # Validated before anything is applied. Without this an unparseable, empty or
+  # truncated file applies nothing at all and the step carries on as if it had —
+  # the consequence then surfaces as an OOM or a wrong-credentials error far
+  # from its cause, which is the failure mode this whole feature exists to
+  # avoid. resolve-goal-envs already guarantees a JSON object; this is the last
+  # line of defence, and cheap.
+  if ! _extra_envs_type=$(jq -r 'type' "${_extra_envs_file}" 2>/dev/null); then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' is not valid JSON!"
+    return 1
+  fi
+  if [ ! "${_extra_envs_type}" == 'object' ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' must hold a JSON object, got '${_extra_envs_type:-nothing}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
+    # and the value 'x' it happily assigns 'BAR=x' to FOO — silently setting a
+    # different variable than the caller asked for. Hence the explicit check.
+    if [[ ! "${_extra_envs_key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      log-error "'${_extra_envs_key}' is not a valid environment variable name!"
+      end-group
+      return 1
+    fi
     if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
       log-info "unsetting '${_extra_envs_key}'"
-      unset "${_extra_envs_key}"
+      if ! unset "${_extra_envs_key}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     else
       log-info "setting '${_extra_envs_key}'"
-      export "${_extra_envs_key}=${_extra_envs_value}"
+      # Still guarded: a readonly variable makes 'export' fail even though the
+      # name itself is valid.
+      if ! export "${_extra_envs_key}=${_extra_envs_value}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     fi
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
   end-group

--- a/lint-with-tflint/run_all_tests.sh
+++ b/lint-with-tflint/run_all_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/env bash
+#
+# Orchestrates the per-step test suites for lint-with-tflint.
+# See docs/Testing-in-ci.md §4.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+overall_exit=0
+
+run_suite() {
+  local script="${1}"
+  local label="${2}"
+
+  echo ""
+  echo -e "${YELLOW}>>> Running ${label}${NC}"
+  bash "${script}" || overall_exit=1
+}
+
+run_suite "${_this_script_dir}/run_tests_step_get_config.sh" "step_get_config.sh tests"
+run_suite "${_this_script_dir}/run_tests_step_lint.sh" "step_lint.sh tests"
+
+exit ${overall_exit}

--- a/lint-with-tflint/run_local_step_get_config.sh
+++ b/lint-with-tflint/run_local_step_get_config.sh
@@ -1,0 +1,33 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_get_config.sh.
+# Simulates GitHub Actions environment.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}/workspace"
+
+WORK_DIR="${GITHUB_WORKSPACE}/envs/sandbox"
+mkdir -p "${WORK_DIR}"
+
+# Only a repo-root config exists, so the fallback search should find it there.
+cat >"${GITHUB_WORKSPACE}/.tflint.hcl" <<'EOF'
+plugin "terraform" {
+  enabled = true
+}
+EOF
+
+export input_working_directory="${WORK_DIR}"
+export input_config_file_path=""
+
+source "${_this_script_dir}/step_get_config.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"

--- a/lint-with-tflint/run_local_step_lint.sh
+++ b/lint-with-tflint/run_local_step_lint.sh
@@ -49,10 +49,40 @@ export TFLINT_BIN="${STUB_DIR}/tflint"
 export input_working_directory="${WORK_DIR}"
 export input_config_file="${GITHUB_WORKSPACE}/.tflint.hcl"
 
-source "${_this_script_dir}/step_lint.sh"
+# Per-goal environment variables, as resolve-goal-envs would produce them.
+# GOMEMLIMIT is set, and a variable that exists job-wide is unset by a JSON null
+# — something $GITHUB_ENV cannot express.
+export DSB_LEAKY_VAR="value-from-the-job"
+export DSB_UNSET_ME="also-from-the-job"
+export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+cat >"${input_extra_envs_file}" <<'EOF'
+{
+  "GOMEMLIMIT": "12GiB",
+  "GOGC": 25,
+  "DSB_LEAKY_VAR": "value-from-the-goal",
+  "DSB_UNSET_ME": null
+}
+EOF
+
+# Subshell: the step script ends in 'exit', which would otherwise
+# terminate this runner before it can show anything. It is also what
+# makes the scoping check below meaningful — the step's exports die
+# with the subshell, exactly as they do when the GitHub step ends.
+( source "${_this_script_dir}/step_lint.sh" )
+echo ""
+echo "step exit code: ${?}"
+
 
 echo ""
 echo "========================================"
 echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
 echo "========================================"
 cat "${GITHUB_OUTPUT}"
+
+echo ""
+echo "========================================"
+echo "Scoping check (values must NOT leak out)"
+echo "========================================"
+echo "GOMEMLIMIT after the step:    '${GOMEMLIMIT:-<unset>}'  (expected: <unset>)"
+echo "DSB_LEAKY_VAR after the step: '${DSB_LEAKY_VAR:-<unset>}'  (expected: value-from-the-job)"
+echo "DSB_UNSET_ME after the step:  '${DSB_UNSET_ME:-<unset>}'  (expected: also-from-the-job)"

--- a/lint-with-tflint/run_local_step_lint.sh
+++ b/lint-with-tflint/run_local_step_lint.sh
@@ -1,0 +1,58 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_lint.sh.
+# Simulates GitHub Actions environment using a stub 'tflint' binary and a
+# fake '.terraform/modules/modules.json'.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}/workspace"
+
+WORK_DIR="${GITHUB_WORKSPACE}/envs/sandbox"
+mkdir -p "${WORK_DIR}/.terraform/modules"
+mkdir -p "${WORK_DIR}/modules/network" "${WORK_DIR}/modules/storage account"
+
+cat >"${WORK_DIR}/.terraform/modules/modules.json" <<'EOF'
+{
+  "Modules": [
+    { "Key": "", "Source": "", "Dir": "." },
+    { "Key": "network", "Source": "./modules/network", "Dir": "modules/network" },
+    { "Key": "storage", "Source": "./modules/storage account", "Dir": "modules/storage account" },
+    { "Key": "vendored", "Source": "registry.example.com/foo", "Dir": ".terraform/modules/vendored" }
+  ]
+}
+EOF
+
+cat >"${GITHUB_WORKSPACE}/.tflint.hcl" <<'EOF'
+plugin "terraform" {
+  enabled = true
+}
+EOF
+
+STUB_DIR="${RUNNER_TEMP}/stub-bin"
+mkdir -p "${STUB_DIR}"
+cat >"${STUB_DIR}/tflint" <<'EOF'
+#!/bin/env bash
+echo "stub tflint received ${#} argument(s):"
+for arg in "${@}"; do
+  echo "  - '${arg}'"
+done
+exit 0
+EOF
+chmod +x "${STUB_DIR}/tflint"
+export TFLINT_BIN="${STUB_DIR}/tflint"
+
+export input_working_directory="${WORK_DIR}"
+export input_config_file="${GITHUB_WORKSPACE}/.tflint.hcl"
+
+source "${_this_script_dir}/step_lint.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"

--- a/lint-with-tflint/run_tests_step_get_config.sh
+++ b/lint-with-tflint/run_tests_step_get_config.sh
@@ -177,6 +177,18 @@ assert "Space in path: resolved path is intact" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${GITHUB_WORKSPACE}/.tflint.hcl"
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' "${OUT_FILE}"
+assert "negative: no config file is published" test -z "$(get_output file)"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}         step_get_config.sh SUMMARY         ${NC}"

--- a/lint-with-tflint/run_tests_step_get_config.sh
+++ b/lint-with-tflint/run_tests_step_get_config.sh
@@ -1,0 +1,194 @@
+#!/bin/env bash
+#
+# Tests for step_get_config.sh
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+OUT_FILE=/tmp/test_output_get_config.txt
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}/workspace"
+
+  WORK_DIR="${GITHUB_WORKSPACE}/envs/sandbox"
+  mkdir -p "${WORK_DIR}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_config_file_path=""
+}
+
+make_config() {
+  local path="${1}"
+  mkdir -p "$(dirname "${path}")"
+  printf 'plugin "terraform" { enabled = true }\n' >"${path}"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_get_config.sh"
+  ) >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+}
+
+get_output() {
+  local key="${1}"
+  grep "^${key}=" "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    echo "--- GITHUB_OUTPUT ---"
+    cat "${GITHUB_OUTPUT}" 2>/dev/null || true
+    echo "--- /GITHUB_OUTPUT ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}      LINT-WITH-TFLINT GET-CONFIG TESTS     ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Test: config in the working directory wins over the repo root
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${WORK_DIR}/.tflint.hcl"
+make_config "${GITHUB_WORKSPACE}/.tflint.hcl"
+run_step
+assert "Search: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Search: working-directory config takes precedence" \
+  test "$(get_output file)" = "${WORK_DIR}/.tflint.hcl"
+
+# ----------------------------------------------------------------------
+# Test: falls back to the repository root
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${GITHUB_WORKSPACE}/.tflint.hcl"
+run_step
+assert "Fallback: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Fallback: repo-root config is used" \
+  test "$(get_output file)" = "${GITHUB_WORKSPACE}/.tflint.hcl"
+
+# ----------------------------------------------------------------------
+# Test: no config anywhere → hard error
+# ----------------------------------------------------------------------
+setup_workdir
+run_step
+assert "No config: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "No config: error explains what is missing" \
+  grep -q "could not find a TFLint config file to use" "${OUT_FILE}"
+assert "No config: no 'file' output published" \
+  test -z "$(get_output file)"
+
+# ----------------------------------------------------------------------
+# Test: configured absolute path is used verbatim
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${GITHUB_WORKSPACE}/.tflint.hcl"
+make_config "${RUNNER_TEMP}/custom/my-tflint.hcl"
+export input_config_file_path="${RUNNER_TEMP}/custom/my-tflint.hcl"
+run_step
+assert "Configured absolute: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Configured absolute: takes precedence over conventional locations" \
+  test "$(get_output file)" = "${RUNNER_TEMP}/custom/my-tflint.hcl"
+
+# ----------------------------------------------------------------------
+# Test: configured relative path is resolved against the working directory.
+# It is published as given — step_lint.sh cd's to the same working directory,
+# so tflint resolves it to the same file.
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${WORK_DIR}/config/relative.hcl"
+export input_config_file_path="config/relative.hcl"
+run_step
+assert "Configured relative: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Configured relative: published as given" \
+  test "$(get_output file)" = "config/relative.hcl"
+assert "Configured relative: log resolves it under the working directory" \
+  grep -q "envs/sandbox/config/relative.hcl" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: configured relative path that only exists under the working
+# directory, checked from a different cwd — the fallback branch that
+# prefixes '$(pwd)/' must still find it
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${WORK_DIR}/config/only-here.hcl"
+export input_config_file_path="config/only-here.hcl"
+pushd "${RUNNER_TEMP}" >/dev/null || exit 1
+run_step
+popd >/dev/null || exit 1
+assert "Configured relative from elsewhere: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Configured relative from elsewhere: resolved under the working directory" \
+  test "$(get_output file)" = "config/only-here.hcl"
+
+# ----------------------------------------------------------------------
+# Test: configured path that does not exist → hard error, no silent
+# fallback to a conventional location
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${GITHUB_WORKSPACE}/.tflint.hcl"
+export input_config_file_path="does/not/exist.hcl"
+run_step
+assert "Configured missing: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Configured missing: error names the configured path" \
+  grep -q "the configured path 'does/not/exist.hcl' does not exist" "${OUT_FILE}"
+assert "Configured missing: does not fall back to the repo-root config" \
+  test -z "$(get_output file)"
+
+# ----------------------------------------------------------------------
+# Test: config path containing a space is handled
+# ----------------------------------------------------------------------
+setup_workdir
+make_config "${WORK_DIR}/my configs/.tflint.hcl"
+export input_config_file_path="my configs/.tflint.hcl"
+run_step
+assert "Space in path: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Space in path: resolved path is intact" \
+  test "$(get_output file)" = "my configs/.tflint.hcl"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}         step_get_config.sh SUMMARY         ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/lint-with-tflint/run_tests_step_lint.sh
+++ b/lint-with-tflint/run_tests_step_lint.sh
@@ -1,0 +1,260 @@
+#!/bin/env bash
+#
+# Tests for step_lint.sh
+#
+# Uses a stub 'tflint' binary (injected via TFLINT_BIN) so tests don't require
+# — and never call — the real tflint binary. The stub appends one
+# 'INVOCATION <argc>' line per call followed by one line per argument, which is
+# what makes the "a directory path with a space is ONE argument" assertions
+# possible: the old string-built form produced two bogus directories instead.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+OUT_FILE=/tmp/test_output_lint.txt
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}/workspace"
+
+  WORK_DIR="${GITHUB_WORKSPACE}/envs/sandbox"
+  mkdir -p "${WORK_DIR}"
+
+  CONFIG_FILE="${GITHUB_WORKSPACE}/.tflint.hcl"
+  printf 'plugin "terraform" { enabled = true }\n' >"${CONFIG_FILE}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_config_file="${CONFIG_FILE}"
+
+  ARGS_FILE="${RUNNER_TEMP}/tflint-args.txt"
+  : >"${ARGS_FILE}"
+  export MOCK_TFLINT_ARGS_FILE="${ARGS_FILE}"
+
+  unset MOCK_TFLINT_EXIT MOCK_TFLINT_FAIL_DIR MOCK_TFLINT_INIT_FAIL_DIR
+}
+
+# Write a fake modules.json. Each argument is a module 'Dir' value. The
+# directories are created too: terraform has them on disk by the time this
+# runs, and ws-path (realpath) needs them to exist to render log lines.
+write_modules_file() {
+  local dirs_json dir
+  dirs_json="$(printf '%s\n' "${@}" | jq -Rsc 'split("\n") | map(select(length > 0)) | map({Dir: .})')"
+  for dir in "${@}"; do
+    mkdir -p "${WORK_DIR}/${dir}"
+  done
+  mkdir -p "${WORK_DIR}/.terraform/modules"
+  jq -n --argjson mods "${dirs_json}" '{Modules: $mods}' \
+    >"${WORK_DIR}/.terraform/modules/modules.json"
+}
+
+install_stub_tflint() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/tflint" <<'STUB'
+#!/bin/env bash
+_is_init=0
+_chdir=""
+for arg in "${@}"; do
+  [ "${arg}" = "--init" ] && _is_init=1
+  case "${arg}" in --chdir=*) _chdir="${arg#--chdir=}" ;; esac
+done
+
+if [ -n "${MOCK_TFLINT_ARGS_FILE:-}" ]; then
+  printf 'INVOCATION %s\n' "${#}" >>"${MOCK_TFLINT_ARGS_FILE}"
+  printf '%s\n' "${@}" >>"${MOCK_TFLINT_ARGS_FILE}"
+fi
+
+if [ "${_is_init}" -eq 1 ]; then
+  if [ -n "${MOCK_TFLINT_INIT_FAIL_DIR:-}" ] && [ "${_chdir}" = "${MOCK_TFLINT_INIT_FAIL_DIR}" ]; then
+    echo "Failed to install plugin"
+    exit 7
+  fi
+  exit 0
+fi
+
+if [ -n "${MOCK_TFLINT_FAIL_DIR:-}" ] && [ "${_chdir}" = "${MOCK_TFLINT_FAIL_DIR}" ]; then
+  echo "main.tf:1:1: Warning - something (rule)"
+  exit 2
+fi
+exit "${MOCK_TFLINT_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/tflint"
+  export TFLINT_BIN="${stub_dir}/tflint"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_lint.sh"
+  ) >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+}
+
+invocations() { grep -c '^INVOCATION ' "${ARGS_FILE}"; }
+init_invocations() { grep -c '^--init$' "${ARGS_FILE}"; }
+lint_invocations() { grep -c '^--format=compact$' "${ARGS_FILE}"; }
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    echo "--- recorded invocations ---"
+    cat "${ARGS_FILE}" 2>/dev/null || true
+    echo "--- /recorded invocations ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}        LINT-WITH-TFLINT LINT TESTS         ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Test: no modules.json → lint the project directory only
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+run_step
+assert "No modules file: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "No modules file: one init + one lint invocation" \
+  test "$(invocations)" -eq 2
+assert "No modules file: lints the project directory" \
+  bash -c "grep -Fxq -- '--chdir=${WORK_DIR}' '${ARGS_FILE}'"
+assert "No modules file: problem matcher registered" \
+  grep -q '::add-matcher::.*tflint_matcher.json' "${OUT_FILE}"
+assert "No modules file: config file passed to tflint" \
+  bash -c "grep -Fxq -- '--config=${CONFIG_FILE}' '${ARGS_FILE}'"
+assert "No modules file: summary line present" \
+  grep -q "success ->" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: modules.json → init + lint per module dir, '.terraform/*' filtered
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+write_modules_file "." "modules/network" "modules/network" ".terraform/modules/vendored"
+run_step
+assert "Modules file: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Modules file: two init invocations" test "$(init_invocations)" -eq 2
+assert "Modules file: two lint invocations" test "$(lint_invocations)" -eq 2
+assert "Modules file: vendored '.terraform' dir excluded" \
+  bash -c "! grep -q -- '--chdir=.*\.terraform/modules/vendored' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: a module directory path containing a space is linted as ONE
+# directory, not two. This is the latent bug the array conversion fixes —
+# see docs/Per-goal-environment-variables.md §6.5.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+write_modules_file "modules/storage account"
+run_step
+assert "Space in dir: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Space in dir: exactly one init + one lint (not two dirs)" \
+  test "$(invocations)" -eq 2
+assert "Space in dir: both invocations have 3 arguments (path not word-split)" \
+  test "$(grep -c '^INVOCATION 3$' "${ARGS_FILE}")" -eq 2
+assert "Space in dir: path arrives verbatim as one argument" \
+  bash -c "grep -Fxq -- '--chdir=${WORK_DIR}/modules/storage account' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: a module directory path containing a glob character is not expanded
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+mkdir -p "${WORK_DIR}/modules/a" "${WORK_DIR}/modules/b"
+write_modules_file 'modules/*'
+run_step
+assert "Glob in dir: exactly one init + one lint (not one per match)" \
+  test "$(invocations)" -eq 2
+assert "Glob in dir: path arrives unexpanded" \
+  bash -c "grep -Fxq -- '--chdir=${WORK_DIR}/modules/*' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: lint findings in one directory fail the step, other directories
+# still get linted (exit codes are summed)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+write_modules_file "." "modules/network" "modules/storage"
+export MOCK_TFLINT_FAIL_DIR="${WORK_DIR}/modules/network"
+run_step
+assert "Findings: three dirs linted" test "$(lint_invocations)" -eq 3
+assert "Findings: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Findings: exit code is the sum (0+2+0)" test "${LAST_EXIT}" -eq 2
+assert "Findings: summary marks the failing directory" \
+  grep -q "failure -> ./envs/sandbox/modules/network" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: a failing 'tflint --init' records that directory as failed and the
+# remaining directories are still linted
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+write_modules_file "." "modules/network" "modules/storage"
+export MOCK_TFLINT_INIT_FAIL_DIR="${WORK_DIR}/modules/network"
+run_step
+assert "Init failure: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Init failure: exit code is init's code (0+7+0)" test "${LAST_EXIT}" -eq 7
+assert "Init failure: error logged" \
+  grep -q "TFLint init exited with code '7'" "${OUT_FILE}"
+assert "Init failure: failing dir is not linted" \
+  test "$(lint_invocations)" -eq 2
+assert "Init failure: remaining dirs still linted" \
+  bash -c "grep -Fxq -- '--chdir=${WORK_DIR}/modules/storage' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: config file path containing a space reaches tflint as one argument
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+CONFIG_FILE="${GITHUB_WORKSPACE}/my configs/.tflint.hcl"
+mkdir -p "$(dirname "${CONFIG_FILE}")"
+printf 'plugin "terraform" { enabled = true }\n' >"${CONFIG_FILE}"
+export input_config_file="${CONFIG_FILE}"
+run_step
+assert "Space in config path: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Space in config path: arrives verbatim as one argument" \
+  bash -c "grep -Fxq -- '--config=${CONFIG_FILE}' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}            step_lint.sh SUMMARY            ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/lint-with-tflint/run_tests_step_lint.sh
+++ b/lint-with-tflint/run_tests_step_lint.sh
@@ -434,6 +434,64 @@ assert "T25: and nothing was written to \$GITHUB_ENV" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_lint.txt'
+
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_lint.txt'
+
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_lint.txt'
+
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_lint.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_lint.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_lint.sh SUMMARY            ${NC}"

--- a/lint-with-tflint/run_tests_step_lint.sh
+++ b/lint-with-tflint/run_tests_step_lint.sh
@@ -42,7 +42,8 @@ setup_workdir() {
   : >"${ARGS_FILE}"
   export MOCK_TFLINT_ARGS_FILE="${ARGS_FILE}"
 
-  unset MOCK_TFLINT_EXIT MOCK_TFLINT_FAIL_DIR MOCK_TFLINT_INIT_FAIL_DIR
+  unset MOCK_TFLINT_EXIT MOCK_TFLINT_FAIL_DIR MOCK_TFLINT_INIT_FAIL_DIR MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 # Write a fake modules.json. Each argument is a module 'Dir' value. The
@@ -64,6 +65,11 @@ install_stub_tflint() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/tflint" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 _is_init=0
 _chdir=""
 for arg in "${@}"; do
@@ -239,6 +245,191 @@ run_step
 assert "Space in config path: step exits 0" test "${LAST_EXIT}" -eq 0
 assert "Space in config path: arrives verbatim as one argument" \
   bash -c "grep -Fxq -- '--config=${CONFIG_FILE}' '${ARGS_FILE}'"
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_lint.txt'"
+
+setup_workdir
+install_stub_tflint
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_lint.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_lint.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_lint.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_lint.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_lint.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_tflint
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
 # Summary

--- a/lint-with-tflint/run_tests_step_lint.sh
+++ b/lint-with-tflint/run_tests_step_lint.sh
@@ -492,6 +492,40 @@ assert "negative: it is rejected as a name, not silently reinterpreted" \
 assert "negative: the tool was not invoked at all" \
   bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
 
+# ----------------------------------------------------------------------
+# Linting nothing must not report success. Before this was guarded, an
+# unparseable modules.json made jq fail, the directory list came out empty,
+# the loop never ran and the step exited 0 — "lint passed" with nothing
+# linted.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+mkdir -p "${WORK_DIR}/.terraform/modules"
+printf '{ this is not json' >"${WORK_DIR}/.terraform/modules/modules.json"
+run_step
+assert "negative: unparseable modules.json fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the modules file" \
+  grep -q 'failed to read directories from the terraform modules file' "${OUT_FILE}"
+assert "negative: tflint was never invoked" test "$(invocations)" -eq 0
+
+setup_workdir
+install_stub_tflint
+mkdir -p "${WORK_DIR}/.terraform/modules"
+printf '{"NotModules": []}' >"${WORK_DIR}/.terraform/modules/modules.json"
+run_step
+assert "negative: modules.json without a Modules array fails the step" \
+  test "${LAST_EXIT}" -ne 0
+assert "negative: tflint was never invoked" test "$(invocations)" -eq 0
+
+setup_workdir
+install_stub_tflint
+write_modules_file ".terraform/modules/only-vendored"
+run_step
+assert "negative: an empty directory list fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says nothing was found to lint" \
+  grep -q 'no directories to lint were found' "${OUT_FILE}"
+assert "negative: tflint was never invoked" test "$(invocations)" -eq 0
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_lint.sh SUMMARY            ${NC}"

--- a/lint-with-tflint/run_tests_step_lint.sh
+++ b/lint-with-tflint/run_tests_step_lint.sh
@@ -526,6 +526,22 @@ assert "negative: the error says nothing was found to lint" \
   grep -q 'no directories to lint were found' "${OUT_FILE}"
 assert "negative: tflint was never invoked" test "$(invocations)" -eq 0
 
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_tflint
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_lint.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_lint.sh SUMMARY            ${NC}"

--- a/lint-with-tflint/step_get_config.sh
+++ b/lint-with-tflint/step_get_config.sh
@@ -1,0 +1,68 @@
+#!/bin/env bash
+#
+# Source for the lint-with-tflint get-config step.
+#
+# Resolves which TFLint config file to use: either the caller-configured path
+# (absolute, or relative to the working directory) or the first of the
+# conventional locations that exists.
+#
+# Outputs:
+#   file - Absolute path of the TFLint config file to use.
+#
+# Required environment variables:
+#   input_working_directory - From what directory to run TFLint.
+#
+# Optional environment variables:
+#   input_config_file_path  - Caller-configured config file path. When empty
+#                             the conventional locations are searched.
+#
+
+set +o nounset
+
+# Load helpers
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  cd "${input_working_directory}"
+
+  local configured_path="${input_config_file_path}"
+  local possible_paths=(
+    "$(pwd)/.tflint.hcl"
+    "${GITHUB_WORKSPACE}/.tflint.hcl"
+  )
+
+  local path_to_use=""
+  if [ -n "${configured_path}" ]; then
+    log-info "using configured TFLint config file path"
+    if [ -f "${configured_path}" ]; then
+      path_to_use="${configured_path}"
+    elif [ -f "$(pwd)/${configured_path}" ]; then
+      path_to_use="$(pwd)/${configured_path}"
+    else
+      log-error "the configured path '${configured_path}' does not exist, unable to perform linting!"
+      return 1
+    fi
+  else
+    log-info "TFLint config file path was not configured, attempting to locate one ..."
+    local candidate
+    for candidate in "${possible_paths[@]}"; do
+      if [ -f "${candidate}" ]; then
+        path_to_use="${candidate}"
+        break
+      fi
+    done
+    if [ ! -f "${path_to_use}" ]; then
+      log-error "could not find a TFLint config file to use, unable to perform linting!"
+      return 1
+    fi
+  fi
+
+  log-info "using TFLint config file located at '$(ws-path "${path_to_use}")'"
+  set-output 'file' "${path_to_use}"
+
+  return 0
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/lint-with-tflint/step_get_config.sh
+++ b/lint-with-tflint/step_get_config.sh
@@ -23,7 +23,15 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   local configured_path="${input_config_file_path}"
   local possible_paths=(

--- a/lint-with-tflint/step_lint.sh
+++ b/lint-with-tflint/step_lint.sh
@@ -1,0 +1,104 @@
+#!/bin/env bash
+#
+# Source for the lint-with-tflint lint step.
+#
+# Registers the TFLint problem matcher, determines which directories to lint —
+# every module directory terraform recorded in
+# '<project-dir>/.terraform/modules/modules.json' during init, or just the
+# project directory when there is no modules file — then runs 'tflint --init'
+# followed by 'tflint' in each.
+#
+# Exits with the sum of the per-directory exit codes so a failure anywhere
+# surfaces as a failing step.
+#
+# Required environment variables:
+#   input_working_directory - From what directory to run TFLint.
+#   input_config_file       - Path of the TFLint config file, as resolved by
+#                             step_get_config.sh.
+#
+# Optional environment variables:
+#   TFLINT_BIN - Path to the tflint binary (defaults to 'tflint' on PATH).
+#                Used by tests to inject a stub.
+#
+
+set +o nounset
+
+# Load helpers (provides read-terraform-module-dirs via helpers_additional.sh)
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tflint_bin="${TFLINT_BIN:-tflint}"
+
+  cd "${input_working_directory}"
+
+  # Decoration in github
+  echo "::add-matcher::${GITHUB_ACTION_PATH}/tflint_matcher.json"
+
+  # Dirs
+  local modules_file="$(pwd)/.terraform/modules/modules.json"
+  local lint_dirs=()
+  log-info "looking for terraform modules file at '$(ws-path "${modules_file}")'"
+  if [ -f "${modules_file}" ]; then
+    log-info "found it, parsing directories to lint"
+    read-terraform-module-dirs lint_dirs "${modules_file}" "$(pwd)/"
+  else
+    log-info "no modules file found, linting will only be performed in '$(ws-path "$(pwd)")'"
+    lint_dirs=("$(pwd)")
+  fi
+
+  # Lint
+  declare -A lint_results
+  local lint_dir
+  for lint_dir in "${lint_dirs[@]}"; do
+    start-group "directory '$(ws-path "${lint_dir}")'"
+
+    # Array-built invocations so a directory path containing a space or a
+    # glob character reaches tflint as exactly one argument.
+    local init_cmd=("${tflint_bin}" --init "--config=${input_config_file}" "--chdir=${lint_dir}")
+    local lint_cmd=("${tflint_bin}" --format=compact "--config=${input_config_file}" "--chdir=${lint_dir}")
+
+    log-info "TFLint init ..."
+    log-info "command string is '${init_cmd[*]@Q}'"
+    set +e
+    "${init_cmd[@]}"
+    local init_exit=${?}
+
+    # A failing '--init' used to abort the whole step on the spot. Recording
+    # it as this directory's result instead keeps the remaining directories
+    # linted — the step still fails, because the exit codes are summed — and
+    # the log then shows which directories were reached.
+    if [ ! "${init_exit}" == "0" ]; then
+      log-error "TFLint init exited with code '${init_exit}', skipping linting of this directory!"
+      lint_results["${lint_dir}"]=${init_exit}
+      end-group
+      continue
+    fi
+
+    log-info "linting ..."
+    log-info "command string is '${lint_cmd[*]@Q}'"
+    set +e
+    "${lint_cmd[@]}"
+    lint_results["${lint_dir}"]=${?}
+
+    end-group
+  done
+
+  # Summary
+  log-info "summary:"
+  for lint_dir in "${lint_dirs[@]}"; do
+    log-info "  - $([[ ${lint_results["${lint_dir}"]} -ne 0 ]] && echo 'failure ->' || echo 'success ->') ./$(ws-path "${lint_dir}")"
+  done
+
+  # Exit code — sum of all per-directory codes, matching the legacy
+  # action's behaviour.
+  local sum_exit_codes=0
+  local v
+  for v in "${lint_results[@]}"; do
+    sum_exit_codes=$((sum_exit_codes + v))
+  done
+  return ${sum_exit_codes}
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/lint-with-tflint/step_lint.sh
+++ b/lint-with-tflint/step_lint.sh
@@ -47,10 +47,16 @@ function main {
   log-info "looking for terraform modules file at '$(ws-path "${modules_file}")'"
   if [ -f "${modules_file}" ]; then
     log-info "found it, parsing directories to lint"
-    read-terraform-module-dirs lint_dirs "${modules_file}" "$(pwd)/"
+    read-terraform-module-dirs lint_dirs "${modules_file}" "$(pwd)/" || return 1
   else
     log-info "no modules file found, linting will only be performed in '$(ws-path "$(pwd)")'"
     lint_dirs=("$(pwd)")
+  fi
+
+  # Linting nothing must not report success.
+  if [ ${#lint_dirs[@]} -eq 0 ]; then
+    log-error "no directories to lint were found!"
+    return 1
   fi
 
   # Lint

--- a/lint-with-tflint/step_lint.sh
+++ b/lint-with-tflint/step_lint.sh
@@ -17,6 +17,9 @@
 #                             step_get_config.sh.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   TFLINT_BIN - Path to the tflint binary (defaults to 'tflint' on PATH).
 #                Used by tests to inject a stub.
 #
@@ -27,6 +30,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tflint_bin="${TFLINT_BIN:-tflint}"
 
   cd "${input_working_directory}"

--- a/lint-with-tflint/step_lint.sh
+++ b/lint-with-tflint/step_lint.sh
@@ -36,7 +36,15 @@ function main {
 
   local tflint_bin="${TFLINT_BIN:-tflint}"
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   # Decoration in github
   echo "::add-matcher::${GITHUB_ACTION_PATH}/tflint_matcher.json"

--- a/resolve-goal-envs/action.yml
+++ b/resolve-goal-envs/action.yml
@@ -1,0 +1,109 @@
+name: "Resolve per-goal environment variables"
+description: |
+  Resolves the effective set of environment variables for every terraform goal
+  (init, format, validate, lint, plan, apply, destroy-plan, destroy) by merging
+  the global maps with the per-goal ones and expanding secret names to their
+  values.
+
+  Writes one JSON file per goal into a private directory under $RUNNER_TEMP and
+  outputs that directory's path. Goal actions receive the path and apply the
+  file verbatim, so secret values never enter argv, envp, or a step's
+  interpolated script text.
+
+  See docs/Per-goal-environment-variables.md for the full design.
+author: "Peder Schmedling"
+inputs:
+  extra-envs:
+    description: |
+      JSON object of environment variables that apply to every goal. Per
+      environment resolution has already happened in create-tf-vars-matrix.
+        key:    env name
+        value:  value of env, a JSON null unsets it
+    required: false
+    default: "{}"
+  extra-envs-from-secrets:
+    description: |
+      JSON object of environment variables that apply to every goal, with
+      values read from github secrets.
+        key:    env name
+        value:  name of the secret to read the value from
+    required: false
+    default: "{}"
+  extra-envs-per-goal:
+    description: |
+      JSON object of objects, keyed by goal, of environment variables that
+      apply to that goal only.
+        key:    goal name, one of init, format, validate, lint, plan, apply,
+                destroy-plan, destroy. An unknown goal is a hard error.
+        value:  JSON object as in 'extra-envs'
+    required: false
+    default: "{}"
+  extra-envs-from-secrets-per-goal:
+    description: |
+      JSON object of objects, keyed by goal, of environment variables that
+      apply to that goal only, with values read from github secrets.
+
+      NOTE: these reach the terraform/tflint process for that goal, not the
+      workflow's 'azure/login' step — that runs once, early, and reads job-wide
+      environment variables. A plan/apply cloud identity split does not work
+      through this input.
+        key:    goal name, as in 'extra-envs-per-goal'
+        value:  JSON object as in 'extra-envs-from-secrets'
+    required: false
+    default: "{}"
+  secrets-json:
+    description: |
+      All secrets available to the ci/cd workflow.
+
+      Example (replace '?' with '$'):
+        - uses: ./.github/resolve-goal-envs
+          with:
+            secrets-json: ?{{ toJSON(secrets) }}
+            ...
+    required: true
+outputs:
+  envs-dir:
+    description: |
+      Absolute path of a 0700 directory holding one 0600 '<goal>.json' file per
+      goal. Every file always exists, containing at minimum '{}'. Pass the
+      relevant file to a goal action's 'extra-envs-file' input.
+    value: ${{ steps.resolve.outputs.envs-dir }}
+runs:
+  using: "composite"
+  steps:
+    - id: resolve
+      shell: bash
+      run: |
+        # 'secrets-json' is the one genuinely large payload here — a bag holding
+        # a PEM private key is enough on its own. It goes straight to a file
+        # BEFORE 'set -o allexport', and only the path is exported. A
+        # modern-layout shim defaults to the opposite, so this has to be
+        # deliberate. Ref. docs/Per-goal-environment-variables.md §8.
+        input_secrets_file="$(mktemp "${RUNNER_TEMP:-/tmp}/secrets-bag-XXXXXXXX.json")"
+        chmod 0600 "${input_secrets_file}"
+        cat >"${input_secrets_file}" <<'EOF'
+        ${{ inputs.secrets-json }}
+        EOF
+        export input_secrets_file
+
+        # Heredoc captures (special chars survive verbatim). Intentionally NOT
+        # exported — step_resolve.sh reads them as shell-locals via 'source'.
+        input_extra_envs=$(cat <<'EOF'
+        ${{ inputs.extra-envs }}
+        EOF
+        )
+        input_extra_envs_from_secrets=$(cat <<'EOF'
+        ${{ inputs.extra-envs-from-secrets }}
+        EOF
+        )
+        input_extra_envs_per_goal=$(cat <<'EOF'
+        ${{ inputs.extra-envs-per-goal }}
+        EOF
+        )
+        input_extra_envs_from_secrets_per_goal=$(cat <<'EOF'
+        ${{ inputs.extra-envs-from-secrets-per-goal }}
+        EOF
+        )
+
+        set -o allexport
+        source "${{ github.action_path }}/step_resolve.sh"

--- a/resolve-goal-envs/helpers.sh
+++ b/resolve-goal-envs/helpers.sh
@@ -1,0 +1,40 @@
+#!/bin/env bash
+
+# Helper consts
+_action_name="$(basename "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)")"
+
+# Helper functions
+function _log { echo "${1}${_action_name}: ${2}"; }
+function log-info { _log "" "${*}"; }
+function log-debug { _log "DEBUG: " "${*}"; }
+function log-warn { _log "WARN: " "${*}"; }
+function log-error { _log "ERROR: " "${*}"; }
+function start-group { echo "::group::${_action_name}: ${*}"; }
+function end-group { echo "::endgroup::"; }
+function log-multiline {
+  start-group "${1}"
+  echo "${2}"
+  end-group
+}
+function mask-value { echo "::add-mask::${*}"; }
+function set-output { echo "${1}=${2}" >>$GITHUB_OUTPUT; }
+function set-multiline-output {
+  local outputName outputValue delimiter
+  outputName="${1}"
+  outputValue="${2}"
+  delimiter=$(echo $RANDOM | md5sum | head -c 20)
+  echo "${outputName}<<\"${delimiter}\"" >>$GITHUB_OUTPUT
+  echo "${outputValue}" >>$GITHUB_OUTPUT
+  echo "\"${delimiter}\"" >>$GITHUB_OUTPUT
+}
+function ws-path {
+  local inPath
+  inPath="${1}"
+  realpath --relative-to="${GITHUB_WORKSPACE}" "${inPath}"
+}
+
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."
+
+if [ -f "${GITHUB_ACTION_PATH}/helpers_additional.sh" ]; then
+  source "${GITHUB_ACTION_PATH}/helpers_additional.sh"
+fi

--- a/resolve-goal-envs/helpers_additional.sh
+++ b/resolve-goal-envs/helpers_additional.sh
@@ -118,9 +118,14 @@ function find-input-errors {
         | select(IN($goals[]) | not)
         | "\($ctx): \"\(.)\" is not a valid goal, valid goals are: \($goals | join(", "))";
 
+      # A null goal value is accepted, not rejected: writing
+      #   extra-envs-per-goal-yml: |
+      #     plan:
+      # is natural YAML for "nothing here yet", and yq renders it as null. It
+      # resolves the same as an absent key.
       def bad_goal_values($ctx):
         to_entries[]
-        | select((.value | type) != "object")
+        | select((.value != null) and ((.value | type) != "object"))
         | "\($ctx): the value of goal \"\(.key)\" must be a mapping of environment variables, got \(.value | type)";
 
       def goal_maps: to_entries[] | select((.value | type) == "object");

--- a/resolve-goal-envs/helpers_additional.sh
+++ b/resolve-goal-envs/helpers_additional.sh
@@ -1,0 +1,194 @@
+#!/bin/env bash
+#
+# Action-specific helpers for resolve-goal-envs.
+# Auto-loaded by helpers.sh.
+#
+# Everything here reads JSON from files rather than from shell variables. The
+# secrets bag is the one genuinely large payload in this action — a bag holding
+# a PEM private key is enough on its own — and under 'set -o allexport' any
+# variable holding it, 'local' included, lands in envp for the next fork.
+# Ref. docs/Per-goal-environment-variables.md §8.
+#
+
+# The goals per-goal environment variables can be attached to. Same vocabulary
+# a caller writes in 'goals-yml', with two deliberate differences:
+#
+#   - 'format', not 'fmt': the caller-facing name follows goals-yml, even
+#     though the workflow step id is 'fmt'.
+#   - no 'all': it is not a stage but shorthand expanded inside each workflow
+#     step's 'if:', so there is nothing to attach values to. The every-goal
+#     layer is the plain 'extra-envs-yml'. Rejecting it as an unknown key is
+#     what makes 'all:' fail loudly instead of silently doing nothing.
+#
+# 'destroy-plan' / 'destroy' are separate from 'plan' / 'apply' even though
+# they reuse the same two actions — that is what lets a destroy plan be tuned
+# independently. Kept in sync with create-tf-vars-matrix and
+# docs/Per-goal-environment-variables.md §2.2.
+GOAL_KEYS=(
+  init
+  format
+  validate
+  lint
+  plan
+  apply
+  destroy-plan
+  destroy
+)
+
+# Make sure the file $1 holds a JSON object, using $2 as the input's name in
+# error messages.
+#
+# An empty file, a whitespace-only file, or a literal JSON 'null' all mean
+# "nothing configured" and become '{}'. 'null' in particular is what
+# 'toJSON(...)' renders for a matrix key that does not exist.
+function normalize-json-object-file {
+  local file="${1}" label="${2}" json_type
+
+  if ! grep -q '[^[:space:]]' "${file}" 2>/dev/null; then
+    printf '{}' >"${file}"
+    return 0
+  fi
+
+  if ! json_type=$(jq -r 'type' "${file}" 2>/dev/null); then
+    log-error "input '${label}' is not valid JSON!"
+    return 1
+  fi
+
+  if [ "${json_type}" == 'null' ]; then
+    printf '{}' >"${file}"
+    return 0
+  fi
+
+  if [ "${json_type}" != 'object' ]; then
+    log-error "input '${label}' must be a JSON object, got '${json_type}'!"
+    return 1
+  fi
+
+  return 0
+}
+
+# Echo one line per problem found in the input files under $1. No output means
+# the inputs are valid.
+#
+# Every check happens here, at the single site that resolves per-goal values,
+# so a typo is caught once and early rather than surfacing as a terraform
+# failure far from its cause. Messages name keys, goals and secret *names* —
+# never values, see log hygiene in
+# docs/Per-goal-environment-variables.md §5.5.
+function find-input-errors {
+  local work_dir="${1}"
+
+  jq -n -r \
+    --slurpfile plain "${work_dir}/global-plain.json" \
+    --slurpfile secret_map "${work_dir}/global-secrets.json" \
+    --slurpfile goal_plain "${work_dir}/per-goal-plain.json" \
+    --slurpfile goal_secret_map "${work_dir}/per-goal-secrets.json" \
+    --slurpfile bag "${work_dir}/secrets.json" \
+    '
+      def NAME_RE: "^[A-Za-z_][A-Za-z0-9_]*$";
+
+      def bad_names($ctx):
+        to_entries[]
+        | select(.key | test(NAME_RE) | not)
+        | "\($ctx): \"\(.key)\" is not a valid environment variable name, it must match \(NAME_RE)";
+
+      def bad_values($ctx):
+        to_entries[]
+        | select(.value != null)
+        | select((.value | type) as $t | $t != "string" and $t != "number" and $t != "boolean")
+        | "\($ctx): the value of \"\(.key)\" is of type \(.value | type), only string, number, boolean or null are allowed";
+
+      def bad_secret_names($ctx):
+        to_entries[]
+        | select(((.value | type) != "string") or ((.value | length) == 0))
+        | "\($ctx): the secret name for \"\(.key)\" must be a non-empty string";
+
+      # The entry is bound before the has() test: jq evaluates the argument of
+      # has() against the input of has(), so a bare .value in there would
+      # resolve against the secrets bag rather than against the entry.
+      def missing_secrets($ctx; $secrets):
+        to_entries[]
+        | select(((.value | type) == "string") and ((.value | length) > 0))
+        | . as $entry
+        | select($secrets | has($entry.value) | not)
+        | "\($ctx): secret \"\($entry.value)\", mapped to environment variable \"\($entry.key)\", is not available to the workflow";
+
+      def bad_goal_keys($ctx; $goals):
+        keys[]
+        | select(IN($goals[]) | not)
+        | "\($ctx): \"\(.)\" is not a valid goal, valid goals are: \($goals | join(", "))";
+
+      def bad_goal_values($ctx):
+        to_entries[]
+        | select((.value | type) != "object")
+        | "\($ctx): the value of goal \"\(.key)\" must be a mapping of environment variables, got \(.value | type)";
+
+      def goal_maps: to_entries[] | select((.value | type) == "object");
+
+      $ARGS.positional as $goals
+      | (($plain[0]) // {}) as $p
+      | (($secret_map[0]) // {}) as $s
+      | (($goal_plain[0]) // {}) as $gp
+      | (($goal_secret_map[0]) // {}) as $gs
+      | (($bag[0]) // {}) as $secrets
+      | [
+          ($p  | bad_names("extra-envs")),
+          ($p  | bad_values("extra-envs")),
+          ($s  | bad_names("extra-envs-from-secrets")),
+          ($s  | bad_secret_names("extra-envs-from-secrets")),
+          ($s  | missing_secrets("extra-envs-from-secrets"; $secrets)),
+          ($gp | bad_goal_keys("extra-envs-per-goal"; $goals)),
+          ($gp | bad_goal_values("extra-envs-per-goal")),
+          ($gp | goal_maps | .key as $g | .value | bad_names("extra-envs-per-goal.\($g)")),
+          ($gp | goal_maps | .key as $g | .value | bad_values("extra-envs-per-goal.\($g)")),
+          ($gs | bad_goal_keys("extra-envs-from-secrets-per-goal"; $goals)),
+          ($gs | bad_goal_values("extra-envs-from-secrets-per-goal")),
+          ($gs | goal_maps | .key as $g | .value | bad_names("extra-envs-from-secrets-per-goal.\($g)")),
+          ($gs | goal_maps | .key as $g | .value | bad_secret_names("extra-envs-from-secrets-per-goal.\($g)")),
+          ($gs | goal_maps | .key as $g | .value | missing_secrets("extra-envs-from-secrets-per-goal.\($g)"; $secrets))
+        ]
+      | .[]
+    ' \
+    --args "${GOAL_KEYS[@]}"
+}
+
+# Resolve the effective environment for one goal ($2) from the input files
+# under $1, writing the result to $3.
+#
+# Overlay order, last wins (docs/Per-goal-environment-variables.md §2.3):
+#
+#   1. extra-envs
+#   2. extra-envs-from-secrets, values replaced by the secret's value
+#   3. extra-envs-per-goal[goal]
+#   4. extra-envs-from-secrets-per-goal[goal], resolved as in 2
+#
+# Specificity beats source (3 beats 2) while secrets win within one
+# specificity level (2 beats 1, 4 beats 3) — the latter preserves what
+# export-env-vars already does today by running its plain loop before its
+# secrets loop.
+#
+# jq's '+' on objects is a shallow right-wins merge that keeps null values,
+# which is what makes "a null unsets the variable" survive every overlay.
+function resolve-goal-envs-file {
+  local work_dir="${1}" goal="${2}" out_file="${3}"
+
+  jq -n \
+    --slurpfile plain "${work_dir}/global-plain.json" \
+    --slurpfile secret_map "${work_dir}/global-secrets.json" \
+    --slurpfile goal_plain "${work_dir}/per-goal-plain.json" \
+    --slurpfile goal_secret_map "${work_dir}/per-goal-secrets.json" \
+    --slurpfile bag "${work_dir}/secrets.json" \
+    --arg goal "${goal}" \
+    '
+      def resolve_from($secrets): with_entries(.value = $secrets[.value]);
+
+      (($bag[0]) // {}) as $secrets
+      | (($plain[0]) // {})
+        + ((($secret_map[0]) // {}) | resolve_from($secrets))
+        + (((($goal_plain[0]) // {})[$goal]) // {})
+        + (((((($goal_secret_map[0]) // {})[$goal]) // {})) | resolve_from($secrets))
+    ' >"${out_file}"
+}
+
+# ==========================================================
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/resolve-goal-envs/run_all_tests.sh
+++ b/resolve-goal-envs/run_all_tests.sh
@@ -458,6 +458,74 @@ assert_eq "coverage: unconfigured goals are empty objects" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# An empty goal block is natural YAML for "nothing here yet" — yq renders
+#   plan:
+# as null — and must resolve the same as an absent key rather than failing.
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"GOGC":50}'
+export input_extra_envs_per_goal='{"plan":null,"apply":{"GOGC":25}}'
+run_step
+assert "empty goal block: step exits 0" test "${LAST_EXIT}" -eq 0
+assert_eq "empty goal block: the goal falls back to the global value" \
+  '50' "$(goal_query plan '.GOGC')"
+assert_eq "empty goal block: other goals are unaffected" \
+  '25' "$(goal_query apply '.GOGC')"
+
+setup
+export input_extra_envs_from_secrets_per_goal='{"apply":null}'
+run_step
+assert "empty goal block: accepted in the secrets map too" test "${LAST_EXIT}" -eq 0
+
+# ----------------------------------------------------------------------
+# Further negatives on the inputs
+# ----------------------------------------------------------------------
+# The secrets bag itself must be an object — anything else means the caller
+# wired up 'secrets-json' wrong, and resolving every secret to null would be
+# a silent, confusing failure.
+setup
+set_secrets '["not","an","object"]'
+run_step
+assert "negative: a non-object secrets bag is rejected" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the input" \
+  grep -q "input 'secrets-json' must be a JSON object" "${OUT_FILE}"
+
+setup
+set_secrets '{ truncated'
+run_step
+assert "negative: an unparseable secrets bag is rejected" test "${LAST_EXIT}" -ne 0
+
+# A secret NAME must be a string. A number or a boolean there is a config
+# error, not something to look up.
+setup
+export input_extra_envs_from_secrets='{"ARM_TENANT_ID":123}'
+run_step
+assert "negative: a numeric secret name is rejected" test "${LAST_EXIT}" -ne 0
+assert "negative: the error explains what is required" \
+  grep -q 'must be a non-empty string' "${OUT_FILE}"
+
+setup
+export input_extra_envs_from_secrets_per_goal='{"plan":{"ARM_TENANT_ID":null}}'
+run_step
+assert "negative: a null secret name is rejected" test "${LAST_EXIT}" -ne 0
+
+# Several problems at once: every one of them must be reported, not just the
+# first — otherwise fixing a typo turns into one round-trip per typo.
+setup
+export input_extra_envs='{"BAD NAME":"x","OBJ":{"a":1}}'
+export input_extra_envs_per_goal='{"all":{"A":"1"},"plan":{"ALSO BAD":"y"}}'
+run_step
+assert "negative: multiple problems fail the step" test "${LAST_EXIT}" -ne 0
+assert "negative: all four problems are reported together" \
+  bash -c "[ \$(grep -c 'ERROR' '${OUT_FILE}') -ge 5 ]"
+assert "negative: the invalid name is reported" grep -q '"BAD NAME"' "${OUT_FILE}"
+assert "negative: the object value is reported" grep -q '"OBJ"' "${OUT_FILE}"
+assert "negative: the unknown goal is reported" grep -q '"all"' "${OUT_FILE}"
+assert "negative: the per-goal invalid name is reported" grep -q '"ALSO BAD"' "${OUT_FILE}"
+assert "negative: no files are written when validation fails" \
+  bash -c "[ -z '${ENVS_DIR}' ] || [ ! -d '${ENVS_DIR}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}          step_resolve.sh SUMMARY           ${NC}"

--- a/resolve-goal-envs/run_all_tests.sh
+++ b/resolve-goal-envs/run_all_tests.sh
@@ -526,6 +526,62 @@ assert "negative: the per-goal invalid name is reported" grep -q '"ALSO BAD"' "$
 assert "negative: no files are written when validation fails" \
   bash -c "[ -z '${ENVS_DIR}' ] || [ ! -d '${ENVS_DIR}' ]"
 
+# ======================================================================
+# Cross-file contract: the goal vocabulary exists in three places and
+# nothing else asserts they agree.
+#
+#   1. GOAL_KEYS here, which decides what is valid and what files are written
+#   2. GOAL_KEYS in create-tf-vars-matrix, which decides what gets normalized
+#   3. the '<goal>.json' file names in the reusable workflow
+#
+# A goal added to one and forgotten in another is a silent no-op or a hard
+# error at run time on a calling repo. This suite owns the vocabulary, so the
+# check lives here even though it reaches outside the action directory.
+# ======================================================================
+_repo_root="$(cd -- "${_this_script_dir}/.." &>/dev/null && pwd)"
+_matrix_helpers="${_repo_root}/create-tf-vars-matrix/helpers_additional.sh"
+_workflow="${_repo_root}/.github/workflows/terraform-ci-cd-default.yml"
+
+# The GOAL_KEYS array as declared in a given helpers file, sorted.
+declared_goal_keys() {
+  sed -n '/^GOAL_KEYS=(/,/^)/p' "${1}" \
+    | sed '1d;$d' \
+    | tr -d ' ' \
+    | sort \
+    | paste -sd,
+}
+
+assert "contract: this action declares GOAL_KEYS" \
+  test -n "$(declared_goal_keys "${_this_script_dir}/helpers_additional.sh")"
+assert_eq "contract: create-tf-vars-matrix declares the same goals" \
+  "$(declared_goal_keys "${_this_script_dir}/helpers_additional.sh")" \
+  "$(declared_goal_keys "${_matrix_helpers}")"
+
+# The goal file names the workflow asks for, sorted and de-suffixed.
+workflow_goal_files() {
+  grep -o 'envs-dir }}/[a-z-]*\.json' "${_workflow}" \
+    | sed 's|.*/||; s|\.json$||' \
+    | sort -u \
+    | paste -sd,
+}
+
+assert_eq "contract: the workflow references exactly the declared goals" \
+  "$(declared_goal_keys "${_this_script_dir}/helpers_additional.sh")" \
+  "$(workflow_goal_files)"
+
+assert_eq "contract: the workflow wires up all eight goal steps" \
+  '8' "$(grep -c 'extra-envs-file: ${{ steps.goal-envs.outputs.envs-dir }}/' "${_workflow}")"
+
+# Every file the workflow names must actually be produced.
+setup
+run_step
+_all_referenced_present=true
+for _goal in $(workflow_goal_files | tr ',' ' '); do
+  [ -f "${ENVS_DIR}/${_goal}.json" ] || _all_referenced_present=false
+done
+assert "contract: every file the workflow names is produced by this action" \
+  test "${_all_referenced_present}" = 'true'
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}          step_resolve.sh SUMMARY           ${NC}"

--- a/resolve-goal-envs/run_all_tests.sh
+++ b/resolve-goal-envs/run_all_tests.sh
@@ -582,6 +582,26 @@ done
 assert "contract: every file the workflow names is produced by this action" \
   test "${_all_referenced_present}" = 'true'
 
+# apply-extra-envs is duplicated verbatim into the six goal actions rather than
+# shared (docs/Per-goal-environment-variables.md §9.6, consistent with
+# helpers.sh). The copies are only useful if they stay identical, so that is
+# asserted rather than trusted.
+_goal_actions=(terraform-init terraform-validate terraform-plan terraform-fmt lint-with-tflint terraform-apply)
+
+# The apply-extra-envs function body from one action's helpers_additional.sh.
+extract_apply_extra_envs() {
+  sed -n '/^# Apply a JSON environment-variable map/,/^}$/p' \
+    "${_repo_root}/${1}/helpers_additional.sh"
+}
+
+_reference="$(extract_apply_extra_envs "${_goal_actions[0]}")"
+assert "contract: the reference copy of apply-extra-envs is non-empty" \
+  test -n "${_reference}"
+for _action in "${_goal_actions[@]:1}"; do
+  assert "contract: ${_action}'s copy of apply-extra-envs is byte-identical" \
+    bash -c "diff <(printf '%s' \"\$(sed -n '/^# Apply a JSON environment-variable map/,/^}\$/p' '${_repo_root}/${_goal_actions[0]}/helpers_additional.sh')\") <(printf '%s' \"\$(sed -n '/^# Apply a JSON environment-variable map/,/^}\$/p' '${_repo_root}/${_action}/helpers_additional.sh')\") >/dev/null"
+done
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}          step_resolve.sh SUMMARY           ${NC}"

--- a/resolve-goal-envs/run_all_tests.sh
+++ b/resolve-goal-envs/run_all_tests.sh
@@ -1,0 +1,475 @@
+#!/bin/env bash
+#
+# Tests for step_resolve.sh
+#
+# Covers the resolution algorithm, the precedence rules, the validation
+# rejections, the file/directory permissions, and the log-hygiene claim that no
+# secret value ever reaches stdout or stderr.
+#
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10
+# (T1-T16).
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+OUT_FILE=/tmp/test_output_resolve.txt
+
+GOALS=(init format validate lint plan apply destroy-plan destroy)
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+# Fresh environment. All four maps default to '{}' and the secrets bag to a
+# small fixture; individual tests override what they exercise.
+setup() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}/workspace"
+  mkdir -p "${GITHUB_WORKSPACE}"
+
+  export input_extra_envs='{}'
+  export input_extra_envs_from_secrets='{}'
+  export input_extra_envs_per_goal='{}'
+  export input_extra_envs_from_secrets_per_goal='{}'
+
+  set_secrets '{
+    "AZURE_TENANT_ID": "tenant-value",
+    "AZURE_PLAN_READER_CLIENT_ID": "reader-value",
+    "AZURE_APPLY_CONTRIBUTOR_CLIENT_ID": "contributor-value",
+    "MULTILINE_SECRET": "-----BEGIN RSA PRIVATE KEY-----\nline-two-of-the-key\n-----END RSA PRIVATE KEY-----\n",
+    "EMPTY_SECRET": ""
+  }'
+}
+
+# Write the secrets bag the way the action.yml shim does: to a file, exporting
+# only the path.
+set_secrets() {
+  export input_secrets_file="$(mktemp "${RUNNER_TEMP}/secrets-bag-XXXXXXXX.json")"
+  chmod 0600 "${input_secrets_file}"
+  printf '%s' "${1}" >"${input_secrets_file}"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_resolve.sh"
+  ) >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+  ENVS_DIR="$(grep '^envs-dir=' "${GITHUB_OUTPUT}" | head -n1 | cut -d= -f2-)"
+}
+
+# jq query against one goal's resolved file.
+goal_query() {
+  local goal="${1}" filter="${2}"
+  jq -c "${filter}" "${ENVS_DIR}/${goal}.json"
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# assert_eq <name> <expected> <actual>
+assert_eq() {
+  local name="${1}" expected="${2}" actual="${3}"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if [[ "${expected}" == "${actual}" ]]; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}: expected '${expected}', got '${actual}'"
+    echo "--- step output ---"
+    cat "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}        RESOLVE-GOAL-ENVS STEP TESTS        ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# T1 — all inputs '{}' → eight files, each '{}'
+# ----------------------------------------------------------------------
+setup
+run_step
+assert "T1: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T1: envs-dir output is published" test -n "${ENVS_DIR}"
+assert "T1: envs-dir exists" test -d "${ENVS_DIR}"
+assert_eq "T1: exactly eight files produced" \
+  '8' "$(find "${ENVS_DIR}" -maxdepth 1 -name '*.json' | wc -l)"
+all_empty=true
+for goal in "${GOALS[@]}"; do
+  [ -f "${ENVS_DIR}/${goal}.json" ] || all_empty=false
+  [ "$(goal_query "${goal}" '.')" = '{}' ] || all_empty=false
+done
+assert "T1: one file per goal, each an empty object" test "${all_empty}" = 'true'
+
+# ----------------------------------------------------------------------
+# T15 — directory is 0700, files are 0600
+# ----------------------------------------------------------------------
+assert_eq "T15: envs-dir mode is 0700" \
+  '700' "$(stat -c '%a' "${ENVS_DIR}")"
+assert_eq "T15: every resolved file is mode 0600" \
+  '' "$(find "${ENVS_DIR}" -maxdepth 1 -name '*.json' ! -perm 600 -printf '%f ')"
+
+# The resolved files must not sit in the workspace: artifact globs,
+# 'terraform fmt -recursive' and stray 'git add' all live there.
+assert "T15: envs-dir is outside GITHUB_WORKSPACE" \
+  bash -c "[[ '${ENVS_DIR}' != '${GITHUB_WORKSPACE}'* ]]"
+assert "T15: envs-dir is under RUNNER_TEMP" \
+  bash -c "[[ '${ENVS_DIR}' == '${RUNNER_TEMP}'* ]]"
+
+# The scratch copy of the secrets bag, and the bag the shim wrote, are gone.
+assert "cleanup: the secrets file is removed on exit" \
+  bash -c "[ ! -f '${input_secrets_file}' ]"
+assert_eq "cleanup: no scratch work directory is left behind" \
+  '' "$(find "${RUNNER_TEMP}" -maxdepth 1 -name 'resolve-goal-envs-work-*' -printf '%f ')"
+
+# ----------------------------------------------------------------------
+# T2 — global plain only → identical content in all eight files
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"GOGC":50,"GOMEMLIMIT":"6GiB","ARM_USE_OIDC":true}'
+run_step
+assert "T2: step exits 0" test "${LAST_EXIT}" -eq 0
+identical=true
+for goal in "${GOALS[@]}"; do
+  [ "$(goal_query "${goal}" '. | to_entries | sort_by(.key) | from_entries')" \
+    = '{"ARM_USE_OIDC":true,"GOGC":50,"GOMEMLIMIT":"6GiB"}' ] || identical=false
+done
+assert "T2: all eight goals get the same global values" test "${identical}" = 'true'
+assert_eq "T2: a JSON number stays a number" \
+  '"number"' "$(goal_query plan '.GOGC | type')"
+assert_eq "T2: a JSON boolean stays a boolean" \
+  '"boolean"' "$(goal_query plan '.ARM_USE_OIDC | type')"
+
+# ----------------------------------------------------------------------
+# T3 — per-goal override of one key
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"GOGC":50,"GOMEMLIMIT":"6GiB"}'
+export input_extra_envs_per_goal='{"plan":{"GOMEMLIMIT":"12GiB"}}'
+run_step
+assert "T3: step exits 0" test "${LAST_EXIT}" -eq 0
+assert_eq "T3: the goal sees the override" \
+  '"12GiB"' "$(goal_query plan '.GOMEMLIMIT')"
+assert_eq "T3: the goal keeps the global value of other keys" \
+  '50' "$(goal_query plan '.GOGC')"
+others_untouched=true
+for goal in init format validate lint apply destroy-plan destroy; do
+  [ "$(goal_query "${goal}" '.GOMEMLIMIT')" = '"6GiB"' ] || others_untouched=false
+done
+assert "T3: the other seven goals are untouched" test "${others_untouched}" = 'true'
+
+# ----------------------------------------------------------------------
+# T4 — per-goal null → JSON null present for that goal only
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"GOMEMLIMIT":"6GiB"}'
+export input_extra_envs_per_goal='{"apply":{"GOMEMLIMIT":null}}'
+run_step
+assert "T4: step exits 0" test "${LAST_EXIT}" -eq 0
+assert_eq "T4: the key is present for the goal" \
+  'true' "$(goal_query apply 'has("GOMEMLIMIT")')"
+assert_eq "T4: its value is JSON null (an unset instruction)" \
+  'null' "$(goal_query apply '.GOMEMLIMIT')"
+assert_eq "T4: other goals keep the value" \
+  '"6GiB"' "$(goal_query plan '.GOMEMLIMIT')"
+
+# ----------------------------------------------------------------------
+# T5 — secret resolution maps to the secret's VALUE, not its name
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs_from_secrets='{"ARM_TENANT_ID":"AZURE_TENANT_ID"}'
+run_step
+assert "T5: step exits 0" test "${LAST_EXIT}" -eq 0
+assert_eq "T5: the environment variable holds the secret's value" \
+  '"tenant-value"' "$(goal_query plan '.ARM_TENANT_ID')"
+assert_eq "T5: the secret's NAME does not appear as a value" \
+  'false' "$(goal_query plan '[.[] | tostring] | any(. == "AZURE_TENANT_ID")')"
+
+# ----------------------------------------------------------------------
+# T6/T7/T8 — precedence, one key present in all four inputs
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"KEY":"1-global-plain"}'
+export input_extra_envs_from_secrets='{"KEY":"AZURE_TENANT_ID"}'
+export input_extra_envs_per_goal='{"plan":{"KEY":"3-per-goal-plain"},"lint":{"OTHER":"x"}}'
+export input_extra_envs_from_secrets_per_goal='{"apply":{"KEY":"AZURE_APPLY_CONTRIBUTOR_CLIENT_ID"}}'
+run_step
+assert "T6: step exits 0" test "${LAST_EXIT}" -eq 0
+assert_eq "T6: per-goal secret wins over everything (4 beats 3)" \
+  '"contributor-value"' "$(goal_query apply '.KEY')"
+assert_eq "T7: per-goal plain beats the global secret (3 beats 2)" \
+  '"3-per-goal-plain"' "$(goal_query plan '.KEY')"
+assert_eq "T8: global secret beats global plain (2 beats 1)" \
+  '"tenant-value"' "$(goal_query lint '.KEY')"
+assert_eq "T8: goals with no per-goal entry resolve the same way" \
+  '"tenant-value"' "$(goal_query init '.KEY')"
+
+# ----------------------------------------------------------------------
+# T9 — unknown goal keys are hard errors
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs_per_goal='{"all":{"GOGC":50}}'
+run_step
+assert "T9: 'all' is rejected" test "${LAST_EXIT}" -ne 0
+assert "T9: the error names the offending key" \
+  grep -q '"all" is not a valid goal' "${OUT_FILE}"
+assert "T9: the error lists the valid goals" \
+  grep -q 'init, format, validate, lint, plan, apply, destroy-plan, destroy' "${OUT_FILE}"
+
+setup
+export input_extra_envs_per_goal='{"fmt":{"GOGC":50}}'
+run_step
+assert "T9: 'fmt' is rejected (the goal is named 'format')" test "${LAST_EXIT}" -ne 0
+assert "T9: the error names 'fmt'" \
+  grep -q '"fmt" is not a valid goal' "${OUT_FILE}"
+
+setup
+export input_extra_envs_from_secrets_per_goal='{"typo":{"A":"AZURE_TENANT_ID"}}'
+run_step
+assert "T9: unknown goal in the secrets map is rejected too" test "${LAST_EXIT}" -ne 0
+
+# ----------------------------------------------------------------------
+# T10 — a secret name absent from the bag is a hard error
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs_from_secrets='{"ARM_TENANT_ID":"NO_SUCH_SECRET"}'
+run_step
+assert "T10: missing global secret is rejected" test "${LAST_EXIT}" -ne 0
+assert "T10: the error names the secret and the variable" \
+  grep -q 'secret "NO_SUCH_SECRET", mapped to environment variable "ARM_TENANT_ID"' "${OUT_FILE}"
+
+setup
+export input_extra_envs_from_secrets_per_goal='{"apply":{"ARM_CLIENT_ID":"NO_SUCH_SECRET"}}'
+run_step
+assert "T10: missing per-goal secret is rejected" test "${LAST_EXIT}" -ne 0
+assert "T10: the error names the goal it came from" \
+  grep -q 'extra-envs-from-secrets-per-goal.apply' "${OUT_FILE}"
+
+# A secret that exists but is empty is legitimate — it resolves to "".
+setup
+export input_extra_envs_from_secrets='{"MAYBE_EMPTY":"EMPTY_SECRET"}'
+run_step
+assert "T10: an existing but empty secret is accepted" test "${LAST_EXIT}" -eq 0
+assert_eq "T10: it resolves to the empty string" \
+  '""' "$(goal_query plan '.MAYBE_EMPTY')"
+
+# ----------------------------------------------------------------------
+# T11 — action-managed variable names are accepted (no reserved-name list)
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"TF_IN_AUTOMATION":"false","TF_PLUGIN_CACHE_DIR":"/tmp/cache"}'
+export input_extra_envs_per_goal='{"init":{"TF_PLUGIN_CACHE_DIR":"/tmp/init-cache"}}'
+run_step
+assert "T11: step exits 0 — nothing is reserved" test "${LAST_EXIT}" -eq 0
+assert_eq "T11: TF_IN_AUTOMATION is written through" \
+  '"false"' "$(goal_query plan '.TF_IN_AUTOMATION')"
+assert_eq "T11: TF_PLUGIN_CACHE_DIR is written through per goal" \
+  '"/tmp/init-cache"' "$(goal_query init '.TF_PLUGIN_CACHE_DIR')"
+
+# ----------------------------------------------------------------------
+# T12 — invalid environment variable names are hard errors
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"FOO BAR":"1"}'
+run_step
+assert "T12: a name with a space is rejected" test "${LAST_EXIT}" -ne 0
+assert "T12: the error names it" \
+  grep -q '"FOO BAR" is not a valid environment variable name' "${OUT_FILE}"
+
+setup
+export input_extra_envs='{"FOO=BAR":"1"}'
+run_step
+assert "T12: a name with '=' is rejected" test "${LAST_EXIT}" -ne 0
+
+setup
+export input_extra_envs='{"1STARTS_WITH_DIGIT":"1"}'
+run_step
+assert "T12: a name starting with a digit is rejected" test "${LAST_EXIT}" -ne 0
+
+setup
+export input_extra_envs_per_goal='{"plan":{"BAD-NAME":"1"}}'
+run_step
+assert "T12: a bad name inside a per-goal map is rejected" test "${LAST_EXIT}" -ne 0
+assert "T12: the error says which goal" \
+  grep -q 'extra-envs-per-goal.plan' "${OUT_FILE}"
+
+setup
+export input_extra_envs='{"_LEADING_UNDERSCORE":"ok","MiXeD_case_9":"ok"}'
+run_step
+assert "T12: legal names are accepted" test "${LAST_EXIT}" -eq 0
+
+# ----------------------------------------------------------------------
+# T13 — object/array values are config errors, not values
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='{"NESTED":{"a":1}}'
+run_step
+assert "T13: an object value is rejected" test "${LAST_EXIT}" -ne 0
+assert "T13: the error names the type" \
+  grep -q 'is of type object' "${OUT_FILE}"
+
+setup
+export input_extra_envs_per_goal='{"plan":{"LIST":[1,2]}}'
+run_step
+assert "T13: an array value is rejected" test "${LAST_EXIT}" -ne 0
+
+setup
+export input_extra_envs_per_goal='{"plan":"not-a-map"}'
+run_step
+assert "T13: a non-object goal value is rejected" test "${LAST_EXIT}" -ne 0
+assert "T13: the error explains what was expected" \
+  grep -q 'must be a mapping of environment variables' "${OUT_FILE}"
+
+setup
+export input_extra_envs='["not","an","object"]'
+run_step
+assert "T13: a non-object input is rejected" test "${LAST_EXIT}" -ne 0
+assert "T13: the error names the input" \
+  grep -q "input 'extra-envs' must be a JSON object" "${OUT_FILE}"
+
+setup
+export input_extra_envs='{ this is not json'
+run_step
+assert "T13: unparseable input is rejected" test "${LAST_EXIT}" -ne 0
+assert "T13: the error says it is not valid JSON" \
+  grep -q "input 'extra-envs' is not valid JSON" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Empty / absent inputs are legitimate: 'toJSON(...)' renders 'null' for a
+# matrix key that does not exist, and an unset input arrives as ''.
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs='null'
+export input_extra_envs_from_secrets=''
+export input_extra_envs_per_goal='   '
+unset input_extra_envs_from_secrets_per_goal
+run_step
+assert "empty inputs: step exits 0" test "${LAST_EXIT}" -eq 0
+all_empty=true
+for goal in "${GOALS[@]}"; do
+  [ "$(goal_query "${goal}" '.')" = '{}' ] || all_empty=false
+done
+assert "empty inputs: every goal file is an empty object" test "${all_empty}" = 'true'
+
+# ----------------------------------------------------------------------
+# T14 — a multiline secret value survives byte-identically
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs_from_secrets='{"APP_PRIVATE_KEY":"MULTILINE_SECRET"}'
+run_step
+assert "T14: step exits 0" test "${LAST_EXIT}" -eq 0
+assert_eq "T14: the multiline value round-trips exactly" \
+  '"-----BEGIN RSA PRIVATE KEY-----\nline-two-of-the-key\n-----END RSA PRIVATE KEY-----\n"' \
+  "$(goal_query plan '.APP_PRIVATE_KEY')"
+
+# Shell-hostile characters survive too.
+setup
+set_secrets '{"WEIRD":"a $HOME `id` \"quoted\" * value"}'
+export input_extra_envs_from_secrets='{"WEIRD_VALUE":"WEIRD"}'
+export input_extra_envs='{"WEIRD_PLAIN":"b $HOME `id` * value"}'
+run_step
+assert "T14: step exits 0 with shell metacharacters in values" test "${LAST_EXIT}" -eq 0
+assert_eq "T14: a secret value with shell metacharacters is intact" \
+  'a $HOME `id` "quoted" * value' "$(jq -r '.WEIRD_VALUE' "${ENVS_DIR}/plan.json")"
+assert_eq "T14: a plain value with shell metacharacters is intact" \
+  'b $HOME `id` * value' "$(jq -r '.WEIRD_PLAIN' "${ENVS_DIR}/plan.json")"
+
+# ----------------------------------------------------------------------
+# T16 — no secret value appears in captured stdout/stderr
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs_from_secrets='{"ARM_TENANT_ID":"AZURE_TENANT_ID","APP_PRIVATE_KEY":"MULTILINE_SECRET"}'
+export input_extra_envs_from_secrets_per_goal='{"apply":{"ARM_CLIENT_ID":"AZURE_APPLY_CONTRIBUTOR_CLIENT_ID"}}'
+run_step
+assert "T16: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T16: no secret value is logged" \
+  bash -c "! grep -qE 'tenant-value|contributor-value|line-two-of-the-key' '${OUT_FILE}'"
+assert "T16: the keys ARE logged (so the log is still useful)" \
+  grep -q 'ARM_TENANT_ID' "${OUT_FILE}"
+assert "T16: the log still reports how many variables each goal got" \
+  grep -q "goal 'apply': 3 environment variable(s):" "${OUT_FILE}"
+
+setup
+export input_extra_envs='{"PLAIN_ONE":"plain-value-should-not-be-logged"}'
+run_step
+assert "T16: plain values are not logged either" \
+  bash -c "! grep -q 'plain-value-should-not-be-logged' '${OUT_FILE}'"
+
+# ----------------------------------------------------------------------
+# Missing secrets file — the shim always writes one, so its absence is a bug
+# worth failing on rather than resolving everything to null.
+# ----------------------------------------------------------------------
+setup
+export input_secrets_file="${RUNNER_TEMP}/does-not-exist.json"
+run_step
+assert "secrets file: absence is a hard error" test "${LAST_EXIT}" -ne 0
+assert "secrets file: the error names the path" \
+  grep -q 'does-not-exist.json' "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Every goal file always exists, even when only one goal is configured —
+# the workflow references all eight paths unconditionally.
+# ----------------------------------------------------------------------
+setup
+export input_extra_envs_per_goal='{"plan":{"GOGC":25}}'
+run_step
+all_present=true
+for goal in "${GOALS[@]}"; do
+  [ -f "${ENVS_DIR}/${goal}.json" ] || all_present=false
+done
+assert "coverage: all eight files exist when one goal is configured" \
+  test "${all_present}" = 'true'
+assert_eq "coverage: unconfigured goals are empty objects" \
+  '{}' "$(goal_query destroy '.')"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}          step_resolve.sh SUMMARY           ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/resolve-goal-envs/run_local_step_resolve.sh
+++ b/resolve-goal-envs/run_local_step_resolve.sh
@@ -1,0 +1,84 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_resolve.sh.
+# Simulates GitHub Actions environment.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}/workspace"
+mkdir -p "${GITHUB_WORKSPACE}"
+
+# The shim writes toJSON(secrets) to a file before allexport and exports only
+# the path — mirror that here.
+export input_secrets_file="$(mktemp "${RUNNER_TEMP}/secrets-bag-XXXXXXXX.json")"
+chmod 0600 "${input_secrets_file}"
+cat >"${input_secrets_file}" <<'EOF'
+{
+  "AZURE_TENANT_ID": "11111111-1111-1111-1111-111111111111",
+  "AZURE_PLAN_READER_CLIENT_ID": "22222222-2222-2222-2222-222222222222",
+  "AZURE_APPLY_CONTRIBUTOR_CLIENT_ID": "33333333-3333-3333-3333-333333333333",
+  "TF_CICD_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\nnot-a-real-key\n-----END RSA PRIVATE KEY-----\n"
+}
+EOF
+
+export input_extra_envs='{
+  "ARM_USE_OIDC": true,
+  "GOGC": 50,
+  "GOMEMLIMIT": "6GiB"
+}'
+
+export input_extra_envs_from_secrets='{
+  "ARM_TENANT_ID": "AZURE_TENANT_ID",
+  "ARM_CLIENT_ID": "AZURE_PLAN_READER_CLIENT_ID"
+}'
+
+export input_extra_envs_per_goal='{
+  "init": {},
+  "format": {},
+  "validate": {},
+  "lint": { "GOGC": 400 },
+  "plan": { "GOMEMLIMIT": "12GiB", "GOGC": 25 },
+  "apply": { "GOMEMLIMIT": null },
+  "destroy-plan": {},
+  "destroy": {}
+}'
+
+export input_extra_envs_from_secrets_per_goal='{
+  "init": {},
+  "format": {},
+  "validate": {},
+  "lint": {},
+  "plan": {},
+  "apply": { "ARM_CLIENT_ID": "AZURE_APPLY_CONTRIBUTOR_CLIENT_ID" },
+  "destroy-plan": {},
+  "destroy": {}
+}'
+
+# Subshell: step_resolve.sh ends in 'exit', which would otherwise terminate
+# this script before it gets to show what was produced.
+( source "${_this_script_dir}/step_resolve.sh" )
+echo ""
+echo "step exit code: ${?}"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"
+
+envs_dir=$(grep '^envs-dir=' "${GITHUB_OUTPUT}" | cut -d= -f2-)
+echo ""
+echo "========================================"
+echo "Resolved files in ${envs_dir}"
+echo "========================================"
+ls -l "${envs_dir}"
+for f in "${envs_dir}"/*.json; do
+  echo ""
+  echo "--- $(basename "${f}")"
+  cat "${f}"
+  echo ""
+done

--- a/resolve-goal-envs/step_resolve.sh
+++ b/resolve-goal-envs/step_resolve.sh
@@ -1,0 +1,130 @@
+#!/bin/env bash
+#
+# Source for the resolve-goal-envs main step.
+#
+# Resolves the effective set of environment variables for every terraform goal
+# and writes one JSON file per goal into a private directory under
+# $RUNNER_TEMP. What crosses from here into the goal actions is that
+# directory's path — never a payload — so secret values stay out of argv, out
+# of envp, and out of the goal steps' interpolated run-block script text.
+#
+# This is the only action besides export-env-vars that receives the secrets
+# bag, and the only place per-goal values are merged or validated.
+#
+# Outputs:
+#   envs-dir - Path of a 0700 directory containing one 0600 '<goal>.json' file
+#              per goal. Every file always exists, containing at minimum '{}'.
+#
+# Required environment variables:
+#   input_secrets_file                    - Path of a file holding
+#                                           toJSON(secrets). Written by the
+#                                           action.yml shim before allexport,
+#                                           see §8 of the design doc.
+#
+# Optional environment variables:
+#   input_extra_envs                      - JSON object, global plain values.
+#   input_extra_envs_from_secrets         - JSON object, global secret names.
+#   input_extra_envs_per_goal             - JSON object of objects, by goal.
+#   input_extra_envs_from_secrets_per_goal - JSON object of objects, by goal.
+#
+
+set +o nounset
+
+# Load helpers (provides GOAL_KEYS, normalize-json-object-file,
+# find-input-errors and resolve-goal-envs-file via helpers_additional.sh)
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+# Scratch directory holding the inputs plus a copy of the secrets bag. Removed
+# on exit, including on the validation-failure paths — composite actions cannot
+# declare 'post:' steps, so cleanup has to be explicit.
+_WORK_DIR=""
+
+function _cleanup {
+  [ -n "${_WORK_DIR}" ] && [ -d "${_WORK_DIR}" ] && rm -rf "${_WORK_DIR}"
+  [ -n "${input_secrets_file}" ] && [ -f "${input_secrets_file}" ] && rm -f "${input_secrets_file}"
+  return 0
+}
+trap _cleanup EXIT
+
+function main {
+  if [ -z "${input_secrets_file}" ] || [ ! -f "${input_secrets_file}" ]; then
+    log-error "the secrets file '${input_secrets_file}' does not exist!"
+    return 1
+  fi
+
+  _WORK_DIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/resolve-goal-envs-work-XXXXXXXX")
+  chmod 0700 "${_WORK_DIR}"
+
+  # printf is a builtin, so the input values never reach an execve's argv.
+  printf '%s' "${input_extra_envs}" >"${_WORK_DIR}/global-plain.json"
+  printf '%s' "${input_extra_envs_from_secrets}" >"${_WORK_DIR}/global-secrets.json"
+  printf '%s' "${input_extra_envs_per_goal}" >"${_WORK_DIR}/per-goal-plain.json"
+  printf '%s' "${input_extra_envs_from_secrets_per_goal}" >"${_WORK_DIR}/per-goal-secrets.json"
+  cp "${input_secrets_file}" "${_WORK_DIR}/secrets.json"
+  chmod 0600 "${_WORK_DIR}"/*.json
+
+  start-group "validating inputs"
+  normalize-json-object-file "${_WORK_DIR}/global-plain.json" 'extra-envs' || { end-group; return 1; }
+  normalize-json-object-file "${_WORK_DIR}/global-secrets.json" 'extra-envs-from-secrets' || { end-group; return 1; }
+  normalize-json-object-file "${_WORK_DIR}/per-goal-plain.json" 'extra-envs-per-goal' || { end-group; return 1; }
+  normalize-json-object-file "${_WORK_DIR}/per-goal-secrets.json" 'extra-envs-from-secrets-per-goal' || { end-group; return 1; }
+  normalize-json-object-file "${_WORK_DIR}/secrets.json" 'secrets-json' || { end-group; return 1; }
+
+  # One line per problem. Collected in a file rather than a variable so no
+  # amount of input can push this into envp. The exit code is checked
+  # separately from the file being non-empty: a jq failure here would
+  # otherwise read as "no problems found" and let bad input through.
+  if ! find-input-errors "${_WORK_DIR}" >"${_WORK_DIR}/errors.txt"; then
+    log-error "failed to validate the per-goal environment variable inputs!"
+    end-group
+    return 1
+  fi
+  if [ -s "${_WORK_DIR}/errors.txt" ]; then
+    while IFS= read -r error_line; do
+      log-error "${error_line}"
+    done <"${_WORK_DIR}/errors.txt"
+    log-error "input validation failed, refusing to resolve per-goal environment variables."
+    end-group
+    return 1
+  fi
+  log-info "[OK] inputs are valid."
+  end-group
+
+  # $RUNNER_TEMP rather than $GITHUB_WORKSPACE: keeps the resolved values out
+  # of actions/upload-artifact globs, out of 'terraform fmt -recursive'
+  # traversal, and out of anything that could commit them.
+  local envs_dir
+  envs_dir=$(mktemp -d "${RUNNER_TEMP:-/tmp}/resolved-goal-envs-XXXXXXXX")
+  chmod 0700 "${envs_dir}"
+
+  start-group "resolving per-goal environment variables"
+  local goal out_file
+  for goal in "${GOAL_KEYS[@]}"; do
+    out_file="${envs_dir}/${goal}.json"
+
+    # Create restricted before writing, so the values are never briefly
+    # world-readable.
+    : >"${out_file}"
+    chmod 0600 "${out_file}"
+
+    if ! resolve-goal-envs-file "${_WORK_DIR}" "${goal}" "${out_file}"; then
+      log-error "failed to resolve environment variables for goal '${goal}'!"
+      end-group
+      return 1
+    fi
+
+    # Keys only, never values — a single map may mix plain and secret-sourced
+    # entries, so the safe default is to log no values at all.
+    log-info "goal '${goal}': $(jq -r 'if length == 0 then "no environment variables" else "\(length) environment variable(s): " + ([keys[]] | join(", ")) end' "${out_file}")"
+  done
+  end-group
+
+  log-info "resolved environment files written to '${envs_dir}'"
+  set-output 'envs-dir' "${envs_dir}"
+
+  return 0
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/terraform-apply/action.yml
+++ b/terraform-apply/action.yml
@@ -40,17 +40,10 @@ runs:
         end-group
     - id: apply
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         TF_IN_AUTOMATION: "true"
+        input_working_directory: ${{ inputs.working-directory }}
+        input_terraform_plan_file: ${{ inputs.terraform-plan-file }}
       run: |
-        # run terraform apply of a given plan
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        APPLY_CMD="terraform apply -input=false -auto-approve ${{ inputs.terraform-plan-file }}"
-        log-info "apply command string is '${APPLY_CMD}'"
-        start-group "'terraform apply' in '$(ws-path $(pwd))'"
-        ${APPLY_CMD}
-        echo '' # avoid control characters left behind by apply, messes up the end-group cmd
-        end-group
+        set -o allexport
+        source "${{ github.action_path }}/step_apply.sh"

--- a/terraform-apply/action.yml
+++ b/terraform-apply/action.yml
@@ -9,6 +9,22 @@ inputs:
   terraform-plan-file:
     description: Path of terraform plan output file to apply.
     required: true
+  extra-envs-file:
+    description: |
+      Path to a JSON file with environment variables to apply to this action's
+      invocations only, as produced by the 'resolve-goal-envs' action. A JSON
+      null value unsets the variable rather than setting it to the empty
+      string.
+
+      A path rather than a payload so that the values — which may be secrets —
+      never enter argv, envp, or this step's script text.
+
+      The values are applied before this action's own exports, so an action-managed
+      variable set by the step script at runtime (e.g. TF_PLUGIN_CACHE_DIR) wins,
+      while one set in the step's env: block (e.g. TF_IN_AUTOMATION) is overridden
+      by the caller. See docs/Per-goal-environment-variables.md §6.3.
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -44,6 +60,7 @@ runs:
         TF_IN_AUTOMATION: "true"
         input_working_directory: ${{ inputs.working-directory }}
         input_terraform_plan_file: ${{ inputs.terraform-plan-file }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         set -o allexport
         source "${{ github.action_path }}/step_apply.sh"

--- a/terraform-apply/extract_step_source.py
+++ b/terraform-apply/extract_step_source.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Extract one step's `run:` block from action.yml into a runnable script.
+
+Used by run_all_tests.sh so the tests exercise the action's real inline bash
+rather than a copy of it. GitHub Actions expressions are substituted with
+literal text (no shell escaping involved, unlike a sed-based approach — the
+inputs are JSON blobs full of quotes and slashes).
+
+Usage:
+  extract_step_source.py <action.yml> <step-id> <out-file> [KEY=path-or-value ...]
+
+Each trailing argument replaces one expression:
+  inputs.inputs-json=@/path/to/file    -> contents of the file
+  github.ref_name=main                 -> the literal value
+"""
+
+import sys
+import yaml
+
+
+def main() -> int:
+    action_file, step_id, out_file = sys.argv[1:4]
+    substitutions = sys.argv[4:]
+
+    with open(action_file, encoding="utf-8") as handle:
+        action = yaml.safe_load(handle)
+
+    steps = action["runs"]["steps"]
+    matches = [step for step in steps if step.get("id") == step_id]
+    if not matches:
+        available = ", ".join(str(step.get("id")) for step in steps)
+        print(f"no step with id '{step_id}' (have: {available})", file=sys.stderr)
+        return 1
+
+    source = matches[0]["run"]
+
+    for substitution in substitutions:
+        key, _, value = substitution.partition("=")
+        if value.startswith("@"):
+            with open(value[1:], encoding="utf-8") as handle:
+                value = handle.read()
+        # Both spacing variants occur in this repo's action definitions.
+        for expression in (f"${{{{ {key} }}}}", f"${{{{{key}}}}}"):
+            source = source.replace(expression, value)
+
+    with open(out_file, "w", encoding="utf-8") as handle:
+        handle.write("#!/bin/env bash\n")
+        handle.write(source)
+        if not source.endswith("\n"):
+            handle.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terraform-apply/helpers_additional.sh
+++ b/terraform-apply/helpers_additional.sh
@@ -1,49 +1,8 @@
 #!/bin/env bash
 #
-# Action-specific helpers for terraform-plan.
+# Action-specific helpers for terraform-apply.
 # Auto-loaded by helpers.sh.
 #
-
-# Format an integer seconds count as 'mm:ss'.
-# Minutes are zero-padded only to width 1 (so '0:07', '1:23'); seconds are
-# always zero-padded to width 2. Minutes may exceed 99 — CI plans rarely
-# do, but the format degrades gracefully (e.g. '120:05'). No hours field
-# on purpose: keeps the renderer trivial and the display unambiguous.
-function format-duration-mmss {
-  local total="${1:-0}"
-  local minutes=$((total / 60))
-  local seconds=$((total % 60))
-  printf '%d:%02d' "${minutes}" "${seconds}"
-}
-
-# Split a whitespace-delimited argument string into the array named by $1.
-#
-#   $1 - name of the array variable to populate
-#   $2 - the argument string (may be empty, may contain newlines)
-#
-# The 'extra-global-args' / 'extra-plan-args' inputs are documented as strings
-# of arguments the caller injects verbatim, so splitting on whitespace is their
-# contract and is preserved here. What changes is everything around it: the
-# command used to be assembled into one string and then re-split by the shell
-# at invocation time, which also glob-expanded every element against the
-# working directory and turned an empty input into an empty argv element in
-# some shells. Splitting once, here, and invoking as "${cmd[@]}" keeps the
-# caller's words intact while the paths the action itself builds are never
-# split or expanded.
-#
-# Note: quoting inside the argument string is NOT shell-parsed —
-# '-var=msg=a b' is two arguments, not one. Honoring quotes would mean 'eval'
-# or 'xargs', both of which change behaviour for existing callers (an
-# unbalanced apostrophe currently passes through fine and would start failing).
-function split-args-to-array {
-  local -n _args_out="${1}"
-  # Newlines and tabs are whitespace for this purpose too; 'read' without -d
-  # would otherwise stop at the first newline and silently drop the rest.
-  local _str="${2//[$'\n\t']/ }"
-
-  _args_out=()
-  read -r -a _args_out <<<"${_str}"
-}
 
 # Apply a JSON environment-variable map to the current shell
 # ==========================================================

--- a/terraform-apply/helpers_additional.sh
+++ b/terraform-apply/helpers_additional.sh
@@ -58,6 +58,18 @@ function apply-extra-envs {
     return 1
   fi
 
+  # How many entries must end up applied. 'length' works on any jq, which is
+  # the point: it is the cross-check that catches a jq too old for
+  # --raw-output0 (ref. docs/Per-goal-environment-variables.md §9.2). Without
+  # it, such a jq makes the read loop consume nothing and the step continues
+  # having applied nothing — silently, and only on the runner images where it
+  # happens to be old.
+  local _extra_envs_expected _extra_envs_applied=0
+  if ! _extra_envs_expected=$(jq -r 'length' "${_extra_envs_file}"); then
+    log-error "unable to count the entries in '${_extra_envs_file}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
     # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
@@ -85,7 +97,15 @@ function apply-extra-envs {
         return 1
       fi
     fi
+    _extra_envs_applied=$((_extra_envs_applied + 1))
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+
+  if [ ! "${_extra_envs_applied}" == "${_extra_envs_expected}" ]; then
+    log-error "applied ${_extra_envs_applied} of ${_extra_envs_expected} environment variable(s) from '${_extra_envs_file}'!"
+    log-error "this usually means jq is older than 1.7 and does not support '--raw-output0' — check the runner image."
+    end-group
+    return 1
+  fi
   end-group
 
   return 0

--- a/terraform-apply/helpers_additional.sh
+++ b/terraform-apply/helpers_additional.sh
@@ -32,7 +32,7 @@ _EXTRA_ENVS_UNSET='__DSB_UNSET__'
 _EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
 
 function apply-extra-envs {
-  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value _extra_envs_type
 
   if [ -z "${_extra_envs_file}" ]; then
     log-info "no per-goal environment variables file configured."
@@ -43,14 +43,47 @@ function apply-extra-envs {
     return 1
   fi
 
+  # Validated before anything is applied. Without this an unparseable, empty or
+  # truncated file applies nothing at all and the step carries on as if it had —
+  # the consequence then surfaces as an OOM or a wrong-credentials error far
+  # from its cause, which is the failure mode this whole feature exists to
+  # avoid. resolve-goal-envs already guarantees a JSON object; this is the last
+  # line of defence, and cheap.
+  if ! _extra_envs_type=$(jq -r 'type' "${_extra_envs_file}" 2>/dev/null); then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' is not valid JSON!"
+    return 1
+  fi
+  if [ ! "${_extra_envs_type}" == 'object' ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' must hold a JSON object, got '${_extra_envs_type:-nothing}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
+    # and the value 'x' it happily assigns 'BAR=x' to FOO — silently setting a
+    # different variable than the caller asked for. Hence the explicit check.
+    if [[ ! "${_extra_envs_key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      log-error "'${_extra_envs_key}' is not a valid environment variable name!"
+      end-group
+      return 1
+    fi
     if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
       log-info "unsetting '${_extra_envs_key}'"
-      unset "${_extra_envs_key}"
+      if ! unset "${_extra_envs_key}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     else
       log-info "setting '${_extra_envs_key}'"
-      export "${_extra_envs_key}=${_extra_envs_value}"
+      # Still guarded: a readonly variable makes 'export' fail even though the
+      # name itself is valid.
+      if ! export "${_extra_envs_key}=${_extra_envs_value}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     fi
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
   end-group

--- a/terraform-apply/run_all_tests.sh
+++ b/terraform-apply/run_all_tests.sh
@@ -441,6 +441,22 @@ assert "negative: it is rejected as a name, not silently reinterpreted" \
 assert "negative: the tool was not invoked at all" \
   bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
 
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_apply.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}           step_apply.sh SUMMARY            ${NC}"

--- a/terraform-apply/run_all_tests.sh
+++ b/terraform-apply/run_all_tests.sh
@@ -43,7 +43,8 @@ setup_workdir() {
   export input_working_directory="${WORK_DIR}"
   export input_terraform_plan_file="${PLAN_FILE}"
 
-  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_ARGS_FILE MOCK_TF_PWD_FILE
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_ARGS_FILE MOCK_TF_PWD_FILE MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 install_stub_terraform() {
@@ -51,6 +52,11 @@ install_stub_terraform() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/terraform" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 if [ -n "${MOCK_TF_ARGS_FILE:-}" ]; then
   printf '%s\n' "${#}" "${@}" >"${MOCK_TF_ARGS_FILE}"
 fi
@@ -188,6 +194,191 @@ assert "Glob in path: still exactly 4 arguments (no glob expansion)" \
   test "$(argc)" -eq 4
 assert "Glob in path: plan file arrives unexpanded" \
   test "$(argn 4)" = "${GITHUB_WORKSPACE}/tf-plan-*.plan"
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_apply.txt'"
+
+setup_workdir
+install_stub_terraform
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_apply.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_apply.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_apply.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_apply.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_apply.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
 # Summary

--- a/terraform-apply/run_all_tests.sh
+++ b/terraform-apply/run_all_tests.sh
@@ -510,6 +510,55 @@ run_prereqs "${WORK_DIR}"
 assert "prereqs: a directory is not accepted as a plan file" \
   test "${LAST_EXIT}" -ne 0
 
+# ----------------------------------------------------------------------
+# jq older than 1.7 has no '--raw-output0'. The runner images this repo
+# targets have 1.7.x, but 'runs-on' is caller-overridable to self-hosted
+# groups — and a jq that rejects the flag made the read loop consume nothing
+# while the step carried on having applied nothing at all.
+#
+# apply-extra-envs is byte-identical across the six goal actions
+# (docs/Per-goal-environment-variables.md §9.6), and resolve-goal-envs' suite
+# asserts that, so exercising this once here covers all six.
+# ----------------------------------------------------------------------
+install_stub_old_jq() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/jq" <<'STUB'
+#!/bin/env bash
+# Simulates jq 1.6: every other option works, --raw-output0 does not.
+for _arg in "${@}"; do
+  if [ "${_arg}" = "--raw-output0" ]; then
+    echo "jq: Unknown option: --raw-output0" >&2
+    exit 2
+  fi
+done
+exec "${REAL_JQ}" "${@}"
+STUB
+  chmod +x "${stub_dir}/jq"
+  export REAL_JQ="$(command -v jq)"
+  OLD_JQ_PATH="${stub_dir}"
+}
+
+setup_workdir
+install_stub_terraform
+install_stub_old_jq
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25}'
+(
+  PATH="${OLD_JQ_PATH}:${PATH}"
+  set -o allexport
+  source "${_this_script_dir}/step_apply.sh"
+) >"${OUT_FILE}" 2>&1
+LAST_EXIT=$?
+assert "old jq: the step fails rather than applying nothing" test "${LAST_EXIT}" -ne 0
+assert "old jq: the error reports how many of how many were applied" \
+  grep -q 'applied 0 of 2 environment variable(s)' "${OUT_FILE}"
+assert "old jq: the error points at the jq version" \
+  grep -q 'jq is older than 1.7' "${OUT_FILE}"
+assert "old jq: terraform was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+unset REAL_JQ
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}           step_apply.sh SUMMARY            ${NC}"

--- a/terraform-apply/run_all_tests.sh
+++ b/terraform-apply/run_all_tests.sh
@@ -383,6 +383,64 @@ assert "T25: and nothing was written to \$GITHUB_ENV" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_apply.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_apply.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_apply.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_apply.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_apply.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}           step_apply.sh SUMMARY            ${NC}"

--- a/terraform-apply/run_all_tests.sh
+++ b/terraform-apply/run_all_tests.sh
@@ -457,6 +457,59 @@ assert "negative: the error names the directory" \
 assert "negative: the tool was never invoked" \
   bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
 
+# ======================================================================
+# The inline 'check-prereqs' step.
+#
+# The implementation guide allows prerequisite checks to stay inline, and this
+# one normally would not earn a test — except that this is the only action in
+# the repo that mutates infrastructure, and the check is what stops it running
+# 'apply' against a plan file that is not there.
+# ======================================================================
+run_prereqs() {
+  local plan_file="${1}"
+  local tmp
+  tmp="$(mktemp -d)"
+  printf '%s' "${plan_file}" >"${tmp}/plan-file.txt"
+
+  python3 "${_this_script_dir}/extract_step_source.py" \
+    "${_this_script_dir}/action.yml" check-prereqs "${tmp}/step.sh" \
+    "inputs.terraform-plan-file=@${tmp}/plan-file.txt" \
+    "github.action_path=${_this_script_dir}"
+
+  # Same shell flags the runner uses, so 'exit 1' behaves as it does in CI.
+  PATH="${RUNNER_TEMP}/stub-bin:${PATH}" \
+    bash --noprofile --norc -eo pipefail "${tmp}/step.sh" >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+}
+
+setup_workdir
+install_stub_terraform
+run_prereqs "${PLAN_FILE}"
+assert "prereqs: an existing plan file and terraform on PATH passes" \
+  test "${LAST_EXIT}" -eq 0
+assert "prereqs: it says the plan file exists" \
+  grep -q 'the configured plan file exists' "${OUT_FILE}"
+
+setup_workdir
+install_stub_terraform
+run_prereqs "${GITHUB_WORKSPACE}/no-such-plan.plan"
+assert "prereqs: a missing plan file fails before anything is applied" \
+  test "${LAST_EXIT}" -ne 0
+assert "prereqs: the error explains why" \
+  grep -q 'the configured plan file does not exists' "${OUT_FILE}"
+
+setup_workdir
+install_stub_terraform
+run_prereqs ""
+assert "prereqs: an empty plan-file path fails" test "${LAST_EXIT}" -ne 0
+
+# A directory is not a plan file.
+setup_workdir
+install_stub_terraform
+run_prereqs "${WORK_DIR}"
+assert "prereqs: a directory is not accepted as a plan file" \
+  test "${LAST_EXIT}" -ne 0
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}           step_apply.sh SUMMARY            ${NC}"

--- a/terraform-apply/run_all_tests.sh
+++ b/terraform-apply/run_all_tests.sh
@@ -1,0 +1,209 @@
+#!/bin/env bash
+#
+# Tests for step_apply.sh
+#
+# Uses a stub 'terraform' binary (injected via TF_BIN) so tests don't
+# require — and never call — the real terraform binary. The stub records
+# its argv one element per line (preceded by the argument count) plus its
+# working directory, which is what makes the array-built-invocation
+# assertions possible: a string-built command that word-splits a path with
+# a space shows up as a higher argument count.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+OUT_FILE=/tmp/test_output_apply.txt
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+  WORK_DIR="${RUNNER_TEMP}/work"
+  mkdir -p "${WORK_DIR}"
+
+  PLAN_FILE="${GITHUB_WORKSPACE}/tf-plan-testenv.plan"
+  echo 'fake plan' >"${PLAN_FILE}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_terraform_plan_file="${PLAN_FILE}"
+
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_ARGS_FILE MOCK_TF_PWD_FILE
+}
+
+install_stub_terraform() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/terraform" <<'STUB'
+#!/bin/env bash
+if [ -n "${MOCK_TF_ARGS_FILE:-}" ]; then
+  printf '%s\n' "${#}" "${@}" >"${MOCK_TF_ARGS_FILE}"
+fi
+if [ -n "${MOCK_TF_PWD_FILE:-}" ]; then
+  pwd >"${MOCK_TF_PWD_FILE}"
+fi
+if [ -n "${MOCK_TF_STDOUT:-}" ]; then
+  printf '%s\n' "${MOCK_TF_STDOUT}"
+fi
+exit "${MOCK_TF_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/terraform"
+  export TF_BIN="${stub_dir}/terraform"
+}
+
+# Enable argv + pwd recording for the next run_step.
+record_invocation() {
+  export MOCK_TF_ARGS_FILE="${RUNNER_TEMP}/tf-args.txt"
+  export MOCK_TF_PWD_FILE="${RUNNER_TEMP}/tf-pwd.txt"
+}
+
+# Argument count as recorded by the stub.
+argc() { head -n1 "${MOCK_TF_ARGS_FILE}"; }
+
+# Nth recorded argument (1-based).
+argn() { sed -n "$((${1} + 1))p" "${MOCK_TF_ARGS_FILE}"; }
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_apply.sh"
+  ) >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+}
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    echo "--- recorded argv ---"
+    cat "${MOCK_TF_ARGS_FILE}" 2>/dev/null || true
+    echo "--- /recorded argv ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}         TERRAFORM-APPLY STEP TESTS         ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Test: Happy path (terraform exit 0)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_invocation
+export MOCK_TF_EXIT=0
+export MOCK_TF_STDOUT="Apply complete! Resources: 1 added, 0 changed, 0 destroyed."
+run_step
+assert "Happy path: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Happy path: stub stdout reaches the log" \
+  grep -q "Apply complete" "${OUT_FILE}"
+assert "Happy path: terraform invoked from the working directory" \
+  test "$(cat "${MOCK_TF_PWD_FILE}")" = "${WORK_DIR}"
+
+# ----------------------------------------------------------------------
+# Test: argv shape — apply -input=false -auto-approve <plan-file>
+# ----------------------------------------------------------------------
+assert "argv: exactly 4 arguments" test "$(argc)" -eq 4
+assert "argv: 1st is 'apply'" test "$(argn 1)" = "apply"
+assert "argv: 2nd is '-input=false'" test "$(argn 2)" = "-input=false"
+assert "argv: 3rd is '-auto-approve'" test "$(argn 3)" = "-auto-approve"
+assert "argv: 4th is the plan file, verbatim" test "$(argn 4)" = "${PLAN_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: Failure (terraform exit 1)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=1
+export MOCK_TF_STDOUT="Error: applying plan failed"
+run_step
+assert "Failure: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Failure: error log line present" \
+  grep -q "apply exited with code '1'" "${OUT_FILE}"
+assert "Failure: terraform stderr/stdout still reaches the log" \
+  grep -q "applying plan failed" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: plan file path containing a space reaches terraform as ONE argv
+# element. Regression guard for the string-built invocation this action
+# used to have — see docs/Per-goal-environment-variables.md §6.5.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_invocation
+PLAN_FILE="${GITHUB_WORKSPACE}/tf plan with spaces.plan"
+echo 'fake plan' >"${PLAN_FILE}"
+export input_terraform_plan_file="${PLAN_FILE}"
+export MOCK_TF_EXIT=0
+run_step
+assert "Space in path: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Space in path: still exactly 4 arguments (no word-splitting)" \
+  test "$(argc)" -eq 4
+assert "Space in path: plan file arrives verbatim" \
+  test "$(argn 4)" = "${PLAN_FILE}"
+assert "Space in path: logged command string shows the real quoting" \
+  grep -Fq "'${PLAN_FILE}'" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: plan file path containing a glob character is not expanded
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_invocation
+# Files the glob would match if expansion happened.
+touch "${WORK_DIR}/decoy-a" "${WORK_DIR}/decoy-b"
+PLAN_FILE="${GITHUB_WORKSPACE}/tf-plan-*.plan"
+touch "${GITHUB_WORKSPACE}/tf-plan-one.plan" "${GITHUB_WORKSPACE}/tf-plan-two.plan"
+export input_terraform_plan_file="${PLAN_FILE}"
+export MOCK_TF_EXIT=0
+run_step
+assert "Glob in path: still exactly 4 arguments (no glob expansion)" \
+  test "$(argc)" -eq 4
+assert "Glob in path: plan file arrives unexpanded" \
+  test "$(argn 4)" = "${GITHUB_WORKSPACE}/tf-plan-*.plan"
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}           step_apply.sh SUMMARY            ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/terraform-apply/run_local_step_apply.sh
+++ b/terraform-apply/run_local_step_apply.sh
@@ -1,0 +1,43 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_apply.sh.
+# Simulates GitHub Actions environment using a stub 'terraform' binary.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+WORK_DIR="${RUNNER_TEMP}/envs/sandbox"
+mkdir -p "${WORK_DIR}"
+
+PLAN_FILE="${GITHUB_WORKSPACE}/tf-plan-sandbox.plan"
+echo 'fake binary plan' >"${PLAN_FILE}"
+
+STUB_DIR="${RUNNER_TEMP}/stub-bin"
+mkdir -p "${STUB_DIR}"
+cat >"${STUB_DIR}/terraform" <<'EOF'
+#!/bin/env bash
+echo "stub terraform received ${#} argument(s):"
+for arg in "${@}"; do
+  echo "  - '${arg}'"
+done
+echo "Apply complete! Resources: 1 added, 0 changed, 0 destroyed."
+exit 0
+EOF
+chmod +x "${STUB_DIR}/terraform"
+export TF_BIN="${STUB_DIR}/terraform"
+
+export input_working_directory="${WORK_DIR}"
+export input_terraform_plan_file="${PLAN_FILE}"
+
+source "${_this_script_dir}/step_apply.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"

--- a/terraform-apply/run_local_step_apply.sh
+++ b/terraform-apply/run_local_step_apply.sh
@@ -34,10 +34,40 @@ export TF_BIN="${STUB_DIR}/terraform"
 export input_working_directory="${WORK_DIR}"
 export input_terraform_plan_file="${PLAN_FILE}"
 
-source "${_this_script_dir}/step_apply.sh"
+# Per-goal environment variables, as resolve-goal-envs would produce them.
+# GOMEMLIMIT is set, and a variable that exists job-wide is unset by a JSON null
+# — something $GITHUB_ENV cannot express.
+export DSB_LEAKY_VAR="value-from-the-job"
+export DSB_UNSET_ME="also-from-the-job"
+export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+cat >"${input_extra_envs_file}" <<'EOF'
+{
+  "GOMEMLIMIT": "12GiB",
+  "GOGC": 25,
+  "DSB_LEAKY_VAR": "value-from-the-goal",
+  "DSB_UNSET_ME": null
+}
+EOF
+
+# Subshell: the step script ends in 'exit', which would otherwise
+# terminate this runner before it can show anything. It is also what
+# makes the scoping check below meaningful — the step's exports die
+# with the subshell, exactly as they do when the GitHub step ends.
+( source "${_this_script_dir}/step_apply.sh" )
+echo ""
+echo "step exit code: ${?}"
+
 
 echo ""
 echo "========================================"
 echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
 echo "========================================"
 cat "${GITHUB_OUTPUT}"
+
+echo ""
+echo "========================================"
+echo "Scoping check (values must NOT leak out)"
+echo "========================================"
+echo "GOMEMLIMIT after the step:    '${GOMEMLIMIT:-<unset>}'  (expected: <unset>)"
+echo "DSB_LEAKY_VAR after the step: '${DSB_LEAKY_VAR:-<unset>}'  (expected: value-from-the-job)"
+echo "DSB_UNSET_ME after the step:  '${DSB_UNSET_ME:-<unset>}'  (expected: also-from-the-job)"

--- a/terraform-apply/step_apply.sh
+++ b/terraform-apply/step_apply.sh
@@ -1,0 +1,59 @@
+#!/bin/env bash
+#
+# Source for the terraform-apply main step.
+#
+# Applies a previously created terraform plan file.
+#
+# Required environment variables:
+#   input_working_directory   - Where to invoke terraform.
+#   input_terraform_plan_file - Path of the plan file to apply.
+#
+# Optional environment variables:
+#   TF_BIN - Path to the terraform binary (defaults to 'terraform' on PATH).
+#            Used by tests to inject a stub.
+#
+
+set +o nounset
+
+# Load helpers
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tf_bin="${TF_BIN:-terraform}"
+
+  cd "${input_working_directory}"
+
+  # Built as an array and invoked as "${apply_cmd[@]}": the plan-file path is
+  # caller-supplied and, as an interpolated command string, was subject to
+  # word-splitting and glob expansion before it ever reached terraform.
+  local apply_cmd=(
+    "${tf_bin}"
+    apply
+    -input=false
+    -auto-approve
+    "${input_terraform_plan_file}"
+  )
+  log-info "apply command string is '${apply_cmd[*]@Q}'"
+  start-group "'terraform apply' in '$(ws-path "$(pwd)")'"
+
+  # GitHub runner gets confused by set commands; make sure
+  # 'continue-on-error' still applies to the step.
+  set +e
+  "${apply_cmd[@]}"
+  local apply_exit=${?}
+
+  # Avoid control characters left behind by apply, they mess up the
+  # end-group command.
+  echo ''
+  end-group
+
+  if [ "${apply_exit}" != "0" ]; then
+    log-error "apply exited with code '${apply_exit}'"
+  fi
+
+  return ${apply_exit}
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/terraform-apply/step_apply.sh
+++ b/terraform-apply/step_apply.sh
@@ -9,6 +9,9 @@
 #   input_terraform_plan_file - Path of the plan file to apply.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   TF_BIN - Path to the terraform binary (defaults to 'terraform' on PATH).
 #            Used by tests to inject a stub.
 #
@@ -19,6 +22,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tf_bin="${TF_BIN:-terraform}"
 
   cd "${input_working_directory}"

--- a/terraform-apply/step_apply.sh
+++ b/terraform-apply/step_apply.sh
@@ -28,7 +28,15 @@ function main {
 
   local tf_bin="${TF_BIN:-terraform}"
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   # Built as an array and invoked as "${apply_cmd[@]}": the plan-file path is
   # caller-supplied and, as an interpolated command string, was subject to

--- a/terraform-fmt/action.yml
+++ b/terraform-fmt/action.yml
@@ -30,41 +30,10 @@ runs:
         end-group
     - id: fmt
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         TF_IN_AUTOMATION: "true"
+        input_working_directory: ${{ inputs.working-directory }}
+        input_format_check_in_root_dir: ${{ inputs.format-check-in-root-dir }}
       run: |
-        # run terraform fmt
-
-        set -o allexport; source "${{ github.action_path }}/helpers.sh"; set +o allexport;
-
-        # where to check?
-        MODULES_FILE="$(pwd)/.terraform/modules/modules.json"
-        if [ "${{ inputs.format-check-in-root-dir }}" == 'true' ]; then
-          log-info "check will run from root directory."
-          TF_FMT_DIRS="${GITHUB_WORKSPACE}"
-        elif [ -f "${MODULES_FILE}" ]; then
-          log-info "check will run in directories from terraform modules file '$(ws-path ${MODULES_FILE})'"
-          TF_FMT_DIRS=$(jq -cr --arg pwd "$(pwd)/" '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' "${MODULES_FILE}")
-        else
-          log-info "check will run in 'project-dir' '$(pwd)'"
-          TF_FMT_DIRS="$(pwd)"
-        fi
-
-        # run check
-        declare -A TF_FMT_RESULTS
-        for TF_FMT_DIR in ${TF_FMT_DIRS[*]}; do
-          log-info "running in: '$(ws-path ${TF_FMT_DIR})'"
-          set +e
-          terraform -chdir="${TF_FMT_DIR}" fmt -check -recursive
-          TF_FMT_EXITCODE=${?}
-          set -e
-          TF_FMT_RESULTS["./${TF_FMT_DIR}"]="${TF_FMT_EXITCODE}"
-          if [ ! "${TF_FMT_EXITCODE}" == "0" ];then
-            log-error "fmt exited with code '${TF_FMT_EXITCODE}'!"
-          fi
-        done
-
-        # exit code
-        TF_FMT_SUM_EXIT_CODES=$(IFS=+; echo "$((${TF_FMT_RESULTS[*]}))")
-        exit ${TF_FMT_SUM_EXIT_CODES}
+        set -o allexport
+        source "${{ github.action_path }}/step_fmt.sh"

--- a/terraform-fmt/action.yml
+++ b/terraform-fmt/action.yml
@@ -10,6 +10,22 @@ inputs:
     description: |
       If 'true' the command invocation will be performed in the root directory of the repository.
     required: true
+  extra-envs-file:
+    description: |
+      Path to a JSON file with environment variables to apply to this action's
+      invocations only, as produced by the 'resolve-goal-envs' action. A JSON
+      null value unsets the variable rather than setting it to the empty
+      string.
+
+      A path rather than a payload so that the values — which may be secrets —
+      never enter argv, envp, or this step's script text.
+
+      The values are applied before this action's own exports, so an action-managed
+      variable set by the step script at runtime (e.g. TF_PLUGIN_CACHE_DIR) wins,
+      while one set in the step's env: block (e.g. TF_IN_AUTOMATION) is overridden
+      by the caller. See docs/Per-goal-environment-variables.md §6.3.
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -34,6 +50,7 @@ runs:
         TF_IN_AUTOMATION: "true"
         input_working_directory: ${{ inputs.working-directory }}
         input_format_check_in_root_dir: ${{ inputs.format-check-in-root-dir }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         set -o allexport
         source "${{ github.action_path }}/step_fmt.sh"

--- a/terraform-fmt/helpers_additional.sh
+++ b/terraform-fmt/helpers_additional.sh
@@ -20,14 +20,31 @@ function read-terraform-module-dirs {
   local -n _dirs_out="${1}"
   local _modules_file="${2}"
   local _prefix="${3}"
-  local _dir
+  local _dir _out_file _err_file
 
   _dirs_out=()
+  _out_file="$(mktemp)"
+  _err_file="$(mktemp)"
+
+  # jq's exit code is checked rather than piping straight into the read loop:
+  # an unparseable modules.json, or one without a '.Modules' array, otherwise
+  # yields zero directories and the caller reports success having checked
+  # nothing at all.
+  if ! jq --raw-output0 --arg pwd "${_prefix}" \
+    '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' \
+    "${_modules_file}" >"${_out_file}" 2>"${_err_file}"; then
+    log-error "failed to read directories from the terraform modules file '${_modules_file}':"
+    log-error "$(cat "${_err_file}")"
+    rm -f "${_out_file}" "${_err_file}"
+    return 1
+  fi
+
   while IFS= read -r -d '' _dir; do
     _dirs_out+=("${_dir}")
-  done < <(jq --raw-output0 --arg pwd "${_prefix}" \
-    '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' \
-    "${_modules_file}")
+  done <"${_out_file}"
+
+  rm -f "${_out_file}" "${_err_file}"
+  return 0
 }
 
 # Apply a JSON environment-variable map to the current shell

--- a/terraform-fmt/helpers_additional.sh
+++ b/terraform-fmt/helpers_additional.sh
@@ -101,6 +101,18 @@ function apply-extra-envs {
     return 1
   fi
 
+  # How many entries must end up applied. 'length' works on any jq, which is
+  # the point: it is the cross-check that catches a jq too old for
+  # --raw-output0 (ref. docs/Per-goal-environment-variables.md §9.2). Without
+  # it, such a jq makes the read loop consume nothing and the step continues
+  # having applied nothing — silently, and only on the runner images where it
+  # happens to be old.
+  local _extra_envs_expected _extra_envs_applied=0
+  if ! _extra_envs_expected=$(jq -r 'length' "${_extra_envs_file}"); then
+    log-error "unable to count the entries in '${_extra_envs_file}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
     # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
@@ -128,7 +140,15 @@ function apply-extra-envs {
         return 1
       fi
     fi
+    _extra_envs_applied=$((_extra_envs_applied + 1))
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+
+  if [ ! "${_extra_envs_applied}" == "${_extra_envs_expected}" ]; then
+    log-error "applied ${_extra_envs_applied} of ${_extra_envs_expected} environment variable(s) from '${_extra_envs_file}'!"
+    log-error "this usually means jq is older than 1.7 and does not support '--raw-output0' — check the runner image."
+    end-group
+    return 1
+  fi
   end-group
 
   return 0

--- a/terraform-fmt/helpers_additional.sh
+++ b/terraform-fmt/helpers_additional.sh
@@ -1,0 +1,34 @@
+#!/bin/env bash
+#
+# Action-specific helpers for terraform-fmt.
+# Auto-loaded by helpers.sh.
+#
+
+# Read the module directories terraform recorded in
+# '<project-dir>/.terraform/modules/modules.json' into the array named by $1.
+#
+#   $1 - name of the array variable to populate
+#   $2 - path to modules.json
+#   $3 - prefix to prepend to each relative directory (usually "$(pwd)/")
+#
+# NUL-delimited (jq --raw-output0 + read -d '') rather than newline-joined into
+# a single string: the previous form iterated that string as '${DIRS[*]}', which
+# is not array iteration but word-splitting — so a module path containing a
+# space silently visited two directories that do not exist instead of the one
+# that does. Requires jq 1.7, ref. docs/Per-goal-environment-variables.md §9.2.
+function read-terraform-module-dirs {
+  local -n _dirs_out="${1}"
+  local _modules_file="${2}"
+  local _prefix="${3}"
+  local _dir
+
+  _dirs_out=()
+  while IFS= read -r -d '' _dir; do
+    _dirs_out+=("${_dir}")
+  done < <(jq --raw-output0 --arg pwd "${_prefix}" \
+    '[ .Modules[].Dir | select( startswith(".terraform") | not) ] | unique | sort | $pwd + .[]' \
+    "${_modules_file}")
+}
+
+# ==========================================================
+log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/terraform-fmt/helpers_additional.sh
+++ b/terraform-fmt/helpers_additional.sh
@@ -30,5 +30,59 @@ function read-terraform-module-dirs {
     "${_modules_file}")
 }
 
+# Apply a JSON environment-variable map to the current shell
+# ==========================================================
+# Applies the resolved environment for this action's goal, as produced by the
+# 'resolve-goal-envs' action. A JSON null unsets the variable rather than
+# emptying it — $GITHUB_ENV cannot express that, and the distinction matters for
+# anything that treats "" as a meaningful value.
+#
+# Takes a path, not the JSON itself: the values may be secrets, and nothing here
+# may hold the payload in a shell variable while allexport is in scope (ref. the
+# ARG_MAX rule in CLAUDE.md). jq reads the file and the loop consumes a stream,
+# so only one key and one value transit shell variables at a time.
+#
+# NUL-delimited (jq --raw-output0, requires jq 1.7) so multiline values such as
+# PEM keys and values containing shell metacharacters survive verbatim, with no
+# encoding hop and no per-variable subshell. The sentinel marks a JSON null; an
+# empty field is a genuine empty-string value.
+#
+# Call this early in main, BEFORE the action's own exports: there is no
+# reserved-name list, so that ordering is what decides who wins. See
+# docs/Per-goal-environment-variables.md §6.2 and §6.3.
+#
+# Locals are underscore-prefixed on purpose — a caller whose variable is named
+# 'file', 'key' or 'value' must not collide with them. Not 'readonly' either:
+# helpers.sh being sourced twice in one shell would then hard-fail.
+_EXTRA_ENVS_UNSET='__DSB_UNSET__'
+_EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
+
+function apply-extra-envs {
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+
+  if [ -z "${_extra_envs_file}" ]; then
+    log-info "no per-goal environment variables file configured."
+    return 0
+  fi
+  if [ ! -f "${_extra_envs_file}" ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' does not exist!"
+    return 1
+  fi
+
+  start-group "applying per-goal environment variables"
+  while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
+      log-info "unsetting '${_extra_envs_key}'"
+      unset "${_extra_envs_key}"
+    else
+      log-info "setting '${_extra_envs_key}'"
+      export "${_extra_envs_key}=${_extra_envs_value}"
+    fi
+  done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+  end-group
+
+  return 0
+}
+
 # ==========================================================
 log-info "'$(basename ${BASH_SOURCE[0]})' loaded."

--- a/terraform-fmt/helpers_additional.sh
+++ b/terraform-fmt/helpers_additional.sh
@@ -58,7 +58,7 @@ _EXTRA_ENVS_UNSET='__DSB_UNSET__'
 _EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
 
 function apply-extra-envs {
-  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value _extra_envs_type
 
   if [ -z "${_extra_envs_file}" ]; then
     log-info "no per-goal environment variables file configured."
@@ -69,14 +69,47 @@ function apply-extra-envs {
     return 1
   fi
 
+  # Validated before anything is applied. Without this an unparseable, empty or
+  # truncated file applies nothing at all and the step carries on as if it had —
+  # the consequence then surfaces as an OOM or a wrong-credentials error far
+  # from its cause, which is the failure mode this whole feature exists to
+  # avoid. resolve-goal-envs already guarantees a JSON object; this is the last
+  # line of defence, and cheap.
+  if ! _extra_envs_type=$(jq -r 'type' "${_extra_envs_file}" 2>/dev/null); then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' is not valid JSON!"
+    return 1
+  fi
+  if [ ! "${_extra_envs_type}" == 'object' ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' must hold a JSON object, got '${_extra_envs_type:-nothing}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
+    # and the value 'x' it happily assigns 'BAR=x' to FOO — silently setting a
+    # different variable than the caller asked for. Hence the explicit check.
+    if [[ ! "${_extra_envs_key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      log-error "'${_extra_envs_key}' is not a valid environment variable name!"
+      end-group
+      return 1
+    fi
     if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
       log-info "unsetting '${_extra_envs_key}'"
-      unset "${_extra_envs_key}"
+      if ! unset "${_extra_envs_key}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     else
       log-info "setting '${_extra_envs_key}'"
-      export "${_extra_envs_key}=${_extra_envs_value}"
+      # Still guarded: a readonly variable makes 'export' fail even though the
+      # name itself is valid.
+      if ! export "${_extra_envs_key}=${_extra_envs_value}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     fi
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
   end-group

--- a/terraform-fmt/run_all_tests.sh
+++ b/terraform-fmt/run_all_tests.sh
@@ -43,7 +43,8 @@ setup_workdir() {
   : >"${ARGS_FILE}"
   export MOCK_TF_ARGS_FILE="${ARGS_FILE}"
 
-  unset MOCK_TF_EXIT MOCK_TF_FAIL_DIR
+  unset MOCK_TF_EXIT MOCK_TF_FAIL_DIR MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 # Write a fake modules.json. Each argument is a module 'Dir' value. The
@@ -68,6 +69,11 @@ install_stub_terraform() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/terraform" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 if [ -n "${MOCK_TF_ARGS_FILE:-}" ]; then
   printf 'INVOCATION %s\n' "${#}" >>"${MOCK_TF_ARGS_FILE}"
   printf '%s\n' "${@}" >>"${MOCK_TF_ARGS_FILE}"
@@ -226,6 +232,191 @@ run_step
 assert "Mixed results: three invocations" test "$(invocations)" -eq 3
 assert "Mixed results: step exits non-zero" test "${LAST_EXIT}" -ne 0
 assert "Mixed results: exit code is the sum (0+3+0)" test "${LAST_EXIT}" -eq 3
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_fmt.txt'"
+
+setup_workdir
+install_stub_terraform
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_fmt.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_fmt.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_fmt.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_fmt.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_fmt.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
 # Summary

--- a/terraform-fmt/run_all_tests.sh
+++ b/terraform-fmt/run_all_tests.sh
@@ -421,6 +421,64 @@ assert "T25: and nothing was written to \$GITHUB_ENV" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_fmt.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_fmt.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_fmt.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_fmt.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_fmt.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_fmt.sh SUMMARY             ${NC}"

--- a/terraform-fmt/run_all_tests.sh
+++ b/terraform-fmt/run_all_tests.sh
@@ -515,6 +515,22 @@ assert "negative: the error says nothing was found to check" \
   grep -q 'no directories to check for formatting were found' "${OUT_FILE}"
 assert "negative: terraform was never invoked" test "$(invocations)" -eq 0
 
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_fmt.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_fmt.sh SUMMARY             ${NC}"

--- a/terraform-fmt/run_all_tests.sh
+++ b/terraform-fmt/run_all_tests.sh
@@ -1,0 +1,247 @@
+#!/bin/env bash
+#
+# Tests for step_fmt.sh
+#
+# Uses a stub 'terraform' binary (injected via TF_BIN) so tests don't require
+# — and never call — the real terraform binary. The stub appends one
+# 'INVOCATION <argc>' line per call followed by one line per argument, which is
+# what makes the "a directory path with a space is ONE argument" assertions
+# possible: the old string-built form produced two bogus directories instead.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_RUN=0
+
+OUT_FILE=/tmp/test_output_fmt.txt
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+setup_workdir() {
+  export GITHUB_OUTPUT=$(mktemp)
+  export RUNNER_TEMP=$(mktemp -d)
+  export GITHUB_ACTION_PATH="${_this_script_dir}"
+  export GITHUB_WORKSPACE="${RUNNER_TEMP}/workspace"
+
+  WORK_DIR="${GITHUB_WORKSPACE}/envs/sandbox"
+  mkdir -p "${WORK_DIR}"
+
+  export input_working_directory="${WORK_DIR}"
+  export input_format_check_in_root_dir="false"
+
+  ARGS_FILE="${RUNNER_TEMP}/tf-args.txt"
+  : >"${ARGS_FILE}"
+  export MOCK_TF_ARGS_FILE="${ARGS_FILE}"
+
+  unset MOCK_TF_EXIT MOCK_TF_FAIL_DIR
+}
+
+# Write a fake modules.json. Each argument is a module 'Dir' value. The
+# directories are created too: terraform has them on disk by the time this
+# runs, and ws-path (realpath) needs them to exist to render log lines.
+write_modules_file() {
+  local dirs_json dir
+  dirs_json="$(printf '%s\n' "${@}" | jq -Rsc 'split("\n") | map(select(length > 0)) | map({Dir: .})')"
+  for dir in "${@}"; do
+    mkdir -p "${WORK_DIR}/${dir}"
+  done
+  mkdir -p "${WORK_DIR}/.terraform/modules"
+  jq -n --argjson mods "${dirs_json}" '{Modules: $mods}' \
+    >"${WORK_DIR}/.terraform/modules/modules.json"
+}
+
+# Stub terraform. Exits with MOCK_TF_EXIT, except when MOCK_TF_FAIL_DIR is set
+# and matches the -chdir argument — then it exits 3 (terraform fmt's
+# "formatting needed" code) so per-directory exit-code summing can be tested.
+install_stub_terraform() {
+  local stub_dir="${RUNNER_TEMP}/stub-bin"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/terraform" <<'STUB'
+#!/bin/env bash
+if [ -n "${MOCK_TF_ARGS_FILE:-}" ]; then
+  printf 'INVOCATION %s\n' "${#}" >>"${MOCK_TF_ARGS_FILE}"
+  printf '%s\n' "${@}" >>"${MOCK_TF_ARGS_FILE}"
+fi
+if [ -n "${MOCK_TF_FAIL_DIR:-}" ]; then
+  for arg in "${@}"; do
+    if [ "${arg}" = "-chdir=${MOCK_TF_FAIL_DIR}" ]; then
+      echo "some.tf needs formatting"
+      exit 3
+    fi
+  done
+fi
+exit "${MOCK_TF_EXIT:-0}"
+STUB
+  chmod +x "${stub_dir}/terraform"
+  export TF_BIN="${stub_dir}/terraform"
+}
+
+run_step() {
+  (
+    set -o allexport
+    source "${_this_script_dir}/step_fmt.sh"
+  ) >"${OUT_FILE}" 2>&1
+  LAST_EXIT=$?
+}
+
+# Number of stub invocations.
+invocations() { grep -c '^INVOCATION ' "${ARGS_FILE}"; }
+
+# All -chdir arguments, one per line, in invocation order.
+chdirs() { grep '^-chdir=' "${ARGS_FILE}" | sed 's/^-chdir=//'; }
+
+assert() {
+  local name="${1}"
+  shift
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo ""
+  echo -e "${BLUE}TEST ${TESTS_RUN}: ${name}${NC}"
+  if "$@"; then
+    echo -e "${GREEN}✓ PASSED${NC}"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}"
+    echo "--- step output ---"
+    cat "${OUT_FILE}" 2>/dev/null || true
+    echo "--- /step output ---"
+    echo "--- recorded invocations ---"
+    cat "${ARGS_FILE}" 2>/dev/null || true
+    echo "--- /recorded invocations ---"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}          TERRAFORM-FMT STEP TESTS          ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+
+# ----------------------------------------------------------------------
+# Test: no modules.json → check the project directory only
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+run_step
+assert "No modules file: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "No modules file: exactly one invocation" test "$(invocations)" -eq 1
+assert "No modules file: checks the project directory" \
+  test "$(chdirs)" = "${WORK_DIR}"
+assert "No modules file: argv is -chdir + fmt -check -recursive" \
+  test "$(grep -c '^INVOCATION 4$' "${ARGS_FILE}")" -eq 1
+assert "No modules file: log says it runs in project-dir" \
+  grep -q "check will run in 'project-dir'" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: format-check-in-root-dir → check the repository root only
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+write_modules_file "." "modules/network"
+export input_format_check_in_root_dir="true"
+run_step
+assert "Root dir: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Root dir: exactly one invocation" test "$(invocations)" -eq 1
+assert "Root dir: checks GITHUB_WORKSPACE (modules file ignored)" \
+  test "$(chdirs)" = "${GITHUB_WORKSPACE}"
+
+# ----------------------------------------------------------------------
+# Test: modules.json → one invocation per module dir, '.terraform/*'
+#       entries filtered out, duplicates collapsed
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+write_modules_file "." "modules/network" "modules/network" ".terraform/modules/vendored"
+run_step
+assert "Modules file: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Modules file: one invocation per unique non-vendored dir" \
+  test "$(invocations)" -eq 2
+assert "Modules file: project dir ('.') included" \
+  bash -c "chdirs() { grep '^-chdir=' '${ARGS_FILE}' | sed 's/^-chdir=//'; }; chdirs | grep -Fxq '${WORK_DIR}/.'"
+assert "Modules file: module dir included" \
+  bash -c "grep -Fxq -- '-chdir=${WORK_DIR}/modules/network' '${ARGS_FILE}'"
+assert "Modules file: vendored '.terraform' dir excluded" \
+  bash -c "! grep -q -- '-chdir=.*\.terraform/modules/vendored' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: a module directory path containing a space is checked as ONE
+# directory, not two. This is the latent bug the array conversion fixes —
+# see docs/Per-goal-environment-variables.md §6.5.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+write_modules_file "modules/storage account"
+run_step
+assert "Space in dir: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Space in dir: exactly one invocation (not two)" \
+  test "$(invocations)" -eq 1
+assert "Space in dir: argv has 4 elements (path not word-split)" \
+  test "$(grep -c '^INVOCATION 4$' "${ARGS_FILE}")" -eq 1
+assert "Space in dir: path arrives verbatim as one argument" \
+  bash -c "grep -Fxq -- '-chdir=${WORK_DIR}/modules/storage account' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: a module directory path containing a glob character is not expanded
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+mkdir -p "${WORK_DIR}/modules/a" "${WORK_DIR}/modules/b"
+write_modules_file 'modules/*'
+run_step
+assert "Glob in dir: exactly one invocation (not one per match)" \
+  test "$(invocations)" -eq 1
+assert "Glob in dir: path arrives unexpanded" \
+  bash -c "grep -Fxq -- '-chdir=${WORK_DIR}/modules/*' '${ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: non-zero exit from terraform propagates
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export MOCK_TF_EXIT=3
+run_step
+assert "Failure: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Failure: exits with terraform's code" test "${LAST_EXIT}" -eq 3
+assert "Failure: error log line present" \
+  grep -q "fmt exited with code '3'!" "${OUT_FILE}"
+
+# ----------------------------------------------------------------------
+# Test: exit codes are summed across directories — one failing directory
+# out of three still fails the step
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+write_modules_file "." "modules/network" "modules/storage"
+export MOCK_TF_FAIL_DIR="${WORK_DIR}/modules/network"
+run_step
+assert "Mixed results: three invocations" test "$(invocations)" -eq 3
+assert "Mixed results: step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "Mixed results: exit code is the sum (0+3+0)" test "${LAST_EXIT}" -eq 3
+
+# ----------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}============================================${NC}"
+echo -e "${YELLOW}            step_fmt.sh SUMMARY             ${NC}"
+echo -e "${YELLOW}============================================${NC}"
+echo ""
+echo -e "Tests run:    ${TESTS_RUN}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+echo ""
+
+if [[ ${TESTS_FAILED} -gt 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/terraform-fmt/run_all_tests.sh
+++ b/terraform-fmt/run_all_tests.sh
@@ -479,6 +479,42 @@ assert "negative: it is rejected as a name, not silently reinterpreted" \
 assert "negative: the tool was not invoked at all" \
   bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
 
+# ----------------------------------------------------------------------
+# A format check that checked nothing must not report success. Before this
+# was guarded, an unparseable modules.json made jq fail, the directory list
+# came out empty, the loop never ran and the step exited 0 — "fmt passed"
+# with nothing formatted.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+mkdir -p "${WORK_DIR}/.terraform/modules"
+printf '{ this is not json' >"${WORK_DIR}/.terraform/modules/modules.json"
+run_step
+assert "negative: unparseable modules.json fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the modules file" \
+  grep -q 'failed to read directories from the terraform modules file' "${OUT_FILE}"
+assert "negative: terraform was never invoked" test "$(invocations)" -eq 0
+
+setup_workdir
+install_stub_terraform
+mkdir -p "${WORK_DIR}/.terraform/modules"
+printf '{"NotModules": []}' >"${WORK_DIR}/.terraform/modules/modules.json"
+run_step
+assert "negative: modules.json without a Modules array fails the step" \
+  test "${LAST_EXIT}" -ne 0
+assert "negative: terraform was never invoked" test "$(invocations)" -eq 0
+
+# Every entry filtered out as vendored leaves nothing to check — which means
+# something is wrong with the modules file, not that everything is formatted.
+setup_workdir
+install_stub_terraform
+write_modules_file ".terraform/modules/only-vendored"
+run_step
+assert "negative: an empty directory list fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says nothing was found to check" \
+  grep -q 'no directories to check for formatting were found' "${OUT_FILE}"
+assert "negative: terraform was never invoked" test "$(invocations)" -eq 0
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_fmt.sh SUMMARY             ${NC}"

--- a/terraform-fmt/run_local_step_fmt.sh
+++ b/terraform-fmt/run_local_step_fmt.sh
@@ -43,10 +43,40 @@ export TF_BIN="${STUB_DIR}/terraform"
 export input_working_directory="${WORK_DIR}"
 export input_format_check_in_root_dir="false"
 
-source "${_this_script_dir}/step_fmt.sh"
+# Per-goal environment variables, as resolve-goal-envs would produce them.
+# GOMEMLIMIT is set, and a variable that exists job-wide is unset by a JSON null
+# — something $GITHUB_ENV cannot express.
+export DSB_LEAKY_VAR="value-from-the-job"
+export DSB_UNSET_ME="also-from-the-job"
+export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+cat >"${input_extra_envs_file}" <<'EOF'
+{
+  "GOMEMLIMIT": "12GiB",
+  "GOGC": 25,
+  "DSB_LEAKY_VAR": "value-from-the-goal",
+  "DSB_UNSET_ME": null
+}
+EOF
+
+# Subshell: the step script ends in 'exit', which would otherwise
+# terminate this runner before it can show anything. It is also what
+# makes the scoping check below meaningful — the step's exports die
+# with the subshell, exactly as they do when the GitHub step ends.
+( source "${_this_script_dir}/step_fmt.sh" )
+echo ""
+echo "step exit code: ${?}"
+
 
 echo ""
 echo "========================================"
 echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
 echo "========================================"
 cat "${GITHUB_OUTPUT}"
+
+echo ""
+echo "========================================"
+echo "Scoping check (values must NOT leak out)"
+echo "========================================"
+echo "GOMEMLIMIT after the step:    '${GOMEMLIMIT:-<unset>}'  (expected: <unset>)"
+echo "DSB_LEAKY_VAR after the step: '${DSB_LEAKY_VAR:-<unset>}'  (expected: value-from-the-job)"
+echo "DSB_UNSET_ME after the step:  '${DSB_UNSET_ME:-<unset>}'  (expected: also-from-the-job)"

--- a/terraform-fmt/run_local_step_fmt.sh
+++ b/terraform-fmt/run_local_step_fmt.sh
@@ -1,0 +1,52 @@
+#!/bin/env bash
+#
+# Local testing/debugging script for step_fmt.sh.
+# Simulates GitHub Actions environment using a stub 'terraform' binary and a
+# fake '.terraform/modules/modules.json'.
+#
+
+_this_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export GITHUB_OUTPUT=$(mktemp)
+export RUNNER_TEMP=$(mktemp -d)
+export GITHUB_ACTION_PATH="${_this_script_dir}"
+export GITHUB_WORKSPACE="${RUNNER_TEMP}"
+
+WORK_DIR="${GITHUB_WORKSPACE}/envs/sandbox"
+mkdir -p "${WORK_DIR}/.terraform/modules"
+mkdir -p "${WORK_DIR}/modules/network" "${WORK_DIR}/modules/storage account"
+
+cat >"${WORK_DIR}/.terraform/modules/modules.json" <<'EOF'
+{
+  "Modules": [
+    { "Key": "", "Source": "", "Dir": "." },
+    { "Key": "network", "Source": "./modules/network", "Dir": "modules/network" },
+    { "Key": "storage", "Source": "./modules/storage account", "Dir": "modules/storage account" },
+    { "Key": "vendored", "Source": "registry.example.com/foo", "Dir": ".terraform/modules/vendored" }
+  ]
+}
+EOF
+
+STUB_DIR="${RUNNER_TEMP}/stub-bin"
+mkdir -p "${STUB_DIR}"
+cat >"${STUB_DIR}/terraform" <<'EOF'
+#!/bin/env bash
+echo "stub terraform received ${#} argument(s):"
+for arg in "${@}"; do
+  echo "  - '${arg}'"
+done
+exit 0
+EOF
+chmod +x "${STUB_DIR}/terraform"
+export TF_BIN="${STUB_DIR}/terraform"
+
+export input_working_directory="${WORK_DIR}"
+export input_format_check_in_root_dir="false"
+
+source "${_this_script_dir}/step_fmt.sh"
+
+echo ""
+echo "========================================"
+echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
+echo "========================================"
+cat "${GITHUB_OUTPUT}"

--- a/terraform-fmt/step_fmt.sh
+++ b/terraform-fmt/step_fmt.sh
@@ -35,7 +35,15 @@ function main {
 
   local tf_bin="${TF_BIN:-terraform}"
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   # Where to check?
   local modules_file="$(pwd)/.terraform/modules/modules.json"

--- a/terraform-fmt/step_fmt.sh
+++ b/terraform-fmt/step_fmt.sh
@@ -45,10 +45,16 @@ function main {
     fmt_dirs=("${GITHUB_WORKSPACE}")
   elif [ -f "${modules_file}" ]; then
     log-info "check will run in directories from terraform modules file '$(ws-path "${modules_file}")'"
-    read-terraform-module-dirs fmt_dirs "${modules_file}" "$(pwd)/"
+    read-terraform-module-dirs fmt_dirs "${modules_file}" "$(pwd)/" || return 1
   else
     log-info "check will run in 'project-dir' '$(pwd)'"
     fmt_dirs=("$(pwd)")
+  fi
+
+  # A format check that checked nothing must not report success.
+  if [ ${#fmt_dirs[@]} -eq 0 ]; then
+    log-error "no directories to check for formatting were found!"
+    return 1
   fi
 
   # Run check

--- a/terraform-fmt/step_fmt.sh
+++ b/terraform-fmt/step_fmt.sh
@@ -1,0 +1,79 @@
+#!/bin/env bash
+#
+# Source for the terraform-fmt main step.
+#
+# Runs 'terraform fmt -check -recursive' in one or more directories:
+#   1. the repository root, if 'format-check-in-root-dir' is 'true'
+#   2. otherwise every module directory terraform recorded in
+#      '<project-dir>/.terraform/modules/modules.json' during init
+#   3. otherwise just the project directory
+#
+# Exits with the sum of the per-directory exit codes so a failure anywhere
+# surfaces as a failing step.
+#
+# Required environment variables:
+#   input_working_directory        - Where to invoke terraform.
+#   input_format_check_in_root_dir - 'true' to check from the repository root.
+#
+# Optional environment variables:
+#   TF_BIN - Path to the terraform binary (defaults to 'terraform' on PATH).
+#            Used by tests to inject a stub.
+#
+
+set +o nounset
+
+# Load helpers (provides read-terraform-module-dirs via helpers_additional.sh)
+source "${GITHUB_ACTION_PATH}/helpers.sh"
+
+function main {
+  local tf_bin="${TF_BIN:-terraform}"
+
+  cd "${input_working_directory}"
+
+  # Where to check?
+  local modules_file="$(pwd)/.terraform/modules/modules.json"
+  local fmt_dirs=()
+  if [ "${input_format_check_in_root_dir}" == 'true' ]; then
+    log-info "check will run from root directory."
+    fmt_dirs=("${GITHUB_WORKSPACE}")
+  elif [ -f "${modules_file}" ]; then
+    log-info "check will run in directories from terraform modules file '$(ws-path "${modules_file}")'"
+    read-terraform-module-dirs fmt_dirs "${modules_file}" "$(pwd)/"
+  else
+    log-info "check will run in 'project-dir' '$(pwd)'"
+    fmt_dirs=("$(pwd)")
+  fi
+
+  # Run check
+  declare -A fmt_results
+  local fmt_dir
+  for fmt_dir in "${fmt_dirs[@]}"; do
+    log-info "running in: '$(ws-path "${fmt_dir}")'"
+
+    # Array-built invocation so a directory path containing a space or a
+    # glob character reaches terraform as exactly one argument.
+    local fmt_cmd=("${tf_bin}" "-chdir=${fmt_dir}" fmt -check -recursive)
+    log-info "command string is '${fmt_cmd[*]@Q}'"
+
+    set +e
+    "${fmt_cmd[@]}"
+    local fmt_exit=${?}
+    fmt_results["${fmt_dir}"]="${fmt_exit}"
+    if [ ! "${fmt_exit}" == "0" ]; then
+      log-error "fmt exited with code '${fmt_exit}'!"
+    fi
+  done
+
+  # Exit code — sum of all per-directory codes, matching the legacy
+  # action's behaviour.
+  local sum_exit_codes=0
+  local v
+  for v in "${fmt_results[@]}"; do
+    sum_exit_codes=$((sum_exit_codes + v))
+  done
+  return ${sum_exit_codes}
+}
+
+main
+_main_exit_code=$?
+exit ${_main_exit_code}

--- a/terraform-fmt/step_fmt.sh
+++ b/terraform-fmt/step_fmt.sh
@@ -16,6 +16,9 @@
 #   input_format_check_in_root_dir - 'true' to check from the repository root.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   TF_BIN - Path to the terraform binary (defaults to 'terraform' on PATH).
 #            Used by tests to inject a stub.
 #
@@ -26,6 +29,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tf_bin="${TF_BIN:-terraform}"
 
   cd "${input_working_directory}"

--- a/terraform-init/action.yml
+++ b/terraform-init/action.yml
@@ -30,6 +30,22 @@ inputs:
       additional-dirs init loop so providers are reused across envs.
     required: false
     default: ""
+  extra-envs-file:
+    description: |
+      Path to a JSON file with environment variables to apply to this action's
+      invocations only, as produced by the 'resolve-goal-envs' action. A JSON
+      null value unsets the variable rather than setting it to the empty
+      string.
+
+      A path rather than a payload so that the values — which may be secrets —
+      never enter argv, envp, or this step's script text.
+
+      The values are applied before this action's own exports, so an action-managed
+      variable set by the step script at runtime (e.g. TF_PLUGIN_CACHE_DIR) wins,
+      while one set in the step's env: block (e.g. TF_IN_AUTOMATION) is overridden
+      by the caller. See docs/Per-goal-environment-variables.md §6.3.
+    required: false
+    default: ""
 outputs:
   console-output-file:
     description: |
@@ -78,6 +94,7 @@ runs:
         input_working_directory: ${{ inputs.working-directory }}
         input_environment_name: ${{ inputs.environment-name }}
         input_plugin_cache_directory: ${{ inputs.plugin-cache-directory }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         # JSON input via heredoc — keeps quotes/special chars intact and
         # out of envp (the ARG_MAX guard pattern from CLAUDE.md).

--- a/terraform-init/helpers_additional.sh
+++ b/terraform-init/helpers_additional.sh
@@ -58,6 +58,18 @@ function apply-extra-envs {
     return 1
   fi
 
+  # How many entries must end up applied. 'length' works on any jq, which is
+  # the point: it is the cross-check that catches a jq too old for
+  # --raw-output0 (ref. docs/Per-goal-environment-variables.md §9.2). Without
+  # it, such a jq makes the read loop consume nothing and the step continues
+  # having applied nothing — silently, and only on the runner images where it
+  # happens to be old.
+  local _extra_envs_expected _extra_envs_applied=0
+  if ! _extra_envs_expected=$(jq -r 'length' "${_extra_envs_file}"); then
+    log-error "unable to count the entries in '${_extra_envs_file}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
     # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
@@ -85,7 +97,15 @@ function apply-extra-envs {
         return 1
       fi
     fi
+    _extra_envs_applied=$((_extra_envs_applied + 1))
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+
+  if [ ! "${_extra_envs_applied}" == "${_extra_envs_expected}" ]; then
+    log-error "applied ${_extra_envs_applied} of ${_extra_envs_expected} environment variable(s) from '${_extra_envs_file}'!"
+    log-error "this usually means jq is older than 1.7 and does not support '--raw-output0' — check the runner image."
+    end-group
+    return 1
+  fi
   end-group
 
   return 0

--- a/terraform-init/helpers_additional.sh
+++ b/terraform-init/helpers_additional.sh
@@ -1,49 +1,8 @@
 #!/bin/env bash
 #
-# Action-specific helpers for terraform-plan.
+# Action-specific helpers for terraform-init.
 # Auto-loaded by helpers.sh.
 #
-
-# Format an integer seconds count as 'mm:ss'.
-# Minutes are zero-padded only to width 1 (so '0:07', '1:23'); seconds are
-# always zero-padded to width 2. Minutes may exceed 99 — CI plans rarely
-# do, but the format degrades gracefully (e.g. '120:05'). No hours field
-# on purpose: keeps the renderer trivial and the display unambiguous.
-function format-duration-mmss {
-  local total="${1:-0}"
-  local minutes=$((total / 60))
-  local seconds=$((total % 60))
-  printf '%d:%02d' "${minutes}" "${seconds}"
-}
-
-# Split a whitespace-delimited argument string into the array named by $1.
-#
-#   $1 - name of the array variable to populate
-#   $2 - the argument string (may be empty, may contain newlines)
-#
-# The 'extra-global-args' / 'extra-plan-args' inputs are documented as strings
-# of arguments the caller injects verbatim, so splitting on whitespace is their
-# contract and is preserved here. What changes is everything around it: the
-# command used to be assembled into one string and then re-split by the shell
-# at invocation time, which also glob-expanded every element against the
-# working directory and turned an empty input into an empty argv element in
-# some shells. Splitting once, here, and invoking as "${cmd[@]}" keeps the
-# caller's words intact while the paths the action itself builds are never
-# split or expanded.
-#
-# Note: quoting inside the argument string is NOT shell-parsed —
-# '-var=msg=a b' is two arguments, not one. Honoring quotes would mean 'eval'
-# or 'xargs', both of which change behaviour for existing callers (an
-# unbalanced apostrophe currently passes through fine and would start failing).
-function split-args-to-array {
-  local -n _args_out="${1}"
-  # Newlines and tabs are whitespace for this purpose too; 'read' without -d
-  # would otherwise stop at the first newline and silently drop the rest.
-  local _str="${2//[$'\n\t']/ }"
-
-  _args_out=()
-  read -r -a _args_out <<<"${_str}"
-}
 
 # Apply a JSON environment-variable map to the current shell
 # ==========================================================

--- a/terraform-init/helpers_additional.sh
+++ b/terraform-init/helpers_additional.sh
@@ -32,7 +32,7 @@ _EXTRA_ENVS_UNSET='__DSB_UNSET__'
 _EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
 
 function apply-extra-envs {
-  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value _extra_envs_type
 
   if [ -z "${_extra_envs_file}" ]; then
     log-info "no per-goal environment variables file configured."
@@ -43,14 +43,47 @@ function apply-extra-envs {
     return 1
   fi
 
+  # Validated before anything is applied. Without this an unparseable, empty or
+  # truncated file applies nothing at all and the step carries on as if it had —
+  # the consequence then surfaces as an OOM or a wrong-credentials error far
+  # from its cause, which is the failure mode this whole feature exists to
+  # avoid. resolve-goal-envs already guarantees a JSON object; this is the last
+  # line of defence, and cheap.
+  if ! _extra_envs_type=$(jq -r 'type' "${_extra_envs_file}" 2>/dev/null); then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' is not valid JSON!"
+    return 1
+  fi
+  if [ ! "${_extra_envs_type}" == 'object' ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' must hold a JSON object, got '${_extra_envs_type:-nothing}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
+    # and the value 'x' it happily assigns 'BAR=x' to FOO — silently setting a
+    # different variable than the caller asked for. Hence the explicit check.
+    if [[ ! "${_extra_envs_key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      log-error "'${_extra_envs_key}' is not a valid environment variable name!"
+      end-group
+      return 1
+    fi
     if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
       log-info "unsetting '${_extra_envs_key}'"
-      unset "${_extra_envs_key}"
+      if ! unset "${_extra_envs_key}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     else
       log-info "setting '${_extra_envs_key}'"
-      export "${_extra_envs_key}=${_extra_envs_value}"
+      # Still guarded: a readonly variable makes 'export' fail even though the
+      # name itself is valid.
+      if ! export "${_extra_envs_key}=${_extra_envs_value}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     fi
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
   end-group

--- a/terraform-init/run_local_step_init.sh
+++ b/terraform-init/run_local_step_init.sh
@@ -36,7 +36,29 @@ export input_environment_name="sandbox"
 export input_additional_dirs_json="[\"${EXTRA_DIR_REL}\"]"
 export input_plugin_cache_directory=""
 
-source "${_this_script_dir}/step_init.sh"
+# Per-goal environment variables, as resolve-goal-envs would produce them.
+# GOMEMLIMIT is set, and a variable that exists job-wide is unset by a JSON null
+# — something $GITHUB_ENV cannot express.
+export DSB_LEAKY_VAR="value-from-the-job"
+export DSB_UNSET_ME="also-from-the-job"
+export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+cat >"${input_extra_envs_file}" <<'EOF'
+{
+  "GOMEMLIMIT": "12GiB",
+  "GOGC": 25,
+  "DSB_LEAKY_VAR": "value-from-the-goal",
+  "DSB_UNSET_ME": null
+}
+EOF
+
+# Subshell: the step script ends in 'exit', which would otherwise
+# terminate this runner before it can show anything. It is also what
+# makes the scoping check below meaningful — the step's exports die
+# with the subshell, exactly as they do when the GitHub step ends.
+( source "${_this_script_dir}/step_init.sh" )
+echo ""
+echo "step exit code: ${?}"
+
 
 echo ""
 echo "========================================"
@@ -49,3 +71,11 @@ echo "Console-output file contents:"
 echo "========================================"
 console_file=$(grep '^tf-init-console-output-file=' "${GITHUB_OUTPUT}" | cut -d= -f2-)
 cat "${console_file}" 2>/dev/null || echo "(missing)"
+
+echo ""
+echo "========================================"
+echo "Scoping check (values must NOT leak out)"
+echo "========================================"
+echo "GOMEMLIMIT after the step:    '${GOMEMLIMIT:-<unset>}'  (expected: <unset>)"
+echo "DSB_LEAKY_VAR after the step: '${DSB_LEAKY_VAR:-<unset>}'  (expected: value-from-the-job)"
+echo "DSB_UNSET_ME after the step:  '${DSB_UNSET_ME:-<unset>}'  (expected: also-from-the-job)"

--- a/terraform-init/run_tests_step_init.sh
+++ b/terraform-init/run_tests_step_init.sh
@@ -500,6 +500,22 @@ assert "negative: the tool was not invoked at all" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_init.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_init.sh SUMMARY            ${NC}"

--- a/terraform-init/run_tests_step_init.sh
+++ b/terraform-init/run_tests_step_init.sh
@@ -440,6 +440,64 @@ assert "T25: and nothing was written to \$GITHUB_ENV" \
   bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_init.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_init.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_init.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_init.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_init.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
+# ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
 echo ""

--- a/terraform-init/run_tests_step_init.sh
+++ b/terraform-init/run_tests_step_init.sh
@@ -38,7 +38,8 @@ setup_workdir() {
   export input_additional_dirs_json="[]"
   export input_plugin_cache_directory=""
 
-  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_ARGV_FILE
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_ARGV_FILE MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 # Installs a stub terraform that records argv and obeys MOCK_TF_EXIT.
@@ -49,6 +50,11 @@ install_stub_terraform() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/terraform" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 if [ -n "${MOCK_TF_ARGV_FILE:-}" ]; then
   # Record argv plus PWD so tests can verify which dir each call ran from.
   printf 'pwd=%s argv=%s\n' "$(pwd)" "$*" >>"${MOCK_TF_ARGV_FILE}"
@@ -224,6 +230,214 @@ run_step
 cf="$(get_output tf-init-console-output-file)"
 assert "Env name: file name embeds environment name" \
   bash -c "[[ '${cf}' == *'tf-init-console-output-my-special-env.txt' ]]"
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_init.txt'"
+
+setup_workdir
+install_stub_terraform
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_init.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_init.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_init.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_init.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_init.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# §6.3 — who wins for an action-managed variable.
+#
+# TF_PLUGIN_CACHE_DIR is exported by this step script at runtime, i.e. AFTER
+# apply-extra-envs has run, so the action wins and a caller cannot accidentally
+# disable provider plugin caching. Asymmetric on purpose: a variable set in the
+# step's env: block (TF_IN_AUTOMATION) is applied before the script runs, so
+# there the caller wins. Documented, not enforced.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+mkdir -p "${GITHUB_WORKSPACE}/extra-dir"
+export input_additional_dirs_json='["extra-dir"]'
+export input_plugin_cache_directory="${RUNNER_TEMP}/action-owned-cache"
+use_extra_envs '{"TF_PLUGIN_CACHE_DIR":"/tmp/caller-owned-cache","TF_IN_AUTOMATION":"false"}'
+run_step
+assert "§6.3: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "§6.3: the action wins for TF_PLUGIN_CACHE_DIR (exported at runtime)" \
+  env_eq TF_PLUGIN_CACHE_DIR "${RUNNER_TEMP}/action-owned-cache"
+assert "§6.3: the caller's TF_IN_AUTOMATION is applied (env: block equivalent)" \
+  env_eq TF_IN_AUTOMATION 'false'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
 # Summary

--- a/terraform-init/step_init.sh
+++ b/terraform-init/step_init.sh
@@ -56,7 +56,15 @@ function main {
   # behaviour: "exit ${TF_INIT_SUM_EXIT_CODES}").
   declare -A TF_INIT_RESULTS
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   # Project init — tee with overwrite ('>' under tee) so re-runs of the
   # step in the same workspace start fresh.

--- a/terraform-init/step_init.sh
+++ b/terraform-init/step_init.sh
@@ -21,6 +21,9 @@
 #                                 array or empty string skips the loop.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   input_environment_name      - Used in the console-file name. Defaults
 #                                 to empty (file becomes
 #                                 'tf-init-console-output-.txt' — ugly but
@@ -39,6 +42,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tf_bin="${TF_BIN:-terraform}"
 
   local console_file="${GITHUB_WORKSPACE}/tf-init-console-output-${input_environment_name}.txt"

--- a/terraform-plan/action.yml
+++ b/terraform-plan/action.yml
@@ -26,6 +26,22 @@ inputs:
       Boolean as tring, if 'true' the action will exit with a non-zero exit code.
     required: false
     default: "true"
+  extra-envs-file:
+    description: |
+      Path to a JSON file with environment variables to apply to this action's
+      invocations only, as produced by the 'resolve-goal-envs' action. A JSON
+      null value unsets the variable rather than setting it to the empty
+      string.
+
+      A path rather than a payload so that the values — which may be secrets —
+      never enter argv, envp, or this step's script text.
+
+      The values are applied before this action's own exports, so an action-managed
+      variable set by the step script at runtime (e.g. TF_PLUGIN_CACHE_DIR) wins,
+      while one set in the step's env: block (e.g. TF_IN_AUTOMATION) is overridden
+      by the caller. See docs/Per-goal-environment-variables.md §6.3.
+    required: false
+    default: ""
 outputs:
   exitcode:
     description: |
@@ -74,6 +90,7 @@ runs:
         input_environment_name: ${{ inputs.environment-name }}
         input_extra_global_args: ${{ inputs.extra-global-args }}
         input_extra_plan_args: ${{ inputs.extra-plan-args }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         set -o allexport
         source "${{ github.action_path }}/step_plan.sh"
@@ -92,6 +109,7 @@ runs:
         input_working_directory: ${{ inputs.working-directory }}
         input_environment_name: ${{ inputs.environment-name }}
         input_plan_tf_output_file: ${{ steps.plan.outputs.tf-plan-tf-output-file }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         set -o allexport
         source "${{ github.action_path }}/step_plan_show.sh"
@@ -103,6 +121,7 @@ runs:
         input_working_directory: ${{ inputs.working-directory }}
         input_environment_name: ${{ inputs.environment-name }}
         input_plan_tf_output_file: ${{ steps.plan.outputs.tf-plan-tf-output-file }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         set -o allexport
         source "${{ github.action_path }}/step_plan_json.sh"

--- a/terraform-plan/helpers_additional.sh
+++ b/terraform-plan/helpers_additional.sh
@@ -99,6 +99,18 @@ function apply-extra-envs {
     return 1
   fi
 
+  # How many entries must end up applied. 'length' works on any jq, which is
+  # the point: it is the cross-check that catches a jq too old for
+  # --raw-output0 (ref. docs/Per-goal-environment-variables.md §9.2). Without
+  # it, such a jq makes the read loop consume nothing and the step continues
+  # having applied nothing — silently, and only on the runner images where it
+  # happens to be old.
+  local _extra_envs_expected _extra_envs_applied=0
+  if ! _extra_envs_expected=$(jq -r 'length' "${_extra_envs_file}"); then
+    log-error "unable to count the entries in '${_extra_envs_file}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
     # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
@@ -126,7 +138,15 @@ function apply-extra-envs {
         return 1
       fi
     fi
+    _extra_envs_applied=$((_extra_envs_applied + 1))
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+
+  if [ ! "${_extra_envs_applied}" == "${_extra_envs_expected}" ]; then
+    log-error "applied ${_extra_envs_applied} of ${_extra_envs_expected} environment variable(s) from '${_extra_envs_file}'!"
+    log-error "this usually means jq is older than 1.7 and does not support '--raw-output0' — check the runner image."
+    end-group
+    return 1
+  fi
   end-group
 
   return 0

--- a/terraform-plan/helpers_additional.sh
+++ b/terraform-plan/helpers_additional.sh
@@ -15,3 +15,32 @@ function format-duration-mmss {
   local seconds=$((total % 60))
   printf '%d:%02d' "${minutes}" "${seconds}"
 }
+
+# Split a whitespace-delimited argument string into the array named by $1.
+#
+#   $1 - name of the array variable to populate
+#   $2 - the argument string (may be empty, may contain newlines)
+#
+# The 'extra-global-args' / 'extra-plan-args' inputs are documented as strings
+# of arguments the caller injects verbatim, so splitting on whitespace is their
+# contract and is preserved here. What changes is everything around it: the
+# command used to be assembled into one string and then re-split by the shell
+# at invocation time, which also glob-expanded every element against the
+# working directory and turned an empty input into an empty argv element in
+# some shells. Splitting once, here, and invoking as "${cmd[@]}" keeps the
+# caller's words intact while the paths the action itself builds are never
+# split or expanded.
+#
+# Note: quoting inside the argument string is NOT shell-parsed —
+# '-var=msg=a b' is two arguments, not one. Honoring quotes would mean 'eval'
+# or 'xargs', both of which change behaviour for existing callers (an
+# unbalanced apostrophe currently passes through fine and would start failing).
+function split-args-to-array {
+  local -n _args_out="${1}"
+  # Newlines and tabs are whitespace for this purpose too; 'read' without -d
+  # would otherwise stop at the first newline and silently drop the rest.
+  local _str="${2//[$'\n\t']/ }"
+
+  _args_out=()
+  read -r -a _args_out <<<"${_str}"
+}

--- a/terraform-plan/helpers_additional.sh
+++ b/terraform-plan/helpers_additional.sh
@@ -73,7 +73,7 @@ _EXTRA_ENVS_UNSET='__DSB_UNSET__'
 _EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
 
 function apply-extra-envs {
-  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value _extra_envs_type
 
   if [ -z "${_extra_envs_file}" ]; then
     log-info "no per-goal environment variables file configured."
@@ -84,14 +84,47 @@ function apply-extra-envs {
     return 1
   fi
 
+  # Validated before anything is applied. Without this an unparseable, empty or
+  # truncated file applies nothing at all and the step carries on as if it had —
+  # the consequence then surfaces as an OOM or a wrong-credentials error far
+  # from its cause, which is the failure mode this whole feature exists to
+  # avoid. resolve-goal-envs already guarantees a JSON object; this is the last
+  # line of defence, and cheap.
+  if ! _extra_envs_type=$(jq -r 'type' "${_extra_envs_file}" 2>/dev/null); then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' is not valid JSON!"
+    return 1
+  fi
+  if [ ! "${_extra_envs_type}" == 'object' ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' must hold a JSON object, got '${_extra_envs_type:-nothing}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
+    # and the value 'x' it happily assigns 'BAR=x' to FOO — silently setting a
+    # different variable than the caller asked for. Hence the explicit check.
+    if [[ ! "${_extra_envs_key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      log-error "'${_extra_envs_key}' is not a valid environment variable name!"
+      end-group
+      return 1
+    fi
     if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
       log-info "unsetting '${_extra_envs_key}'"
-      unset "${_extra_envs_key}"
+      if ! unset "${_extra_envs_key}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     else
       log-info "setting '${_extra_envs_key}'"
-      export "${_extra_envs_key}=${_extra_envs_value}"
+      # Still guarded: a readonly variable makes 'export' fail even though the
+      # name itself is valid.
+      if ! export "${_extra_envs_key}=${_extra_envs_value}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     fi
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
   end-group

--- a/terraform-plan/run_local_step_plan.sh
+++ b/terraform-plan/run_local_step_plan.sh
@@ -34,10 +34,40 @@ export input_environment_name="sandbox"
 export input_extra_global_args=""
 export input_extra_plan_args=""
 
-source "${_this_script_dir}/step_plan.sh"
+# Per-goal environment variables, as resolve-goal-envs would produce them.
+# GOMEMLIMIT is set, and a variable that exists job-wide is unset by a JSON null
+# — something $GITHUB_ENV cannot express.
+export DSB_LEAKY_VAR="value-from-the-job"
+export DSB_UNSET_ME="also-from-the-job"
+export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+cat >"${input_extra_envs_file}" <<'EOF'
+{
+  "GOMEMLIMIT": "12GiB",
+  "GOGC": 25,
+  "DSB_LEAKY_VAR": "value-from-the-goal",
+  "DSB_UNSET_ME": null
+}
+EOF
+
+# Subshell: the step script ends in 'exit', which would otherwise
+# terminate this runner before it can show anything. It is also what
+# makes the scoping check below meaningful — the step's exports die
+# with the subshell, exactly as they do when the GitHub step ends.
+( source "${_this_script_dir}/step_plan.sh" )
+echo ""
+echo "step exit code: ${?}"
+
 
 echo ""
 echo "========================================"
 echo "GitHub Actions Outputs (GITHUB_OUTPUT):"
 echo "========================================"
 cat "${GITHUB_OUTPUT}"
+
+echo ""
+echo "========================================"
+echo "Scoping check (values must NOT leak out)"
+echo "========================================"
+echo "GOMEMLIMIT after the step:    '${GOMEMLIMIT:-<unset>}'  (expected: <unset>)"
+echo "DSB_LEAKY_VAR after the step: '${DSB_LEAKY_VAR:-<unset>}'  (expected: value-from-the-job)"
+echo "DSB_UNSET_ME after the step:  '${DSB_UNSET_ME:-<unset>}'  (expected: also-from-the-job)"

--- a/terraform-plan/run_tests_step_plan.sh
+++ b/terraform-plan/run_tests_step_plan.sh
@@ -40,14 +40,34 @@ setup_workdir() {
   export input_extra_global_args=""
   export input_extra_plan_args=""
 
-  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_SLEEP MOCK_TF_ARGV_FILE
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_SLEEP MOCK_TF_ARGV_FILE MOCK_TF_ARGS_FILE
 }
+
+# Enable one-argument-per-line recording for the next run_step.
+record_args() {
+  export MOCK_TF_ARGS_FILE="${RUNNER_TEMP}/tf-args.txt"
+  : >"${MOCK_TF_ARGS_FILE}"
+}
+
+# Argument count as recorded by the stub.
+argc() { sed -n 's/^INVOCATION //p' "${MOCK_TF_ARGS_FILE}" | head -n1; }
+
+# Nth recorded argument (1-based).
+argn() { sed -n "$((${1} + 1))p" "${MOCK_TF_ARGS_FILE}"; }
+
+# Whether any recorded argument equals the given string exactly.
+has_arg() { grep -Fxq -- "${1}" "${MOCK_TF_ARGS_FILE}"; }
 
 # Install a stub 'terraform' binary configurable per-test via env vars.
 # Captures argv to MOCK_TF_ARGV_FILE if that variable is set when the
 # stub is invoked. Path is exported as TF_BIN so step_plan.sh picks it
 # up without needing to alter PATH (the legacy action shells out to bare
 # 'terraform'; the script reads TF_BIN to allow this seam).
+#
+# MOCK_TF_ARGS_FILE records the same invocation one argument per line,
+# preceded by the argument count. That is what makes the array-built
+# invocation assertions possible: MOCK_TF_ARGV_FILE joins argv with spaces,
+# so it cannot tell one argument containing a space from two arguments.
 install_stub_terraform() {
   local stub_dir="${RUNNER_TEMP}/stub-bin"
   mkdir -p "${stub_dir}"
@@ -56,6 +76,11 @@ install_stub_terraform() {
 # Recorded argv (one line per invocation)
 if [ -n "${MOCK_TF_ARGV_FILE:-}" ]; then
   printf '%s\n' "$*" >>"${MOCK_TF_ARGV_FILE}"
+fi
+# Recorded argv, one element per line, preceded by the argument count
+if [ -n "${MOCK_TF_ARGS_FILE:-}" ]; then
+  printf 'INVOCATION %s\n' "${#}" >>"${MOCK_TF_ARGS_FILE}"
+  printf '%s\n' "${@}" >>"${MOCK_TF_ARGS_FILE}"
 fi
 if [ -n "${MOCK_TF_STDOUT:-}" ]; then
   printf '%s\n' "${MOCK_TF_STDOUT}"
@@ -272,6 +297,79 @@ assert "argv: plan flags from script present" \
   bash -c "[[ '${argv_line}' == *'-detailed-exitcode'* && '${argv_line}' == *'-input=false'* && '${argv_line}' == *'-no-color'* ]]"
 assert "argv: plan args appear after the -out flag" \
   bash -c "[[ '${argv_line}' == *'-var foo=bar -var baz=qux' ]]"
+
+# ----------------------------------------------------------------------
+# Test: the -out path this script builds reaches terraform as ONE argv
+# element even when the environment name puts a space in it. Regression
+# guard for the string-built invocation this step used to have — see
+# docs/Per-goal-environment-variables.md §6.5.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_args
+export MOCK_TF_EXIT=0
+export input_environment_name="env with spaces"
+run_step
+assert "Space in -out: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "Space in -out: exactly 5 arguments (no word-splitting)" \
+  test "$(argc)" -eq 5
+assert "Space in -out: -out arrives as one argument, verbatim" \
+  has_arg "-out=${GITHUB_WORKSPACE}/tf-plan-env with spaces.plan"
+
+# ----------------------------------------------------------------------
+# Test: an extra arg containing a glob character is not expanded against
+# the working directory
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_args
+# Files the glob would match if expansion happened.
+touch "${WORK_DIR}/decoy-a.tf" "${WORK_DIR}/decoy-b.tf"
+export MOCK_TF_EXIT=0
+export input_extra_plan_args="-var=pattern=*.tf"
+run_step
+assert "Glob in extra args: arrives unexpanded" \
+  has_arg "-var=pattern=*.tf"
+assert "Glob in extra args: exactly 6 arguments (not one per match)" \
+  test "$(argc)" -eq 6
+
+# ----------------------------------------------------------------------
+# Test: empty extra-global-args / extra-plan-args produce no empty argv
+# element
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_args
+export MOCK_TF_EXIT=0
+export input_extra_global_args=""
+export input_extra_plan_args=""
+run_step
+assert "Empty extra args: exactly 5 arguments" test "$(argc)" -eq 5
+assert "Empty extra args: first argument is 'plan'" test "$(argn 1)" = "plan"
+assert "Empty extra args: no empty argv element" \
+  bash -c "! grep -q '^\$' '${MOCK_TF_ARGS_FILE}'"
+
+# ----------------------------------------------------------------------
+# Test: whitespace-only / multi-line extra args are split into real
+# arguments and contribute no empty elements
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_args
+export MOCK_TF_EXIT=0
+export input_extra_global_args="   "
+export input_extra_plan_args=$'-refresh=false\n  -lock=false   -parallelism=5'
+run_step
+assert "Whitespace extra args: whitespace-only global args add nothing" \
+  test "$(argn 1)" = "plan"
+assert "Whitespace extra args: 8 arguments (5 + 3 plan args)" \
+  test "$(argc)" -eq 8
+assert "Whitespace extra args: newline-separated arg is picked up" \
+  has_arg "-refresh=false"
+assert "Whitespace extra args: arg after the newline is picked up" \
+  has_arg "-lock=false"
+assert "Whitespace extra args: run of spaces collapses" \
+  has_arg "-parallelism=5"
 
 # ----------------------------------------------------------------------
 # Summary

--- a/terraform-plan/run_tests_step_plan.sh
+++ b/terraform-plan/run_tests_step_plan.sh
@@ -40,7 +40,8 @@ setup_workdir() {
   export input_extra_global_args=""
   export input_extra_plan_args=""
 
-  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_SLEEP MOCK_TF_ARGV_FILE MOCK_TF_ARGS_FILE
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_TF_SLEEP MOCK_TF_ARGV_FILE MOCK_TF_ARGS_FILE MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 # Enable one-argument-per-line recording for the next run_step.
@@ -73,6 +74,11 @@ install_stub_terraform() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/terraform" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 # Recorded argv (one line per invocation)
 if [ -n "${MOCK_TF_ARGV_FILE:-}" ]; then
   printf '%s\n' "$*" >>"${MOCK_TF_ARGV_FILE}"
@@ -370,6 +376,191 @@ assert "Whitespace extra args: arg after the newline is picked up" \
   has_arg "-lock=false"
 assert "Whitespace extra args: run of spaces collapses" \
   has_arg "-parallelism=5"
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_plan.txt'"
+
+setup_workdir
+install_stub_terraform
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_plan.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_plan.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_plan.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_plan.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_plan.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
 # Summary

--- a/terraform-plan/run_tests_step_plan.sh
+++ b/terraform-plan/run_tests_step_plan.sh
@@ -623,6 +623,22 @@ assert "negative: the tool was not invoked at all" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_plan.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}            step_plan.sh SUMMARY            ${NC}"

--- a/terraform-plan/run_tests_step_plan.sh
+++ b/terraform-plan/run_tests_step_plan.sh
@@ -563,6 +563,64 @@ assert "T25: and nothing was written to \$GITHUB_ENV" \
   bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_plan.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_plan.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_plan.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_plan.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_plan.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
+# ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
 echo ""

--- a/terraform-plan/run_tests_step_plan_json.sh
+++ b/terraform-plan/run_tests_step_plan_json.sh
@@ -31,7 +31,8 @@ setup_workdir() {
   export input_environment_name="testenv"
   export input_plan_tf_output_file="${RUNNER_TEMP}/fake-plan.bin"
 
-  unset MOCK_TF_EXIT MOCK_TF_STDOUT
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 install_stub_terraform() {
@@ -39,6 +40,11 @@ install_stub_terraform() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/terraform" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 if [ -n "${MOCK_TF_STDOUT:-}" ]; then
   printf '%s' "${MOCK_TF_STDOUT}"
 fi
@@ -103,6 +109,191 @@ assert "json output file contains stub output verbatim" \
 assert "json output is valid JSON" \
   bash -c "python3 -c 'import json,sys; json.load(open(\"${json_file}\"))'"
 assert "step exits 0 on happy path" test "${LAST_EXIT}" -eq 0
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_json.txt'"
+
+setup_workdir
+install_stub_terraform
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_json.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_json.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_json.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_json.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_json.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 echo ""
 echo -e "${YELLOW}============================================${NC}"

--- a/terraform-plan/run_tests_step_plan_json.sh
+++ b/terraform-plan/run_tests_step_plan_json.sh
@@ -295,6 +295,64 @@ assert "T25: it did not leak into the surrounding shell" \
 assert "T25: and nothing was written to \$GITHUB_ENV" \
   bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
+# ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_json.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_json.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_json.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_json.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_json.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}         step_plan_json.sh SUMMARY          ${NC}"

--- a/terraform-plan/run_tests_step_plan_json.sh
+++ b/terraform-plan/run_tests_step_plan_json.sh
@@ -353,6 +353,22 @@ assert "negative: it is rejected as a name, not silently reinterpreted" \
 assert "negative: the tool was not invoked at all" \
   bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
 
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_json.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}         step_plan_json.sh SUMMARY          ${NC}"

--- a/terraform-plan/run_tests_step_plan_show.sh
+++ b/terraform-plan/run_tests_step_plan_show.sh
@@ -372,6 +372,22 @@ assert "negative: it is rejected as a name, not silently reinterpreted" \
 assert "negative: the tool was not invoked at all" \
   bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
 
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_show.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}         step_plan_show.sh SUMMARY          ${NC}"

--- a/terraform-plan/run_tests_step_plan_show.sh
+++ b/terraform-plan/run_tests_step_plan_show.sh
@@ -31,7 +31,8 @@ setup_workdir() {
   export input_environment_name="testenv"
   export input_plan_tf_output_file="${RUNNER_TEMP}/fake-plan.bin"
 
-  unset MOCK_TF_EXIT MOCK_TF_STDOUT
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 install_stub_terraform() {
@@ -39,6 +40,11 @@ install_stub_terraform() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/terraform" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 if [ -n "${MOCK_TF_STDOUT:-}" ]; then
   printf '%s\n' "${MOCK_TF_STDOUT}"
 fi
@@ -122,6 +128,191 @@ assert "txt output file path still published on failure" \
   test -n "${txt_file}"
 assert "txt output file contains the error text from stub stdout" \
   grep -q "Error rendering plan" "${txt_file}"
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_show.txt'"
+
+setup_workdir
+install_stub_terraform
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_show.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_show.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_show.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_show.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_show.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 echo ""
 echo -e "${YELLOW}============================================${NC}"

--- a/terraform-plan/run_tests_step_plan_show.sh
+++ b/terraform-plan/run_tests_step_plan_show.sh
@@ -314,6 +314,64 @@ assert "T25: it did not leak into the surrounding shell" \
 assert "T25: and nothing was written to \$GITHUB_ENV" \
   bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
+# ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_show.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_show.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_show.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_show.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_show.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}         step_plan_show.sh SUMMARY          ${NC}"

--- a/terraform-plan/step_plan.sh
+++ b/terraform-plan/step_plan.sh
@@ -30,6 +30,9 @@
 #   input_extra_plan_args     - Args after the 'plan' subcommand.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   TF_BIN - Path to the terraform binary (defaults to 'terraform' on PATH).
 #            Used by tests to inject a stub.
 #
@@ -40,6 +43,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tf_bin="${TF_BIN:-terraform}"
 
   cd "${input_working_directory}"

--- a/terraform-plan/step_plan.sh
+++ b/terraform-plan/step_plan.sh
@@ -49,10 +49,21 @@ function main {
   set-output 'tf-plan-console-output-file' "${plan_console_out_file}"
   set-output 'tf-plan-tf-output-file' "${plan_tf_out_file}"
 
-  # Build the command. Quote-light to match the legacy action's behavior:
-  # extra-* args are space-delimited strings that the user injects verbatim.
-  local plan_cmd="${tf_bin} ${input_extra_global_args} plan -detailed-exitcode -input=false -no-color -out=${plan_tf_out_file} ${input_extra_plan_args}"
-  log-info "command string is '${plan_cmd}'"
+  # Build the command as an array and invoke it as "${plan_cmd[@]}". The
+  # extra-* args are still whitespace-split (that is their documented
+  # contract, see split-args-to-array), but the paths this script builds —
+  # notably -out= — are no longer word-split or glob-expanded on the way to
+  # terraform.
+  local extra_global_args=() extra_plan_args=()
+  split-args-to-array extra_global_args "${input_extra_global_args}"
+  split-args-to-array extra_plan_args "${input_extra_plan_args}"
+
+  local plan_cmd=("${tf_bin}")
+  plan_cmd+=("${extra_global_args[@]}")
+  plan_cmd+=(plan -detailed-exitcode -input=false -no-color "-out=${plan_tf_out_file}")
+  plan_cmd+=("${extra_plan_args[@]}")
+
+  log-info "command string is '${plan_cmd[*]@Q}'"
   start-group "'terraform plan' in '$(ws-path "$(pwd)")'"
 
   # Needed to properly catch terraform's exit code through the pipe to tee.
@@ -67,7 +78,7 @@ function main {
   # wall-clock time spent inside terraform plan (plus the trivial overhead
   # of the surrounding shell, which is below mm:ss granularity).
   local plan_start=${SECONDS}
-  ${plan_cmd} 2>&1 | tee "${plan_console_out_file}"
+  "${plan_cmd[@]}" 2>&1 | tee "${plan_console_out_file}"
   local plan_exit_code=${?}
   local plan_duration=$((SECONDS - plan_start))
 

--- a/terraform-plan/step_plan.sh
+++ b/terraform-plan/step_plan.sh
@@ -49,7 +49,15 @@ function main {
 
   local tf_bin="${TF_BIN:-terraform}"
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   local plan_console_out_file="${GITHUB_WORKSPACE}/tf-plan-console-output-${input_environment_name}.txt"
   local plan_tf_out_file="${GITHUB_WORKSPACE}/tf-plan-${input_environment_name}.plan"

--- a/terraform-plan/step_plan_json.sh
+++ b/terraform-plan/step_plan_json.sh
@@ -14,6 +14,9 @@
 #   input_plan_tf_output_file - the binary plan file produced by step_plan.sh.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   TF_BIN - Path to terraform binary (defaults to 'terraform' on PATH).
 #
 
@@ -22,6 +25,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tf_bin="${TF_BIN:-terraform}"
 
   cd "${input_working_directory}"

--- a/terraform-plan/step_plan_json.sh
+++ b/terraform-plan/step_plan_json.sh
@@ -31,7 +31,15 @@ function main {
 
   local tf_bin="${TF_BIN:-terraform}"
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   start-group "output the plan as json"
   local plan_tf_out_file="${input_plan_tf_output_file}"

--- a/terraform-plan/step_plan_show.sh
+++ b/terraform-plan/step_plan_show.sh
@@ -14,6 +14,9 @@
 #   input_plan_tf_output_file - the binary plan file produced by step_plan.sh.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   TF_BIN - Path to terraform binary (defaults to 'terraform' on PATH).
 #
 
@@ -22,6 +25,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tf_bin="${TF_BIN:-terraform}"
 
   cd "${input_working_directory}"

--- a/terraform-plan/step_plan_show.sh
+++ b/terraform-plan/step_plan_show.sh
@@ -31,7 +31,15 @@ function main {
 
   local tf_bin="${TF_BIN:-terraform}"
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   start-group "output the plan as txt"
   local plan_tf_out_file="${input_plan_tf_output_file}"

--- a/terraform-validate/action.yml
+++ b/terraform-validate/action.yml
@@ -14,6 +14,22 @@ inputs:
       console-output file ('tf-validate-console-output-<env>.txt').
     required: false
     default: ""
+  extra-envs-file:
+    description: |
+      Path to a JSON file with environment variables to apply to this action's
+      invocations only, as produced by the 'resolve-goal-envs' action. A JSON
+      null value unsets the variable rather than setting it to the empty
+      string.
+
+      A path rather than a payload so that the values — which may be secrets —
+      never enter argv, envp, or this step's script text.
+
+      The values are applied before this action's own exports, so an action-managed
+      variable set by the step script at runtime (e.g. TF_PLUGIN_CACHE_DIR) wins,
+      while one set in the step's env: block (e.g. TF_IN_AUTOMATION) is overridden
+      by the caller. See docs/Per-goal-environment-variables.md §6.3.
+    required: false
+    default: ""
 outputs:
   console-output-file:
     description: |
@@ -44,6 +60,7 @@ runs:
       env:
         input_working_directory: ${{ inputs.working-directory }}
         input_environment_name: ${{ inputs.environment-name }}
+        input_extra_envs_file: ${{ inputs.extra-envs-file }}
       run: |
         set -o allexport
         source "${{ github.action_path }}/step_validate.sh"

--- a/terraform-validate/helpers_additional.sh
+++ b/terraform-validate/helpers_additional.sh
@@ -1,49 +1,8 @@
 #!/bin/env bash
 #
-# Action-specific helpers for terraform-plan.
+# Action-specific helpers for terraform-validate.
 # Auto-loaded by helpers.sh.
 #
-
-# Format an integer seconds count as 'mm:ss'.
-# Minutes are zero-padded only to width 1 (so '0:07', '1:23'); seconds are
-# always zero-padded to width 2. Minutes may exceed 99 — CI plans rarely
-# do, but the format degrades gracefully (e.g. '120:05'). No hours field
-# on purpose: keeps the renderer trivial and the display unambiguous.
-function format-duration-mmss {
-  local total="${1:-0}"
-  local minutes=$((total / 60))
-  local seconds=$((total % 60))
-  printf '%d:%02d' "${minutes}" "${seconds}"
-}
-
-# Split a whitespace-delimited argument string into the array named by $1.
-#
-#   $1 - name of the array variable to populate
-#   $2 - the argument string (may be empty, may contain newlines)
-#
-# The 'extra-global-args' / 'extra-plan-args' inputs are documented as strings
-# of arguments the caller injects verbatim, so splitting on whitespace is their
-# contract and is preserved here. What changes is everything around it: the
-# command used to be assembled into one string and then re-split by the shell
-# at invocation time, which also glob-expanded every element against the
-# working directory and turned an empty input into an empty argv element in
-# some shells. Splitting once, here, and invoking as "${cmd[@]}" keeps the
-# caller's words intact while the paths the action itself builds are never
-# split or expanded.
-#
-# Note: quoting inside the argument string is NOT shell-parsed —
-# '-var=msg=a b' is two arguments, not one. Honoring quotes would mean 'eval'
-# or 'xargs', both of which change behaviour for existing callers (an
-# unbalanced apostrophe currently passes through fine and would start failing).
-function split-args-to-array {
-  local -n _args_out="${1}"
-  # Newlines and tabs are whitespace for this purpose too; 'read' without -d
-  # would otherwise stop at the first newline and silently drop the rest.
-  local _str="${2//[$'\n\t']/ }"
-
-  _args_out=()
-  read -r -a _args_out <<<"${_str}"
-}
 
 # Apply a JSON environment-variable map to the current shell
 # ==========================================================

--- a/terraform-validate/helpers_additional.sh
+++ b/terraform-validate/helpers_additional.sh
@@ -58,6 +58,18 @@ function apply-extra-envs {
     return 1
   fi
 
+  # How many entries must end up applied. 'length' works on any jq, which is
+  # the point: it is the cross-check that catches a jq too old for
+  # --raw-output0 (ref. docs/Per-goal-environment-variables.md §9.2). Without
+  # it, such a jq makes the read loop consume nothing and the step continues
+  # having applied nothing — silently, and only on the runner images where it
+  # happens to be old.
+  local _extra_envs_expected _extra_envs_applied=0
+  if ! _extra_envs_expected=$(jq -r 'length' "${_extra_envs_file}"); then
+    log-error "unable to count the entries in '${_extra_envs_file}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
     # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
@@ -85,7 +97,15 @@ function apply-extra-envs {
         return 1
       fi
     fi
+    _extra_envs_applied=$((_extra_envs_applied + 1))
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
+
+  if [ ! "${_extra_envs_applied}" == "${_extra_envs_expected}" ]; then
+    log-error "applied ${_extra_envs_applied} of ${_extra_envs_expected} environment variable(s) from '${_extra_envs_file}'!"
+    log-error "this usually means jq is older than 1.7 and does not support '--raw-output0' — check the runner image."
+    end-group
+    return 1
+  fi
   end-group
 
   return 0

--- a/terraform-validate/helpers_additional.sh
+++ b/terraform-validate/helpers_additional.sh
@@ -32,7 +32,7 @@ _EXTRA_ENVS_UNSET='__DSB_UNSET__'
 _EXTRA_ENVS_FILTER='to_entries[] | (.key, (if .value == null then "__DSB_UNSET__" else (.value | tostring) end))'
 
 function apply-extra-envs {
-  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value
+  local _extra_envs_file="${1}" _extra_envs_key _extra_envs_value _extra_envs_type
 
   if [ -z "${_extra_envs_file}" ]; then
     log-info "no per-goal environment variables file configured."
@@ -43,14 +43,47 @@ function apply-extra-envs {
     return 1
   fi
 
+  # Validated before anything is applied. Without this an unparseable, empty or
+  # truncated file applies nothing at all and the step carries on as if it had —
+  # the consequence then surfaces as an OOM or a wrong-credentials error far
+  # from its cause, which is the failure mode this whole feature exists to
+  # avoid. resolve-goal-envs already guarantees a JSON object; this is the last
+  # line of defence, and cheap.
+  if ! _extra_envs_type=$(jq -r 'type' "${_extra_envs_file}" 2>/dev/null); then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' is not valid JSON!"
+    return 1
+  fi
+  if [ ! "${_extra_envs_type}" == 'object' ]; then
+    log-error "the per-goal environment variables file '${_extra_envs_file}' must hold a JSON object, got '${_extra_envs_type:-nothing}'!"
+    return 1
+  fi
+
   start-group "applying per-goal environment variables"
   while IFS= read -r -d '' _extra_envs_key && IFS= read -r -d '' _extra_envs_value; do
+    # 'export' cannot be relied on to reject a bad name: given the key 'FOO=BAR'
+    # and the value 'x' it happily assigns 'BAR=x' to FOO — silently setting a
+    # different variable than the caller asked for. Hence the explicit check.
+    if [[ ! "${_extra_envs_key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      log-error "'${_extra_envs_key}' is not a valid environment variable name!"
+      end-group
+      return 1
+    fi
     if [ "${_extra_envs_value}" == "${_EXTRA_ENVS_UNSET}" ]; then
       log-info "unsetting '${_extra_envs_key}'"
-      unset "${_extra_envs_key}"
+      if ! unset "${_extra_envs_key}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     else
       log-info "setting '${_extra_envs_key}'"
-      export "${_extra_envs_key}=${_extra_envs_value}"
+      # Still guarded: a readonly variable makes 'export' fail even though the
+      # name itself is valid.
+      if ! export "${_extra_envs_key}=${_extra_envs_value}"; then
+        log-error "'${_extra_envs_key}' is not a usable environment variable name!"
+        end-group
+        return 1
+      fi
     fi
   done < <(jq --raw-output0 "${_EXTRA_ENVS_FILTER}" "${_extra_envs_file}")
   end-group

--- a/terraform-validate/run_local_step_validate.sh
+++ b/terraform-validate/run_local_step_validate.sh
@@ -28,7 +28,29 @@ export TF_BIN="${STUB_DIR}/terraform"
 export input_working_directory="${WORK_DIR}"
 export input_environment_name="sandbox"
 
-source "${_this_script_dir}/step_validate.sh"
+# Per-goal environment variables, as resolve-goal-envs would produce them.
+# GOMEMLIMIT is set, and a variable that exists job-wide is unset by a JSON null
+# — something $GITHUB_ENV cannot express.
+export DSB_LEAKY_VAR="value-from-the-job"
+export DSB_UNSET_ME="also-from-the-job"
+export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+cat >"${input_extra_envs_file}" <<'EOF'
+{
+  "GOMEMLIMIT": "12GiB",
+  "GOGC": 25,
+  "DSB_LEAKY_VAR": "value-from-the-goal",
+  "DSB_UNSET_ME": null
+}
+EOF
+
+# Subshell: the step script ends in 'exit', which would otherwise
+# terminate this runner before it can show anything. It is also what
+# makes the scoping check below meaningful — the step's exports die
+# with the subshell, exactly as they do when the GitHub step ends.
+( source "${_this_script_dir}/step_validate.sh" )
+echo ""
+echo "step exit code: ${?}"
+
 
 echo ""
 echo "========================================"
@@ -41,3 +63,11 @@ echo "Console-output file contents:"
 echo "========================================"
 console_file=$(grep '^tf-validate-console-output-file=' "${GITHUB_OUTPUT}" | cut -d= -f2-)
 cat "${console_file}" 2>/dev/null || echo "(missing)"
+
+echo ""
+echo "========================================"
+echo "Scoping check (values must NOT leak out)"
+echo "========================================"
+echo "GOMEMLIMIT after the step:    '${GOMEMLIMIT:-<unset>}'  (expected: <unset>)"
+echo "DSB_LEAKY_VAR after the step: '${DSB_LEAKY_VAR:-<unset>}'  (expected: value-from-the-job)"
+echo "DSB_UNSET_ME after the step:  '${DSB_UNSET_ME:-<unset>}'  (expected: also-from-the-job)"

--- a/terraform-validate/run_tests_step_validate.sh
+++ b/terraform-validate/run_tests_step_validate.sh
@@ -378,6 +378,22 @@ assert "negative: the tool was not invoked at all" \
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# A working directory that cannot be entered must fail the step. Unguarded,
+# 'cd' failing left the step running in whatever directory it was invoked
+# from — i.e. operating on the wrong tree.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export input_working_directory="${RUNNER_TEMP}/no-such-project-dir"
+run_step
+assert "negative: a missing working directory fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the directory" \
+  grep -q 'could not be entered' '/tmp/test_output_validate.txt'
+assert "negative: the tool was never invoked" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
 echo ""
 echo -e "${YELLOW}============================================${NC}"
 echo -e "${YELLOW}          step_validate.sh SUMMARY          ${NC}"

--- a/terraform-validate/run_tests_step_validate.sh
+++ b/terraform-validate/run_tests_step_validate.sh
@@ -318,6 +318,64 @@ assert "T25: and nothing was written to \$GITHUB_ENV" \
   bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
+# An unusable file must fail the step, not be silently skipped. A file that
+# applies nothing while the step carries on as if it had is the failure mode
+# this whole feature exists to avoid: the consequence surfaces as an OOM or a
+# wrong-credentials error far from its cause.
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{ this is not json'
+run_step
+assert "negative: unparseable JSON fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says it is not valid JSON" \
+  grep -q 'is not valid JSON' '/tmp/test_output_validate.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs ''
+run_step
+assert "negative: an empty file fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error says an object was expected" \
+  grep -q 'must hold a JSON object' '/tmp/test_output_validate.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '["not","an","object"]'
+run_step
+assert "negative: a JSON array fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the type found" \
+  grep -q "got 'array'" '/tmp/test_output_validate.txt'
+
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO BAR":"x"}'
+run_step
+assert "negative: a variable name with a space fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: the error names the offending key" \
+  grep -q "'FOO BAR' is not a valid environment variable name" '/tmp/test_output_validate.txt'
+
+# 'export FOO=BAR=x' would otherwise assign 'BAR=x' to FOO — a different
+# variable than the caller asked for, silently.
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"FOO=BAR":"x"}'
+run_step
+assert "negative: a variable name containing '=' fails the step" test "${LAST_EXIT}" -ne 0
+assert "negative: it is rejected as a name, not silently reinterpreted" \
+  grep -q "'FOO=BAR' is not a valid environment variable name" '/tmp/test_output_validate.txt'
+
+# The tool must never have run for the case above: a step that cannot apply its
+# configured environment must not proceed to invoke terraform/tflint.
+assert "negative: the tool was not invoked at all" \
+  bash -c "[ ! -s '${MOCK_ENV_FILE}' ]"
+
+# ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
 echo ""

--- a/terraform-validate/run_tests_step_validate.sh
+++ b/terraform-validate/run_tests_step_validate.sh
@@ -27,7 +27,8 @@ setup_workdir() {
   export input_working_directory="${WORK_DIR}"
   export input_environment_name="testenv"
 
-  unset MOCK_TF_EXIT MOCK_TF_STDOUT
+  unset MOCK_TF_EXIT MOCK_TF_STDOUT MOCK_ENV_FILE
+  unset input_extra_envs_file
 }
 
 install_stub_terraform() {
@@ -35,6 +36,11 @@ install_stub_terraform() {
   mkdir -p "${stub_dir}"
   cat >"${stub_dir}/terraform" <<'STUB'
 #!/bin/env bash
+# Dump the environment the invocation was handed, NUL-delimited so multiline
+# values survive. Used by the per-goal environment-variable tests.
+if [ -n "${MOCK_ENV_FILE:-}" ]; then
+  env -0 >"${MOCK_ENV_FILE}"
+fi
 if [ -n "${MOCK_TF_STDOUT:-}" ]; then
   printf '%s\n' "${MOCK_TF_STDOUT}"
 fi
@@ -125,6 +131,191 @@ run_step
 cf="$(get_output tf-validate-console-output-file)"
 assert "Env name: file name embeds environment name" \
   bash -c "[[ '${cf}' == *'tf-validate-console-output-weird-env-name.txt' ]]"
+
+# ======================================================================
+# Per-goal environment variables (the 'extra-envs-file' input)
+# Scenario numbering follows docs/Per-goal-environment-variables.md §10.
+# ======================================================================
+
+# Write a JSON environment map to a file and point the step at it.
+use_extra_envs() {
+  export input_extra_envs_file="${RUNNER_TEMP}/extra-envs.json"
+  printf '%s' "${1}" >"${input_extra_envs_file}"
+}
+
+# Have the stub dump the environment it was handed.
+record_env() {
+  export MOCK_ENV_FILE="${RUNNER_TEMP}/invocation-env.txt"
+  : >"${MOCK_ENV_FILE}"
+}
+
+# Exact value of one variable as the invocation saw it. Non-zero if it was
+# unset. NUL-delimited, so a multiline value comes back byte-identical.
+env_value() {
+  local name="${1}" entry
+  while IFS= read -r -d '' entry; do
+    if [[ "${entry}" == "${name}="* ]]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done <"${MOCK_ENV_FILE}"
+  return 1
+}
+
+# Trailing newlines survive the comparison: command substitution strips them,
+# so both sides get a sentinel appended. A PEM value ends in one.
+env_eq() {
+  local var="${1}" expected="${2}" actual
+  env_value "${var}" >/dev/null || return 1
+  actual="$(env_value "${var}"; printf 'x')"
+  [[ "${actual}" == "${expected}x" ]]
+}
+
+env_is_unset() { ! env_value "${1}" >/dev/null; }
+
+# ----------------------------------------------------------------------
+# T17 — no file configured is a no-op (regression guard for every existing
+# caller: they pass nothing at all)
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+unset input_extra_envs_file
+run_step
+assert "T17: unset extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: nothing is injected" env_is_unset DSB_TEST_VALUE
+assert "T17: no per-goal group is opened in the log" \
+  bash -c "! grep -q 'applying per-goal environment variables' '/tmp/test_output_validate.txt'"
+
+setup_workdir
+install_stub_terraform
+record_env
+export input_extra_envs_file=""
+run_step
+assert "T17: empty extra-envs-file, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T17: empty path is reported as not configured" \
+  grep -q 'no per-goal environment variables file configured' '/tmp/test_output_validate.txt'
+
+# ----------------------------------------------------------------------
+# T18 — a path that does not exist is a hard error
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+export input_extra_envs_file="${RUNNER_TEMP}/nope/missing.json"
+run_step
+assert "T18: missing file, step exits non-zero" test "${LAST_EXIT}" -ne 0
+assert "T18: the error names the path" \
+  grep -q "missing.json' does not exist" '/tmp/test_output_validate.txt'
+
+# ----------------------------------------------------------------------
+# T19 — an empty map is a no-op
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{}'
+run_step
+assert "T19: empty map, step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T19: nothing is injected" env_is_unset DSB_TEST_VALUE
+
+# ----------------------------------------------------------------------
+# T20 — plain values reach the environment the invocation sees
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"GOMEMLIMIT":"12GiB","GOGC":25,"DSB_TEST_BOOL":true}'
+run_step
+assert "T20: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T20: a string value arrives verbatim" env_eq GOMEMLIMIT '12GiB'
+assert "T20: a JSON number arrives as its decimal text" env_eq GOGC '25'
+assert "T20: a JSON boolean arrives as 'true'" env_eq DSB_TEST_BOOL 'true'
+assert "T20: keys are logged" grep -q "setting 'GOMEMLIMIT'" '/tmp/test_output_validate.txt'
+assert "T20: values are NOT logged" \
+  bash -c "! grep -q '12GiB' '/tmp/test_output_validate.txt'"
+
+# ----------------------------------------------------------------------
+# T21 — a JSON null genuinely unsets, even a variable exported job-wide
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB" # stands in for a value that came via $GITHUB_ENV
+use_extra_envs '{"GOMEMLIMIT":null}'
+run_step
+assert "T21: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T21: the variable is gone from the invocation's environment" \
+  env_is_unset GOMEMLIMIT
+assert "T21: the unset is logged" grep -q "unsetting 'GOMEMLIMIT'" '/tmp/test_output_validate.txt'
+unset GOMEMLIMIT
+
+# Sanity check the other half of T21: without the null it would have been seen.
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+unset input_extra_envs_file
+run_step
+assert "T21: control — the job-wide value is visible without an override" \
+  env_eq GOMEMLIMIT '6GiB'
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T22 — an empty string is set-and-empty, which is NOT the same as unset
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+export GOMEMLIMIT="6GiB"
+use_extra_envs '{"GOMEMLIMIT":""}'
+run_step
+assert "T22: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T22: the variable is still present" \
+  bash -c "grep -qz '^GOMEMLIMIT=$' '${MOCK_ENV_FILE}'"
+assert "T22: and its value is the empty string" env_eq GOMEMLIMIT ''
+unset GOMEMLIMIT
+
+# ----------------------------------------------------------------------
+# T23 — a multiline value survives intact
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_PEM":"-----BEGIN RSA PRIVATE KEY-----\nline-two\n-----END RSA PRIVATE KEY-----\n"}'
+run_step
+assert "T23: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T23: the multiline value arrives byte-identical" \
+  env_eq DSB_TEST_PEM '-----BEGIN RSA PRIVATE KEY-----
+line-two
+-----END RSA PRIVATE KEY-----
+'
+
+# ----------------------------------------------------------------------
+# T24 — shell metacharacters are not interpreted anywhere on the way
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"a $HOME `id` \"q\" '"'"'s'"'"' * ; | & value"}'
+run_step
+assert "T24: step exits 0" test "${LAST_EXIT}" -eq 0
+assert "T24: the value arrives verbatim, nothing expanded or executed" \
+  env_eq DSB_TEST_VALUE 'a $HOME `id` "q" '"'"'s'"'"' * ; | & value'
+
+# ----------------------------------------------------------------------
+# T25 — the values are scoped to the step's own shell and do not leak
+# ----------------------------------------------------------------------
+setup_workdir
+install_stub_terraform
+record_env
+use_extra_envs '{"DSB_TEST_VALUE":"only-inside-the-step"}'
+run_step
+assert "T25: the invocation did see the value" \
+  env_eq DSB_TEST_VALUE 'only-inside-the-step'
+assert "T25: it did not leak into the surrounding shell" \
+  test -z "${DSB_TEST_VALUE:-}"
+assert "T25: and nothing was written to \$GITHUB_ENV" \
+  bash -c "[ -z \"\${GITHUB_ENV:-}\" ] || ! grep -q 'DSB_TEST_VALUE' \"\${GITHUB_ENV}\""
 
 # ----------------------------------------------------------------------
 # Summary

--- a/terraform-validate/step_validate.sh
+++ b/terraform-validate/step_validate.sh
@@ -13,6 +13,9 @@
 #   input_working_directory     - Where to invoke 'terraform validate'.
 #
 # Optional environment variables:
+#   input_extra_envs_file - Path of a JSON file with environment variables
+#                           to apply to this step only. Empty or unset is a
+#                           no-op.
 #   input_environment_name      - Used in the console-file name. Defaults
 #                                 to empty.
 #   TF_BIN                       - Path to the terraform binary (defaults
@@ -26,6 +29,10 @@ set +o nounset
 source "${GITHUB_ACTION_PATH}/helpers.sh"
 
 function main {
+  # Applied first, before this action's own exports — see
+  # docs/Per-goal-environment-variables.md §6.3.
+  apply-extra-envs "${input_extra_envs_file}" || return 1
+
   local tf_bin="${TF_BIN:-terraform}"
 
   local console_file="${GITHUB_WORKSPACE}/tf-validate-console-output-${input_environment_name}.txt"

--- a/terraform-validate/step_validate.sh
+++ b/terraform-validate/step_validate.sh
@@ -38,7 +38,15 @@ function main {
   local console_file="${GITHUB_WORKSPACE}/tf-validate-console-output-${input_environment_name}.txt"
   set-output 'tf-validate-console-output-file' "${console_file}"
 
-  cd "${input_working_directory}"
+  # Guarded: an unguarded 'cd' that fails leaves the step running in whatever
+  # directory it was invoked from and operating on the wrong tree. The runner's
+  # errexit catches it in production, but only there — the test harness and the
+  # local runners do not set it, so the failure mode is invisible where it would
+  # be caught.
+  if ! cd "${input_working_directory}"; then
+    log-error "the working directory '${input_working_directory}' could not be entered!"
+    return 1
+  fi
 
   start-group "running 'terraform validate' in '$(ws-path "$(pwd)")'"
   set -o pipefail


### PR DESCRIPTION
Lets callers set environment variables — plain and secret-sourced — for a single terraform goal rather than for the whole job.

## Why

`extra-envs-yml` / `extra-envs-from-secrets-yml` resolve to one set of values that `export-env-vars` writes to `$GITHUB_ENV`. That file is append-only and job-wide, so every value reaches every subsequent step. Scope granularity is the environment, and nothing finer exists.

That is wrong for values whose correct setting differs per stage. `plan` may need a much higher `GOMEMLIMIT` than `validate`; `terraform show -json` on a large plan is a serious allocator while `fmt` is not; a `GOGC` low enough to keep `plan` inside a runner's memory would needlessly slow down `lint`. Being able to express a genuine *unset* — which `$GITHUB_ENV` cannot — falls out of the same design.

Full design, and the decisions behind it: [docs/Per-goal-environment-variables.md](docs/Per-goal-environment-variables.md).

## What changes

Two new workflow inputs, `extra-envs-per-goal-yml` and `extra-envs-from-secrets-per-goal-yml`, both also valid as per-environment fields. A new `resolve-goal-envs` action merges them with the global maps, expands secret names, validates the lot, and writes one JSON file per goal into a 0700 directory under `$RUNNER_TEMP`. Each goal action gains one input, `extra-envs-file`, and applies that file in its own shell.

The load-bearing property is that **what crosses from the resolver into a goal action is a filesystem path, never a payload** — so values that may be secrets stay out of `argv`, out of `envp`, and out of the goal step's interpolated script text. It also keeps the secrets bag confined to one new place instead of six.

Commits are ordered so each is reviewable on its own:

| | commit | notes |
|---|---|---|
| 1 | `docs:` spec | design doc, written first |
| 2-4 | `refactor:` conversions | `terraform-apply`, `terraform-fmt`, `lint-with-tflint` to the modern step-script layout — they had no `step_*.sh` to host the hook, and no tests at all |
| 5 | `refactor(terraform-plan):` array invocation | the one place caller-controlled argument strings were interpolated into a command string and re-split by the shell |
| 6 | `feat(create-tf-vars-matrix):` new inputs | plus deep merge, goal-key normalization, and the action's first CI-facing test suite |
| 7 | `feat(resolve-goal-envs):` new action | |
| 8 | `fix(export-env-vars):` missing secrets | separable improvement to the same wart |
| 9 | `feat:` goal actions | where the hook lands |
| 10 | `feat(terraform-ci-cd-default):` wiring | where the feature becomes live |
| 11 | `docs:` caller-facing | |
| 12-18 | audit follow-ups | see below |

Commits 12-18 came out of a coverage audit done after the feature was complete — reviewing each commit for whether its tests were good enough, and specifically whether there were enough negative ones. That turned up five ways this code could fail **silently**, each verified before being fixed:

| | found | why it mattered |
|---|---|---|
| `fix:` unusable env file | `apply-extra-envs` returned 0 on unparseable, empty, array or bad-name input | applied nothing while the step carried on as if it had — plan OOMs, apply authenticates as nothing, no indication why |
| `fix:` `export FOO=BAR=x` | a name containing `=` silently set a *different* variable | exactly the corruption the resolver's name check exists to prevent |
| `fix:` directory discovery | jq's exit code was never checked in `fmt`/`lint` | an unparseable `modules.json` meant "checked nothing, reported success" — a false green on a validation step |
| `fix:` bare `cd` | `cd` failing left the step running in the caller's cwd | operated on the wrong tree; the runner's errexit hid it everywhere except the tests |
| `fix:` old jq | jq < 1.7 rejects `--raw-output0` | same silent no-op, reachable only on self-hosted images — which is what the verification repo uses |

Plus `fix(resolve-goal-envs):` accepting an empty `plan:` YAML block (natural YAML that was a hard error), and three `test:` commits: a suite for `export-env-vars` (the one behaviour change that had shipped unverified), the matrix builder's failure paths, and an assertion that the goal vocabulary agrees across its three copies.

## Things worth a reviewer's attention

**Three legacy conversions ride along.** They are behaviour-preserving by intention, but they are rewrites of previously untested code, and `terraform-apply` is the only step that mutates infrastructure. All three now have test suites; that is a benefit, not a substitute for exercising them for real.

**Two latent bugs fixed on the way.** `terraform-fmt` and `lint-with-tflint` newline-joined their discovered module directories into a scalar and then iterated it as `${DIRS[*]}` — which word-splits, so a module path containing a space visited two directories that do not exist instead of the one that does. `jq -r` over `modules.json` paths is exactly where a space eventually shows up.

**One deliberate behaviour change.** A failing `tflint --init` used to abort the lint step on the spot, leaving the remaining directories unlinted and unreported. It is now recorded as that directory's result: the step still fails, but the other directories get linted.

**Per-goal secrets cannot swap cloud identity, and that is documented rather than guarded.** `azure/login` runs once, early, and reads job-wide environment variables, so a reader service principal for `plan` and a contributor for `apply` does not work through this mechanism. The caveat is on the input description and in the caller docs, worded so it is obvious before someone builds on it.

**Merge semantics in the matrix builder.** The per-environment merge had to become a deep merge for the nested per-goal maps, but a blanket switch to jq's `*` is a regression: `pr-auto-merge-from-actors-yml` is a YAML array and `*` errors on arrays outright. The merge now dispatches on type. Both regressions were verified to fail the new suite before being fixed.

## Verification

**1071 tests across 20 suites, green in CI** — up from 859 before the audit. `create-tf-vars-matrix` and `export-env-vars` are no longer excluded from `action-tests` discovery, so the deep-merge and secret-resolution paths are covered in CI rather than by a tty-dependent harness or not at all.

Where a test asserts a fix, the fix was verified to fail it first: shallow `add` and blanket `*` both break the matrix merge suite, removing the `apply-extra-envs` call fails 14 of `terraform-fmt`'s, removing the missing-secret guard fails 5 of `export-env-vars`', a one-word drift in one copy of `apply-extra-envs` fails the byte-identical assertion, and a `fmt.json` typo in the workflow fails the vocabulary contract.

### End-to-end against real infrastructure

Verified from [dsb-infra/azure-terraform-dsb-platform-sandbox#83](https://github.com/dsb-infra/azure-terraform-dsb-platform-sandbox/pull/83) on a **self-hosted** runner group, which also exercises the jq 1.7 assumption in §9.2 that a hosted runner would not. Two runs to inspect:

| run | what it covers |
|---|---|
| [**PR run 32044886814**](https://github.com/dsb-infra/azure-terraform-dsb-platform-sandbox/actions/runs/32044886814) | `init`, `fmt`, `validate`, `lint`, `plan` — the read-only path |
| [**apply run 32050131546**](https://github.com/dsb-infra/azure-terraform-dsb-platform-sandbox/actions/runs/32050131546) | the same plus `apply`, on merge to `main`. **Attempt 2** is the successful one; see below for attempt 1 |

What they show:

- **`terraform-apply` works after being rewritten from inline bash.** Its prerequisite check found the plan file and the invocation is array-built: `'terraform' 'apply' '-input=false' '-auto-approve' '/…/tf-plan-sandbox.plan'`. `Apply complete! Resources: 0 added, 2 changed, 0 destroyed.`
- **A YAML `~` genuinely unsets a variable.** The apply step logged `unsetting 'GOMEMLIMIT'` for a value `export-env-vars` had written into job-wide `$GITHUB_ENV`. That is the capability `$GITHUB_ENV` does not have, and the main functional reason this feature routes through files.
- **The deep merge holds in production.** The caller overrode only `plan.GOMEMLIMIT`; `plan` resolved to 8 variables *including the `GOGC` from the global `plan:` block*, while `init`/`format`/`validate` got 7. A shallow merge would have replaced that block and left `plan` on 7 without `GOGC` — regression T31, observed live rather than only in a unit test.
- `fmt` and `lint` each discovered and visited three directories with array-built, correctly quoted commands; `plan`'s command has no empty argv element from the unset `extra-*-args`; every goal step logged keys only, never values.

**Attempt 1 of the apply run failed, and it is worth a reviewer's minute** — GitHub returned `HTTP 504` cloning an AVM module during init, during a confirmed GitHub Partial System Outage. Not this code, but it exercised the failure path for real in a way no test can: init's *outcome* was `failure` while its *conclusion* stayed `success` under `continue-on-error`, `🧐 Validation outcome: ⚙️ Init` hard-failed on it, plan/apply/destroy-plan were correctly skipped, and `🧹 Shred resolved environment files` still ran on `always()`. The new "no directories found" hard error in `fmt`/`lint` also did **not** false-positive against a partially-initialised `modules.json`, which was the real risk of adding it.

The sandbox has been fully reverted ([#84](https://github.com/dsb-infra/azure-terraform-dsb-platform-sandbox/pull/84), merged): it is back on `@v0`, byte-identical to its pre-test commit, with the tags removed by a final apply on the released actions. The dev tag has been deleted from this repo and origin, and the `@v0` refs are restored — this branch is release-ready as it stands.

### One limit on the end-to-end evidence

The probe variable proved *which keys* reached which step, not which *values* — values are deliberately never logged. Value-level correctness rests on the unit tests, which inspect the child process's actual environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
